### PR TITLE
Improving mesh separating

### DIFF
--- a/packages/split/src/split.ts
+++ b/packages/split/src/split.ts
@@ -11,13 +11,22 @@ const split = function (container: GLTFContainer, meshes: Array<string>): GLTFCo
   // Group bufferviews by mesh.
   json.meshes.forEach((mesh) => {
     if (meshes.indexOf(mesh.name) === -1) return;
-    mesh.primitives.forEach((prim) => {
-      if (prim.indices) markAccessor(json.accessors[prim.indices]);
-      Object.keys(prim.attributes).forEach((attrName) => {
-        markAccessor(json.accessors[prim.attributes[attrName]]);
-      });
 
-      function markAccessor(accessor) {
+    mesh.primitives.forEach((primitive) => {
+      if (primitive.indices) markAccessor(primitive.indices);
+
+      markAttributesAccessors(primitive.attributes);
+      if (primitive.targets) primitive.targets.forEach(markAttributesAccessors);
+
+      function markAttributesAccessors(attributes) {
+        Object.values(attributes).forEach((index) => {
+          markAccessor(index);
+        });
+      }
+
+      function markAccessor(index) {
+        const accessor = json.accessors[index];
+
         if (bufferViewMap[accessor.bufferView] === undefined) {
           bufferViewMap[accessor.bufferView] = mesh.name;
         } else if (bufferViewMap[accessor.bufferView] !== mesh.name) {

--- a/packages/split/src/split.ts
+++ b/packages/split/src/split.ts
@@ -13,7 +13,7 @@ const split = function (container: GLTFContainer, meshes: Array<string>): GLTFCo
     if (meshes.indexOf(mesh.name) === -1) return;
 
     mesh.primitives.forEach((primitive) => {
-      if (primitive.indices) markAccessor(primitive.indices);
+      if (primitive.indices !== undefined) markAccessor(primitive.indices);
       if (primitive.targets) primitive.targets.forEach(markAttributesAccessors);
 
       markAttributesAccessors(primitive.attributes);

--- a/packages/split/src/split.ts
+++ b/packages/split/src/split.ts
@@ -14,14 +14,12 @@ const split = function (container: GLTFContainer, meshes: Array<string>): GLTFCo
 
     mesh.primitives.forEach((primitive) => {
       if (primitive.indices) markAccessor(primitive.indices);
-
-      markAttributesAccessors(primitive.attributes);
       if (primitive.targets) primitive.targets.forEach(markAttributesAccessors);
 
+      markAttributesAccessors(primitive.attributes);
+
       function markAttributesAccessors(attributes) {
-        Object.values(attributes).forEach((index) => {
-          markAccessor(index);
-        });
+        Object.values(attributes).forEach(markAccessor);
       }
 
       function markAccessor(index) {

--- a/packages/split/test/test.js
+++ b/packages/split/test/test.js
@@ -14,12 +14,11 @@ test('@gltf-transform/split', t => {
   t.equal(container.json.buffers.length, 1, 'initialized with one buffer');
 
   split(container, ['CubeA', 'CubeB']);
-  // TODO: This should be two, not three.
+
   t.deepEqual(container.json.buffers, [
-    { uri: 'resources.bin', byteLength: 36, name: 'TwoCubes', },
-    { uri: 'CubeA.bin', byteLength: 288, name: 'CubeA' },
+    { uri: 'CubeA.bin', byteLength: 324, name: 'CubeA' },
     { uri: 'CubeB.bin', byteLength: 324, name: 'CubeB' }
-  ], 'splits into three buffers');
+  ], 'splits into two buffers');
 
   t.end();
 });


### PR DESCRIPTION
Handle `targets` primitive property when splitting a mesh because it may contain buffer accessors indexes as well.

Also fixed `if (primitive.indices)` condition (because `indices` can be `0`) and the test case that was affected by this bug.