### PR TITLE
Fixed buffer view removing

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -350,9 +350,9 @@ class GLTFUtil {
       const buffer = container.json.buffers[bufferView.buffer];
       buffer.byteLength -= bufferView.byteLength;
 
-      container.json.bufferViews.forEach((bufferView) => {
-        if (bufferView.byteOffset > bufferView.byteOffset) {
-          bufferView.byteOffset -= bufferView.byteLength;
+      container.json.bufferViews.forEach((otherBufferView) => {
+        if (otherBufferView.buffer === bufferView.buffer && otherBufferView.byteOffset > bufferView.byteOffset) {
+          otherBufferView.byteOffset -= bufferView.byteLength;
         }
       });
     }


### PR DESCRIPTION
`bufferView.byteOffset > bufferView.byteOffset` is always false, so byte offset of the rest of buffers isn't aligned properly.

Also we need to align only buffer views that point to the same buffer as the buffer view being removed, so added check for it as well.