### PR TITLE
Implement .clone(), .copy(), and .merge()

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -54,7 +54,7 @@ program
 		validate(args.input, options, logger);
 	});
 
-// REPACK
+// COPY
 program
 	.command('copy', '📦 Copies the model with minimal changes')
 	.help('Copies the model with minimal changes.')
@@ -63,6 +63,19 @@ program
 	.action(({args, logger}) => {
 		const doc = io.read(args.input).setLogger(logger);
 		io.write(args.output, doc);
+	});
+
+program
+	.command('merge', '📦 Merges two models into one')
+	.help('Merges two models into one.')
+	.argument('<a>', 'Path to glTF 2.0 (.glb, .gltf) model')
+	.argument('<b>', 'Path to glTF 2.0 (.glb, .gltf) model')
+	.argument('<output>', 'Path to write output')
+	.action(({args, logger}) => {
+		const a = io.read(args.a).setLogger(logger);
+		const b = io.read(args.b).setLogger(logger);
+		// TODO(bug): Need more graceful way to deal with 1-buffer GLB requirement.
+		io.write(args.output, a.merge(b));
 	});
 
 // PARTITION

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,6 +1,6 @@
 export { Document, Transform } from './document';
 export { Extension } from './extension';
-export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, TextureLink, TextureSampler } from './properties';
+export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, TextureLink, TextureSampler, COPY_IDENTITY } from './properties';
 export { Graph, GraphChild } from './graph/';
 export { NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
 export { BufferUtils, FileUtils, ImageUtils, Logger, uuid } from './utils/';

--- a/packages/core/src/graph/graph-node.ts
+++ b/packages/core/src/graph/graph-node.ts
@@ -82,7 +82,7 @@ export abstract class GraphNode {
 	}
 
 	/**
-	 * Removes a {@link GraphNode} from a {@link @GraphChildList}.
+	 * Removes a {@link GraphNode} from a {@link GraphChildList}.
 	 *
 	 * @hidden
 	 */
@@ -92,18 +92,13 @@ export abstract class GraphNode {
 		return this;
 	}
 
-	/** @hidden */
+	/**
+	 * Removes all {@link GraphNode}s from a {@link GraphChildList}.
+	 *
+	 * @hidden
+	 */
 	protected clearGraphChildList(links: Link<GraphNode, GraphNode>[]): this {
 		while (links.length > 0) links[0].dispose();
-		return this;
-	}
-
-	/** @hidden */
-	protected copyGraphChildList(name: string, source: Link<GraphNode, GraphNode>[], target: Link<GraphNode, GraphNode>[], resolve = (p: GraphNode): GraphNode => p): this {
-		this.clearGraphChildList(target);
-		for (const link of source) {
-			this.addGraphChild(target, this.graph.link(name, this, resolve(link.getChild())));
-		}
 		return this;
 	}
 

--- a/packages/core/src/graph/graph-node.ts
+++ b/packages/core/src/graph/graph-node.ts
@@ -92,6 +92,21 @@ export abstract class GraphNode {
 		return this;
 	}
 
+	/** @hidden */
+	protected clearGraphChildList(links: Link<GraphNode, GraphNode>[]): this {
+		while (links.length > 0) links[0].dispose();
+		return this;
+	}
+
+	/** @hidden */
+	protected copyGraphChildList(name: string, source: Link<GraphNode, GraphNode>[], target: Link<GraphNode, GraphNode>[], resolve = (p: GraphNode): GraphNode => p): this {
+		this.clearGraphChildList(target);
+		for (const link of source) {
+			this.addGraphChild(target, this.graph.link(name, this, resolve(link.getChild())));
+		}
+		return this;
+	}
+
 	/**
 	 * Returns a list of all nodes that hold a reference to this node.
 	 *

--- a/packages/core/src/properties/accessor.ts
+++ b/packages/core/src/properties/accessor.ts
@@ -82,25 +82,25 @@ import { COPY_IDENTITY } from './property';
 export class Accessor extends ExtensibleProperty {
 	public readonly propertyType = PropertyType.ACCESSOR;
 
-	/** Raw data of the accessor. */
+	/** @hidden Raw data of the accessor. */
 	private _array: TypedArray = null;
 
-	/** Type of element represented. */
+	/** @hidden Type of element represented. */
 	private _type: GLTF.AccessorType = GLTF.AccessorType.SCALAR;
 
-	/** Numeric type of each component in an element. */
+	/** @hidden Numeric type of each component in an element. */
 	private _componentType: GLTF.AccessorComponentType = null;
 
-	/** Whether data in the raw array should be considered normalized. */
+	/** @hidden Whether data in the raw array should be considered normalized. */
 	private _normalized = false;
 
-	/** Inbound transform to normalized representation, if applicable. */
+	/** @hidden Inbound transform to normalized representation, if applicable. */
 	private _in = identity;
 
-	/** Outbound transform from normalized representation, if applicable. */
+	/** @hidden Outbound transform from normalized representation, if applicable. */
 	private _out = identity;
 
-	/** The {@link Buffer} to which this accessor's data will be written. */
+	/** @hidden The {@link Buffer} to which this accessor's data will be written. */
 	@GraphChild private buffer: Link<Accessor, Buffer> = null;
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {

--- a/packages/core/src/properties/accessor.ts
+++ b/packages/core/src/properties/accessor.ts
@@ -2,6 +2,7 @@ import { PropertyType, TypedArray } from '../constants';
 import { GraphChild, Link } from '../graph';
 import { Buffer } from './buffer';
 import { ExtensibleProperty } from './extensible-property';
+import { COPY_IDENTITY } from './property';
 
 /**
  * # Accessor
@@ -101,6 +102,21 @@ export class Accessor extends ExtensibleProperty {
 
 	/** The {@link Buffer} to which this accessor's data will be written. */
 	@GraphChild private buffer: Link<Accessor, Buffer> = null;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._array = other._array.slice();
+		this._type = other._type;
+		this._componentType = other._componentType;
+		this._normalized = other._normalized;
+		this._in = other._in;
+		this._out = other._out;
+
+		if (other.buffer) this.setBuffer(resolve(other.buffer.getChild()));
+
+		return this;
+	}
 
 	/**********************************************************************************************
 	 * Static.

--- a/packages/core/src/properties/animation.ts
+++ b/packages/core/src/properties/animation.ts
@@ -3,7 +3,7 @@ import { GraphChild, GraphChildList, Link } from '../graph';
 import { Accessor } from './accessor';
 import { ExtensibleProperty } from './extensible-property';
 import { Node } from './node';
-import { Property } from './property';
+import { COPY_IDENTITY, Property } from './property';
 
 /**
  * # Animation
@@ -206,6 +206,17 @@ export class AnimationSampler extends Property {
 
 	@GraphChild private input: Link<AnimationSampler, Accessor> = null;
 	@GraphChild private output: Link<AnimationSampler, Accessor> = null;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._interpolation = other._interpolation;
+
+		if (other.input) this.setInput(resolve(other.input.getChild()));
+		if (other.output) this.setOutput(resolve(other.output.getChild()));
+
+		return this;
+	}
 
 	/** Interpolation mode: `STEP`, `LINEAR`, or `CUBICSPLINE`. */
 	public getInterpolation(): GLTF.AnimationSamplerInterpolation {

--- a/packages/core/src/properties/animation.ts
+++ b/packages/core/src/properties/animation.ts
@@ -46,6 +46,18 @@ export class Animation extends ExtensibleProperty {
 	@GraphChildList private channels: Link<Animation, AnimationChannel>[] = [];
 	@GraphChildList private samplers: Link<Animation, AnimationSampler>[] = [];
 
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this.clearGraphChildList(this.channels);
+		this.clearGraphChildList(this.samplers);
+
+		other.channels.forEach((link) => this.addChannel(resolve(link.getChild())));
+		other.samplers.forEach((link) => this.addSampler(resolve(link.getChild())));
+
+		return this;
+	}
+
 	/** Adds an {@link AnimationChannel} to this Animation. */
 	public addChannel(channel: AnimationChannel): this {
 		const link = this.graph.link('channel', this, channel);
@@ -112,6 +124,17 @@ export class AnimationChannel extends Property {
 	private _targetPath: GLTF.AnimationChannelTargetPath = null;
 	@GraphChild private targetNode: Link<AnimationChannel, Node> = null;
 	@GraphChild private sampler: Link<AnimationChannel, AnimationSampler> = null;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._targetPath = other._targetPath;
+
+		if (other.targetNode) this.setTargetNode(resolve(other.targetNode.getChild()));
+		if (other.sampler) this.setSampler(resolve(other.sampler.getChild()));
+
+		return this;
+	}
 
 	/**
 	 * Path (property) animated on the target {@link Node}. Supported values include:

--- a/packages/core/src/properties/buffer.ts
+++ b/packages/core/src/properties/buffer.ts
@@ -1,5 +1,6 @@
 import { PropertyType } from '../constants';
 import { ExtensibleProperty } from './extensible-property';
+import { COPY_IDENTITY } from './property';
 
 /**
  * # Buffer
@@ -61,6 +62,14 @@ export class Buffer extends ExtensibleProperty {
 
 	/** URI (or filename) of the buffer. */
 	private _uri: string;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._uri = other._uri;
+
+		return this;
+	}
 
 	/**
 	 * Returns the URI (or filename) of this buffer (e.g. 'myBuffer.bin'). URIs are strongly

--- a/packages/core/src/properties/buffer.ts
+++ b/packages/core/src/properties/buffer.ts
@@ -60,7 +60,7 @@ import { COPY_IDENTITY } from './property';
 export class Buffer extends ExtensibleProperty {
 	public readonly propertyType = PropertyType.BUFFER;
 
-	/** URI (or filename) of the buffer. */
+	/** @hidden URI (or filename) of the buffer. */
 	private _uri: string;
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {

--- a/packages/core/src/properties/camera.ts
+++ b/packages/core/src/properties/camera.ts
@@ -1,5 +1,6 @@
 import { PropertyType } from '../constants';
 import { ExtensibleProperty } from './extensible-property';
+import { COPY_IDENTITY } from './property';
 
 /**
  * # Camera
@@ -47,6 +48,20 @@ export class Camera extends ExtensibleProperty {
 
 	private _xmag: number;
 	private _ymag: number;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._type = other._type;
+		this._znear = other._znear;
+		this._zfar = other._zfar;
+		this._aspectRatio = other._aspectRatio;
+		this._yfov = other._yfov;
+		this._xmag = other._xmag;
+		this._ymag = other._ymag;
+
+		return this;
+	}
 
 	/**********************************************************************************************
 	 * Common.

--- a/packages/core/src/properties/extensible-property.ts
+++ b/packages/core/src/properties/extensible-property.ts
@@ -1,6 +1,7 @@
+import { ExtensionConstructor } from '../extension';
 import { GraphChildList, Link } from '../graph';
 import { ExtensionProperty, ExtensionPropertyConstructor } from './extension-property';
-import { Property } from './property';
+import { COPY_IDENTITY, Property } from './property';
 
 /**
  * # ExtensibleProperty
@@ -14,6 +15,18 @@ import { Property } from './property';
  */
 export abstract class ExtensibleProperty extends Property {
 	@GraphChildList protected extensions: Link<Property, ExtensionProperty>[] = [];
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this.clearGraphChildList(this.extensions);
+		other.extensions.forEach((link) => {
+			const extension = link.getChild();
+			this.setExtension(extension.constructor as ExtensionPropertyConstructor<typeof extension>, extension);
+		})
+
+		return this;
+	}
 
 	/**
 	 * Returns the {@link ExtensionProperty} of the given type attached to this Property, if any.

--- a/packages/core/src/properties/extensible-property.ts
+++ b/packages/core/src/properties/extensible-property.ts
@@ -22,7 +22,7 @@ export abstract class ExtensibleProperty extends Property {
 		this.clearGraphChildList(this.extensions);
 		other.extensions.forEach((link) => {
 			const extension = link.getChild();
-			this.setExtension(extension.constructor as ExtensionPropertyConstructor<typeof extension>, extension);
+			this.setExtension(extension.constructor as ExtensionPropertyConstructor<typeof extension>, resolve(extension));
 		})
 
 		return this;

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -40,54 +40,58 @@ import { Texture, TextureInfo, TextureSampler } from './texture';
 export class Material extends ExtensibleProperty {
 	public readonly propertyType = PropertyType.MATERIAL;
 
-	/** Mode of the material's alpha channels. (`OPAQUE`, `BLEND`, or `MASK`) */
+	/** @hidden Mode of the material's alpha channels. (`OPAQUE`, `BLEND`, or `MASK`) */
 	private _alphaMode: GLTF.MaterialAlphaMode = GLTF.MaterialAlphaMode.OPAQUE;
 
-	/** Visibility threshold. Applied only when `.alphaMode='MASK'`. */
+	/** @hidden Visibility threshold. Applied only when `.alphaMode='MASK'`. */
 	private _alphaCutoff = 0.5;
 
-	/** When true, both sides of each triangle are rendered. May decrease performance. */
+	/** @hidden When true, both sides of each triangle are rendered. May decrease performance. */
 	private _doubleSided = false;
 
-	/** Base color / albedo; linear multiplier. */
+	/** @hidden Base color / albedo; linear multiplier. */
 	private _baseColorFactor: vec4 = [1, 1, 1, 1];
 
-	/** Emissive color; linear multiplier. */
+	/** @hidden Emissive color; linear multiplier. */
 	private _emissiveFactor: vec3 = [0, 0, 0];
 
-	/** Normal (surface detail) factor; linear multiplier. Affects `.normalTexture`. */
+	/** @hidden Normal (surface detail) factor; linear multiplier. Affects `.normalTexture`. */
 	private _normalScale = 1;
 
-	/** (Ambient) Occlusion factor; linear multiplier. Affects `.occlusionMap`. */
+	/** @hidden (Ambient) Occlusion factor; linear multiplier. Affects `.occlusionMap`. */
 	private _occlusionStrength = 1;
 
 	/**
 	 * Roughness factor; linear multiplier. Affects roughness channel of
 	 * `metallicRoughnessTexture`.
+	 * @hidden
 	 */
 	private _roughnessFactor = 1;
 
 	/**
 	 * Metallic factor; linear multiplier. Affects metallic channel of
 	 * `metallicRoughnessTexture`.
+	 * @hidden
 	 */
 	private _metallicFactor = 1;
 
-	/** Base color / albedo texture. */
+	/** @hidden Base color / albedo texture. */
 	@GraphChild private baseColorTexture: TextureLink = null;
 
-	/** Emissive texture. */
+	/** @hidden Emissive texture. */
 	@GraphChild private emissiveTexture: TextureLink = null;
 
 	/**
 	 * Normal (surface detail) texture. Normal maps often suffer artifacts with JPEG compression,
 	 * so PNG files are preferred.
+	 * @hidden
 	 */
 	@GraphChild private normalTexture: TextureLink = null;
 
 	/**
 	 * (Ambient) Occlusion texture. Occlusion data is stored in the `.r` channel, allowing this
 	 * texture to be packed with `metallicRoughnessTexture`, optionally.
+	 * @hidden
 	 */
 	@GraphChild private occlusionTexture: TextureLink = null;
 
@@ -95,6 +99,7 @@ export class Material extends ExtensibleProperty {
 	 * Metallic/roughness PBR texture. Roughness data is stored in the `.g` channel and metallic
 	 * data is stored in the `.b` channel, allowing thist exture to be packed with
 	 * `occlusionTexture`, optionally.
+	 * @hidden
 	*/
 	@GraphChild private metallicRoughnessTexture: TextureLink = null;
 

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -1,6 +1,7 @@
 import { PropertyType, vec3, vec4 } from '../constants';
 import { GraphChild } from '../graph/index';
 import { ExtensibleProperty } from './extensible-property';
+import { COPY_IDENTITY } from './property';
 import { TextureLink } from './property-links';
 import { Texture, TextureInfo, TextureSampler } from './texture';
 
@@ -96,6 +97,43 @@ export class Material extends ExtensibleProperty {
 	 * `occlusionTexture`, optionally.
 	*/
 	@GraphChild private metallicRoughnessTexture: TextureLink = null;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._alphaMode = other._alphaMode;
+		this._alphaCutoff = other._alphaCutoff;
+		this._doubleSided = other._doubleSided;
+		this._baseColorFactor = [...other._baseColorFactor] as vec4;
+		this._emissiveFactor = [...other._emissiveFactor] as vec3;
+		this._normalScale = other._normalScale;
+		this._occlusionStrength = other._occlusionStrength;
+		this._roughnessFactor = other._roughnessFactor;
+		this._metallicFactor = other._metallicFactor;
+
+		if (other.baseColorTexture) {
+			this.setBaseColorTexture(resolve(other.baseColorTexture.getChild()));
+			this.baseColorTexture.copy(other.baseColorTexture);
+		}
+		if (other.emissiveTexture) {
+			this.setEmissiveTexture(resolve(other.emissiveTexture.getChild()));
+			this.emissiveTexture.copy(other.emissiveTexture);
+		}
+		if (other.normalTexture) {
+			this.setNormalTexture(resolve(other.normalTexture.getChild()));
+			this.normalTexture.copy(other.normalTexture);
+		}
+		if (other.occlusionTexture) {
+			this.setOcclusionTexture(resolve(other.occlusionTexture.getChild()));
+			this.occlusionTexture.copy(other.occlusionTexture);
+		}
+		if (other.metallicRoughnessTexture) {
+			this.setMetallicRoughnessTexture(resolve(other.metallicRoughnessTexture.getChild()));
+			this.metallicRoughnessTexture.copy(other.metallicRoughnessTexture);
+		}
+
+		return this;
+	}
 
 	/**********************************************************************************************
 	 * Double-sided / culling.

--- a/packages/core/src/properties/mesh.ts
+++ b/packages/core/src/properties/mesh.ts
@@ -45,7 +45,7 @@ export class Mesh extends ExtensibleProperty {
 
 	private _weights: number[] = [];
 
-	/** Primitive GPU draw call list. */
+	/** @hidden Primitive GPU draw call list. */
 	@GraphChildList private primitives: Link<Mesh, Primitive>[] = [];
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
@@ -131,7 +131,7 @@ export class Mesh extends ExtensibleProperty {
 export class Primitive extends Property {
 	public readonly propertyType = PropertyType.PRIMITIVE;
 
-	/** GPU draw mode. */
+	/** @hidden GPU draw mode. */
 	private _mode: GLTF.MeshPrimitiveMode = GLTF.MeshPrimitiveMode.TRIANGLES;
 
 	@GraphChild private material: Link<Primitive, Material> = null;
@@ -284,7 +284,7 @@ export class Primitive extends Property {
 export class PrimitiveTarget extends Property {
 	public readonly propertyType = PropertyType.PRIMITIVE_TARGET;
 
-	/** Vertex attributes. */
+	/** @hidden Vertex attributes. */
 	@GraphChildList private attributes: AttributeLink[] = [];
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {

--- a/packages/core/src/properties/node.ts
+++ b/packages/core/src/properties/node.ts
@@ -4,6 +4,7 @@ import { Link } from '../graph/graph-links';
 import { Camera } from './camera';
 import { ExtensibleProperty } from './extensible-property';
 import { Mesh } from './mesh';
+import { COPY_IDENTITY } from './property';
 import { Skin } from './skin';
 
 /**
@@ -45,6 +46,24 @@ export class Node extends ExtensibleProperty {
 	@GraphChild private mesh: Link<Node, Mesh> = null;
 	@GraphChild private skin: Link<Node, Skin> = null;
 	@GraphChildList private children: Link<Node, Node>[] = [];
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._translation = [...other._translation] as vec3;
+		this._rotation = [...other._rotation] as vec4;
+		this._scale = [...other._scale] as vec3;
+		this._weights = [...other._weights];
+
+		if (other.camera) this.setCamera(resolve(other.camera.getChild()));
+		if (other.mesh) this.setMesh(resolve(other.mesh.getChild()));
+		if (other.skin) this.setSkin(resolve(other.skin.getChild()));
+
+		this.clearGraphChildList(this.children);
+		other.children.forEach((link) => this.addChild(resolve(link.getChild())));
+
+		return this;
+	}
 
 	/** Returns the translation (position) of this node in local space. */
 	public getTranslation(): vec3 { return this._translation; }

--- a/packages/core/src/properties/property-links.ts
+++ b/packages/core/src/properties/property-links.ts
@@ -9,12 +9,23 @@ import { Texture, TextureInfo, TextureSampler } from './texture';
 export class TextureLink extends Link<Material|ExtensionProperty, Texture> {
 	public textureInfo = new TextureInfo();
 	public sampler = new TextureSampler();
+	public copy (other: this): this {
+		this.textureInfo.copy(other.textureInfo);
+		this.sampler.copy(other.sampler);
+		return this;
+	}
 }
 
 /** @hidden */
 export class AttributeLink extends Link<Primitive|PrimitiveTarget, Accessor> {
 	public semantic = '';
+	public copy (other: this): this {
+		this.semantic = other.semantic;
+		return this;
+	}
 }
 
 /** @hidden */
-export class IndexLink extends Link<Primitive, Accessor> {}
+export class IndexLink extends Link<Primitive, Accessor> {
+	public copy (other: this): this { return this; }
+}

--- a/packages/core/src/properties/property.ts
+++ b/packages/core/src/properties/property.ts
@@ -1,6 +1,9 @@
 import { GraphNode } from '../graph';
 import { PropertyGraph } from './property-graph';
 
+export type PropertyResolver<T extends Property> = (p: T) => T;
+export const COPY_IDENTITY = <T extends Property>(t: T): T => t;
+
 /**
  * # Property
  *
@@ -95,7 +98,7 @@ export abstract class Property extends GraphNode {
 	 */
 	public clone(): this {
 		const PropertyClass = this.constructor as new(g: PropertyGraph) => this;
-		return new PropertyClass(this.graph).copy(this);
+		return new PropertyClass(this.graph).copy(this, COPY_IDENTITY);
 	}
 
 	/**
@@ -104,7 +107,7 @@ export abstract class Property extends GraphNode {
 	 * @param other Property to copy references from.
 	 * @param resolve Function to resolve each Property being transferred. Default is identity.
 	 */
-	public copy(other: this, resolve = (p: Property): Property => p): this {
+	public copy(other: this, resolve: PropertyResolver<Property>): this {
 		this._name = other._name;
 		this._extras = JSON.parse(JSON.stringify(other._extras));
 		return this;

--- a/packages/core/src/properties/property.ts
+++ b/packages/core/src/properties/property.ts
@@ -91,11 +91,23 @@ export abstract class Property extends GraphNode {
 	 */
 
 	/**
-	 * Makes a copy of this property, referencing the same resources (not copies) as the original.
-	 * @hidden
+	 * Makes a copy of this property, with the same resources (by reference) as the original.
 	 */
-	public clone(): Property {
-		throw new Error('Not implemented.');
+	public clone(): this {
+		const PropertyClass = this.constructor as new(g: PropertyGraph) => this;
+		return new PropertyClass(this.graph).copy(this);
+	}
+
+	/**
+	 * Copies all data from another property to this one. Child properties are copied by reference,
+	 * unless a 'resolve' function is given to override that.
+	 * @param other Property to copy references from.
+	 * @param resolve Function to resolve each Property being transferred. Default is identity.
+	 */
+	public copy(other: this, resolve = (p: Property): Property => p): this {
+		this._name = other._name;
+		this._extras = JSON.parse(JSON.stringify(other._extras));
+		return this;
 	}
 
 	public detach(): this {

--- a/packages/core/src/properties/root.ts
+++ b/packages/core/src/properties/root.ts
@@ -78,16 +78,29 @@ export class Root extends Property {
 		if (!resolve) throw new Error('Root cannot be copied.');
 
 		Object.assign(this._asset, other._asset);
-		this.copyGraphChildList('accessor', other.accessors, this.accessors, resolve);
-		this.copyGraphChildList('animation', other.animations, this.animations, resolve);
-		this.copyGraphChildList('buffer', other.buffers, this.buffers, resolve);
-		this.copyGraphChildList('camera', other.cameras, this.cameras, resolve);
-		this.copyGraphChildList('material', other.materials, this.materials, resolve);
-		this.copyGraphChildList('mesh', other.meshes, this.meshes, resolve);
-		this.copyGraphChildList('node', other.nodes, this.nodes, resolve);
-		this.copyGraphChildList('scene', other.scenes, this.scenes, resolve);
-		this.copyGraphChildList('skin', other.skins, this.skins, resolve);
-		this.copyGraphChildList('texture', other.textures, this.textures, resolve);
+
+		this.clearGraphChildList(this.accessors);
+		this.clearGraphChildList(this.animations);
+		this.clearGraphChildList(this.buffers);
+		this.clearGraphChildList(this.cameras);
+		this.clearGraphChildList(this.materials);
+		this.clearGraphChildList(this.meshes);
+		this.clearGraphChildList(this.nodes);
+		this.clearGraphChildList(this.scenes);
+		this.clearGraphChildList(this.skins);
+		this.clearGraphChildList(this.textures);
+
+		other.accessors.forEach((link) => this._addAccessor(resolve(link.getChild())));
+		other.animations.forEach((link) => this._addAnimation(resolve(link.getChild())));
+		other.buffers.forEach((link) => this._addBuffer(resolve(link.getChild())));
+		other.cameras.forEach((link) => this._addCamera(resolve(link.getChild())));
+		other.materials.forEach((link) => this._addMaterial(resolve(link.getChild())));
+		other.meshes.forEach((link) => this._addMesh(resolve(link.getChild())));
+		other.nodes.forEach((link) => this._addNode(resolve(link.getChild())));
+		other.scenes.forEach((link) => this._addScene(resolve(link.getChild())));
+		other.skins.forEach((link) => this._addSkin(resolve(link.getChild())));
+		other.textures.forEach((link) => this._addTexture(resolve(link.getChild())));
+
 		return this;
 	}
 

--- a/packages/core/src/properties/root.ts
+++ b/packages/core/src/properties/root.ts
@@ -8,7 +8,7 @@ import { Camera } from './camera';
 import { Material } from './material';
 import { Mesh } from './mesh';
 import { Node } from './node';
-import { Property } from './property';
+import { COPY_IDENTITY, Property } from './property';
 import { Scene } from './scene';
 import { Skin } from './skin';
 import { Texture } from './texture';
@@ -70,7 +70,7 @@ export class Root extends Property {
 		throw new Error('Root cannot be cloned.');
 	}
 
-	public copy(other: this, resolve = null): this {
+	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
 
 		// Root cannot be cloned in isolation: only with its Document. Extensions are managed by

--- a/packages/core/src/properties/root.ts
+++ b/packages/core/src/properties/root.ts
@@ -74,21 +74,11 @@ export class Root extends Property {
 		super.copy(other, resolve);
 
 		// Root cannot be cloned in isolation: only with its Document. Extensions are managed by
-		// the Document during cloning.
+		// the Document during cloning. The Root, and only the Root, should avoid calling
+		// .clearGraphChildList() while copying to avoid overwriting existing links during a merge.
 		if (!resolve) throw new Error('Root cannot be copied.');
 
 		Object.assign(this._asset, other._asset);
-
-		this.clearGraphChildList(this.accessors);
-		this.clearGraphChildList(this.animations);
-		this.clearGraphChildList(this.buffers);
-		this.clearGraphChildList(this.cameras);
-		this.clearGraphChildList(this.materials);
-		this.clearGraphChildList(this.meshes);
-		this.clearGraphChildList(this.nodes);
-		this.clearGraphChildList(this.scenes);
-		this.clearGraphChildList(this.skins);
-		this.clearGraphChildList(this.textures);
 
 		other.accessors.forEach((link) => this._addAccessor(resolve(link.getChild())));
 		other.animations.forEach((link) => this._addAnimation(resolve(link.getChild())));

--- a/packages/core/src/properties/root.ts
+++ b/packages/core/src/properties/root.ts
@@ -55,16 +55,41 @@ export class Root extends Property {
 
 	private readonly _extensions: Set<Extension> = new Set();
 
-	@GraphChildList private scenes: Link<Root, Scene>[] = [];
-	@GraphChildList private nodes: Link<Root, Node>[] = [];
-	@GraphChildList private cameras: Link<Root, Camera>[] = [];
-	@GraphChildList private skins: Link<Root, Skin>[] = [];
-	@GraphChildList private meshes: Link<Root, Mesh>[] = [];
-	@GraphChildList private materials: Link<Root, Material>[] = [];
-	@GraphChildList private textures: Link<Root, Texture>[] = [];
-	@GraphChildList private animations: Link<Root, Animation>[] = [];
 	@GraphChildList private accessors: Link<Root, Accessor>[] = [];
+	@GraphChildList private animations: Link<Root, Animation>[] = [];
 	@GraphChildList private buffers: Link<Root, Buffer>[] = [];
+	@GraphChildList private cameras: Link<Root, Camera>[] = [];
+	@GraphChildList private materials: Link<Root, Material>[] = [];
+	@GraphChildList private meshes: Link<Root, Mesh>[] = [];
+	@GraphChildList private nodes: Link<Root, Node>[] = [];
+	@GraphChildList private scenes: Link<Root, Scene>[] = [];
+	@GraphChildList private skins: Link<Root, Skin>[] = [];
+	@GraphChildList private textures: Link<Root, Texture>[] = [];
+
+	public clone(): this {
+		throw new Error('Root cannot be cloned.');
+	}
+
+	public copy(other: this, resolve = null): this {
+		super.copy(other, resolve);
+
+		// Root cannot be cloned in isolation: only with its Document. Extensions are managed by
+		// the Document during cloning.
+		if (!resolve) throw new Error('Root cannot be copied.');
+
+		Object.assign(this._asset, other._asset);
+		this.copyGraphChildList('accessor', other.accessors, this.accessors, resolve);
+		this.copyGraphChildList('animation', other.animations, this.animations, resolve);
+		this.copyGraphChildList('buffer', other.buffers, this.buffers, resolve);
+		this.copyGraphChildList('camera', other.cameras, this.cameras, resolve);
+		this.copyGraphChildList('material', other.materials, this.materials, resolve);
+		this.copyGraphChildList('mesh', other.meshes, this.meshes, resolve);
+		this.copyGraphChildList('node', other.nodes, this.nodes, resolve);
+		this.copyGraphChildList('scene', other.scenes, this.scenes, resolve);
+		this.copyGraphChildList('skin', other.skins, this.skins, resolve);
+		this.copyGraphChildList('texture', other.textures, this.textures, resolve);
+		return this;
+	}
 
 	/**
 	 * Returns the `asset` object, which specifies the target glTF version of the asset. Additional

--- a/packages/core/src/properties/scene.ts
+++ b/packages/core/src/properties/scene.ts
@@ -2,6 +2,7 @@ import { PropertyType } from '../constants';
 import { GraphChildList, Link } from '../graph/index';
 import { ExtensibleProperty } from './extensible-property';
 import { Node } from './node';
+import { COPY_IDENTITY } from './property';
 
 /**
  * # Scene
@@ -23,6 +24,15 @@ export class Scene extends ExtensibleProperty {
 	public readonly propertyType = PropertyType.SCENE;
 
 	@GraphChildList private nodes: Link<Scene, Node>[] = [];
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this.clearGraphChildList(this.nodes);
+		other.nodes.forEach((link) => this.addNode(resolve(link.getChild())));
+
+		return this;
+	}
 
 	/** Adds a {@link Node} to the scene. */
 	public addNode(node: Node): this {

--- a/packages/core/src/properties/skin.ts
+++ b/packages/core/src/properties/skin.ts
@@ -3,6 +3,7 @@ import { GraphChild, GraphChildList, Link } from '../graph';
 import { Accessor } from './accessor';
 import { ExtensibleProperty } from './extensible-property';
 import { Node } from './node';
+import { COPY_IDENTITY } from './property';
 
 /**
  * # Skin
@@ -21,6 +22,18 @@ export class Skin extends ExtensibleProperty {
 	@GraphChild private skeleton: Link<Skin, Node> = null;
 	@GraphChild private inverseBindMatrices: Link<Skin, Accessor> = null;
 	@GraphChildList private joints: Link<Skin, Node>[] = [];
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		if (other.skeleton) this.setSkeleton(resolve(other.skeleton.getChild()));
+		if (other.inverseBindMatrices) this.setInverseBindMatrices(resolve(other.inverseBindMatrices.getChild()));
+
+		this.clearGraphChildList(this.joints);
+		other.joints.forEach((link) => this.addJoint(resolve(link.getChild())));
+
+		return this;
+	}
 
 	/**
 	 * {@link Node} used as a skeleton root. The node must be the closest common root of the joints

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -27,13 +27,13 @@ import { COPY_IDENTITY } from './property';
 export class Texture extends ExtensibleProperty {
 	public readonly propertyType = PropertyType.TEXTURE;
 
-	/** Raw image data for this texture. */
+	/** @hidden Raw image data for this texture. */
 	private image: ArrayBuffer = null;
 
-	/** Image MIME type. Required if URI is not set. */
+	/** @hidden Image MIME type. Required if URI is not set. */
 	private mimeType = '';
 
-	/** Image URI. Required if MIME type is not set. */
+	/** @hidden Image URI. Required if MIME type is not set. */
 	private uri = '';
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -1,6 +1,7 @@
 import { PropertyType, vec2 } from '../constants';
 import { ImageUtils } from '../utils';
 import { ExtensibleProperty } from './extensible-property';
+import { COPY_IDENTITY } from './property';
 
 /**
  * # Texture
@@ -34,6 +35,16 @@ export class Texture extends ExtensibleProperty {
 
 	/** Image URI. Required if MIME type is not set. */
 	private uri = '';
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this.image = other.image.slice(0);
+		this.mimeType = other.mimeType;
+		this.uri = other.uri;
+
+		return this;
+	}
 
 	/**********************************************************************************************
 	 * MIME type / format.
@@ -114,6 +125,11 @@ export class TextureInfo {
 
 	private texCoord = 0;
 
+	public copy(other: this): this {
+		this.texCoord = other.texCoord;
+		return this;
+	}
+
 	/** Returns the texture coordinate (UV set) index for the texture. */
 	public getTexCoord(): number { return this.texCoord; }
 
@@ -144,6 +160,14 @@ export class TextureSampler {
 	private _minFilter: GLTF.TextureMinFilter = null;
 	private _wrapS: GLTF.TextureWrapMode = GLTF.TextureWrapMode.REPEAT;
 	private _wrapT: GLTF.TextureWrapMode = GLTF.TextureWrapMode.REPEAT;
+
+	public copy(other: this): this {
+		this._magFilter = other._magFilter;
+		this._minFilter = other._minFilter;
+		this._wrapS = other._wrapS;
+		this._wrapT = other._wrapT;
+		return this;
+	}
 
 	/** UV wrapping mode. Values correspond to WebGL enums. */
 	public static TextureWrapMode = {

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -39,9 +39,10 @@ export class Texture extends ExtensibleProperty {
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
 
-		this.image = other.image.slice(0);
 		this.mimeType = other.mimeType;
 		this.uri = other.uri;
+
+		if (other.image) this.image = other.image.slice(0);
 
 		return this;
 	}

--- a/packages/core/test/document.test.js
+++ b/packages/core/test/document.test.js
@@ -16,3 +16,18 @@ test('@gltf-transform/core::document | transform', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::document | clone', t => {
+	const doc1 = new Document();
+	doc1.createMaterial('MyMaterial');
+	doc1.createScene('MyScene');
+
+	const doc2 = doc1.clone();
+
+	t.equal(doc2.getRoot().listScenes()[0].getName(), 'MyScene', 'transfers scene')
+	t.equal(doc2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'transfers material')
+	t.notEqual(doc2.getRoot().listScenes()[0], doc1.getRoot().listScenes()[0], 'does not reference old scene');
+	t.notEqual(doc2.getRoot().listMaterials()[0], doc1.getRoot().listMaterials()[0], 'does not reference old material');
+
+	t.end();
+});

--- a/packages/core/test/properties/animation.test.js
+++ b/packages/core/test/properties/animation.test.js
@@ -72,3 +72,44 @@ test('@gltf-transform/core::animation', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::animation | copy', t => {
+	const doc = new Document();
+	const a = doc.createAnimation('MyAnim')
+		.addChannel(doc.createAnimationChannel())
+		.addSampler(doc.createAnimationSampler());
+	const b = doc.createAnimation().copy(a);
+
+	t.equal(b.getName(), a.getName(), 'copy name');
+	t.deepEqual(b.listChannels(), a.listChannels(), 'copy channels');
+	t.deepEqual(b.listSamplers(), a.listSamplers(), 'copy samplers');
+	t.end();
+});
+
+test('@gltf-transform/core::animationChannel | copy', t => {
+	const doc = new Document();
+	const a = doc.createAnimationChannel('MyChannel')
+		.setTargetNode(doc.createNode())
+		.setSampler(doc.createAnimationSampler());
+	const b = doc.createAnimationChannel().copy(a);
+
+	t.equal(b.getName(), a.getName(), 'copy name');
+	t.equal(b.getTargetNode(), a.getTargetNode(), 'copy targetNode');
+	t.equal(b.getSampler(), a.getSampler(), 'copy sampler');
+	t.end();
+});
+
+test('@gltf-transform/core::animationSampler | copy', t => {
+	const doc = new Document();
+	const a = doc.createAnimationSampler('MySampler')
+		.setInterpolation('STEP')
+		.setInput(doc.createAccessor())
+		.setOutput(doc.createAccessor());
+	const b = doc.createAnimationSampler().copy(a);
+
+	t.equal(b.getName(), a.getName(), 'copy name');
+	t.equal(b.getInterpolation(), a.getInterpolation(), 'copy interpolation');
+	t.equal(b.getInput(), a.getInput(), 'copy input');
+	t.equal(b.getOutput(), a.getOutput(), 'copy output');
+	t.end();
+});

--- a/packages/core/test/properties/buffer.test.js
+++ b/packages/core/test/properties/buffer.test.js
@@ -26,3 +26,13 @@ test('@gltf-transform/core::buffer', t => {
 	t.false('empty.bin' in nativeDoc.resources, 'empty buffer skipped');
 	t.end();
 });
+
+test('@gltf-transform/core::buffer | copy', t => {
+	const doc = new Document();
+	const buffer1 = doc.createBuffer('MyBuffer').setURI('mybuffer.bin');
+	const buffer2 = doc.createBuffer().copy(buffer1);
+
+	t.equal(buffer1.getName(), buffer2.getName(), 'copy name');
+	t.equal(buffer1.getURI(), buffer2.getURI(), 'copy URI');
+	t.end();
+});

--- a/packages/core/test/properties/camera.test.js
+++ b/packages/core/test/properties/camera.test.js
@@ -51,3 +51,38 @@ test('@gltf-transform/core::camera', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::camera | copy', t => {
+	const doc = new Document();
+
+	const a = doc.createCamera('MyPerspectiveCamera')
+		.setType('perspective')
+		.setZNear(0.1)
+		.setZFar(10)
+		.setYFov(Math.PI / 5)
+		.setAspectRatio(.5);
+	const b = doc.createCamera('MyOrthoCamera')
+		.setType('orthographic')
+		.setZNear(10)
+		.setZFar(100)
+		.setXMag(50)
+		.setYMag(25);
+	const c = doc.createCamera().copy(a);
+
+	t.equal(c.getName(), a.getName(), 'copy name');
+	t.equal(c.getType(), a.getType(), 'copy type');
+	t.equal(c.getZNear(), a.getZNear(), 'copy znear');
+	t.equal(c.getZFar(), a.getZFar(), 'copy zfar');
+	t.equal(c.getYFov(), a.getYFov(), 'copy yfov');
+	t.equal(c.getAspectRatio(), a.getAspectRatio(), 'copy aspectRatio');
+
+	c.copy(b);
+
+	t.equal(c.getName(), b.getName(), 'copy name');
+	t.equal(c.getType(), b.getType(), 'copy type');
+	t.equal(c.getZNear(), b.getZNear(), 'copy znear');
+	t.equal(c.getZFar(), b.getZFar(), 'copy zfar');
+	t.equal(c.getXMag(), b.getXMag(), 'copy xmag');
+	t.equal(c.getYMag(), b.getYMag(), 'copy ymag');
+	t.end();
+});

--- a/packages/core/test/properties/material.test.js
+++ b/packages/core/test/properties/material.test.js
@@ -154,3 +154,55 @@ test('@gltf-transform/core::material | texture linking', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::material | copy', t => {
+	const doc = new Document();
+	const tex = doc.createTexture('MyTex');
+	const mat = doc.createMaterial('MyMat')
+		.setAlphaMode('BLEND')
+		.setAlphaCutoff(0.5)
+		.setBaseColorFactor([1, 0, 1, 0.5])
+		.setBaseColorTexture(tex)
+		.setMetallicFactor(0)
+		.setRoughnessFactor(0.9)
+		.setMetallicRoughnessTexture(tex)
+		.setNormalScale(0.9)
+		.setNormalTexture(tex)
+		.setOcclusionStrength(1.5)
+		.setOcclusionTexture(tex)
+		.setEmissiveFactor([2, 2, 2])
+		.setEmissiveTexture(tex);
+	mat.getBaseColorTextureInfo().setTexCoord(2);
+	mat.getBaseColorTextureSampler()
+		.setMagFilter(1)
+		.setMinFilter(2)
+		.setWrapS(3)
+		.setWrapT(4);
+
+	const mat2 = doc.createMaterial().copy(mat);
+
+	t.equal(mat2.getName(), 'MyMat', 'copy name');
+	t.equal(mat2.getAlphaMode(), 'BLEND', 'copy AlphaMode');
+	t.equal(mat2.getAlphaCutoff(), 0.5, 'copy AlphaCutoff');
+	t.deepEqual(mat2.getBaseColorFactor(), [1, 0, 1, 0.5], 'copy BaseColorFactor');
+	t.equal(mat2.getBaseColorTexture(), tex, 'copy BaseColorTexture');
+	t.equal(mat2.getMetallicFactor(), 0, 'copy MetallicFactor');
+	t.equal(mat2.getRoughnessFactor(), 0.9, 'copy RoughnessFactor');
+	t.equal(mat2.getMetallicRoughnessTexture(), tex, 'copy MetallicRoughnessTexture');
+	t.equal(mat2.getNormalScale(), 0.9, 'copy NormalScale');
+	t.equal(mat2.getNormalTexture(), tex, 'copy NormalTexture');
+	t.equal(mat2.getOcclusionStrength(), 1.5, 'copy OcclusionStrength');
+	t.equal(mat2.getOcclusionTexture(), tex, 'copy OcclusionTexture');
+	t.deepEqual(mat2.getEmissiveFactor(), [2, 2, 2], 'copy EmissiveFactor');
+	t.equal(mat2.getEmissiveTexture(), tex, 'copy EmissiveTexture');
+
+	t.equal(mat2.getBaseColorTextureInfo().getTexCoord(), 2, 'copy texCoord');
+
+	const sampler = mat2.getBaseColorTextureSampler();
+	t.equal(sampler.getMagFilter(), 1, 'magFilter');
+	t.equal(sampler.getMinFilter(), 2, 'minFilter');
+	t.equal(sampler.getWrapS(), 3, 'wrapS');
+	t.equal(sampler.getWrapT(), 4, 'wrapT');
+
+	t.end();
+});

--- a/packages/core/test/properties/mesh.test.js
+++ b/packages/core/test/properties/mesh.test.js
@@ -89,3 +89,34 @@ test('@gltf-transform/core::mesh | primitive targets', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::mesh | copy', t => {
+	const doc = new Document();
+	const mesh = doc.createMesh('mesh')
+		.setWeights([1, 2, 3])
+		.addPrimitive(doc.createPrimitive());
+	const mesh2 = doc.createMesh().copy(mesh);
+
+	t.deepEqual(mesh2.getWeights(), mesh.getWeights(), 'copy weights');
+	t.deepEqual(mesh2.listPrimitives(), mesh.listPrimitives(), 'copy primitives');
+	t.end();
+});
+
+test('@gltf-transform/core::primitive | copy', t => {
+	const doc = new Document();
+	const prim = doc.createPrimitive()
+		.setAttribute('POSITION', doc.createAccessor())
+		.setIndices(doc.createAccessor())
+		.setMode(3)
+		.setMaterial(doc.createMaterial())
+		.addTarget(doc.createPrimitiveTarget())
+		.addTarget(doc.createPrimitiveTarget());
+	const prim2 = doc.createPrimitive().copy(prim);
+
+	t.equal(prim2.getAttribute('POSITION'), prim2.getAttribute('POSITION'), 'copy attributes');
+	t.equal(prim2.getIndices(), prim.getIndices(), 'copy indices');
+	t.equal(prim2.getMode(), prim.getMode(), 'copy mode');
+	t.equal(prim2.getMaterial(), prim.getMaterial(), 'copy material');
+	t.deepEqual(prim2.listTargets(), prim.listTargets(), 'copy targets');
+	t.end();
+});

--- a/packages/core/test/properties/node.test.js
+++ b/packages/core/test/properties/node.test.js
@@ -1,0 +1,31 @@
+require('source-map-support').install();
+
+const test = require('tape');
+const { Document } = require('../../');
+
+test('@gltf-transform/core::node | copy', t => {
+	const doc = new Document();
+	const node = doc.createNode('MyNode')
+		.setTranslation([1, 2, 3])
+		.setRotation([1, 0, 1, 0])
+		.setScale([2, 2, 2])
+		.setWeights([1.5, 1.5])
+		.setCamera(doc.createCamera())
+		.setMesh(doc.createMesh())
+		.setSkin(doc.createSkin())
+		.addChild(doc.createNode('OtherNode'));
+
+	const node2 = doc.createNode().copy(node);
+	t.equals(node2.getName(), 'MyNode', 'copy name');
+	t.deepEqual(node2.getTranslation(), [1, 2, 3], 'copy translation');
+	t.deepEqual(node2.getRotation(), [1, 0, 1, 0], 'copy rotation');
+	t.deepEqual(node2.getScale(), [2, 2, 2], 'copy scale');
+	t.deepEqual(node2.getWeights(), [1.5, 1.5], 'copy weights');
+
+	t.equals(node2.getCamera(), node.getCamera(), 'copy camera');
+	t.equals(node2.getMesh(), node.getMesh(), 'copy mesh');
+	t.equals(node2.getSkin(), node.getSkin(), 'copy skin');
+	t.equals(node2.listChildren()[0], node.listChildren()[0], 'copy children');
+
+	t.end();
+});

--- a/packages/core/test/properties/root.test.js
+++ b/packages/core/test/properties/root.test.js
@@ -1,0 +1,16 @@
+require('source-map-support').install();
+
+const test = require('tape');
+const { Document } = require('../../');
+
+test('@gltf-transform/core::root | copy', t => {
+	const doc = new Document();
+	const buffer = doc.createBuffer();
+	const node = doc.createNode();
+	const scene = doc.createScene();
+
+	t.deepEqual(doc.getRoot().listBuffers(), [buffer], 'listBuffers()');
+	t.deepEqual(doc.getRoot().listNodes(), [node], 'listNodes()');
+	t.deepEqual(doc.getRoot().listScenes(), [scene], 'listScenes()');
+	t.end();
+});

--- a/packages/core/test/properties/scene.test.js
+++ b/packages/core/test/properties/scene.test.js
@@ -1,0 +1,16 @@
+require('source-map-support').install();
+
+const test = require('tape');
+const { Document } = require('../../');
+
+test('@gltf-transform/core::scene | copy', t => {
+	const doc = new Document();
+	const scene = doc.createScene('MyScene')
+		.addNode(doc.createNode('Node1'))
+		.addNode(doc.createNode('Node2'));
+
+	const scene2 = doc.createScene().copy(scene);
+	t.equals(scene2.getName(), 'MyScene', 'copy name');
+	t.deepEqual(scene2.listNodes(), scene.listNodes(), 'copy nodes');
+	t.end();
+});

--- a/packages/core/test/properties/skin.test.js
+++ b/packages/core/test/properties/skin.test.js
@@ -73,3 +73,19 @@ test('@gltf-transform/core::skin', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::skin | copy', t => {
+	const doc = new Document();
+	const a = doc.createSkin('MySkin')
+		.addJoint(doc.createNode())
+		.addJoint(doc.createNode())
+		.setSkeleton(doc.createNode())
+		.setInverseBindMatrices(doc.createAccessor());
+	const b = doc.createSkin().copy(a);
+
+	t.equal(b.getName(), a.getName(), 'copy name');
+	t.deepEqual(b.listJoints(), a.listJoints(), 'copy joints');
+	t.equal(b.getSkeleton(), a.getSkeleton(), 'copy skeleton');
+	t.equal(b.getInverseBindMatrices(), a.getInverseBindMatrices(), 'copy inverseBindMatrices');
+	t.end();
+});

--- a/packages/core/test/properties/texture.test.js
+++ b/packages/core/test/properties/texture.test.js
@@ -78,3 +78,19 @@ test('@gltf-transform/core::texture | write', t => {
 	t.equals(nativeDoc.json.samplers.length, 2, 'reuses samplers');
 	t.end();
 });
+
+test('@gltf-transform/core::texture | copy', t => {
+	const doc = new Document();
+	const tex = doc.createTexture('MyTexture')
+		.setImage(new ArrayBuffer(2))
+		.setMimeType('image/gif')
+		.setURI('path/to/image.gif');
+
+	const tex2 = doc.createTexture().copy(tex);
+	t.equals(tex2.getName(), 'MyTexture', 'copy name');
+	t.deepEqual(tex2.getImage(), tex.getImage(), 'copy image');
+	t.equals(tex2.getMimeType(), 'image/gif', 'copy mimeType');
+	t.equals(tex2.getURI(), 'path/to/image.gif', 'copy URI');
+
+	t.end();
+});

--- a/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
@@ -1,4 +1,4 @@
-import { ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, TextureSampler } from '@gltf-transform/core';
+import { COPY_IDENTITY, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, TextureSampler } from '@gltf-transform/core';
 import { KHR_MATERIALS_CLEARCOAT } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -15,6 +15,29 @@ export class Clearcoat extends ExtensionProperty {
 	@GraphChild private clearcoatTexture: TextureLink = null;
 	@GraphChild private clearcoatRoughnessTexture: TextureLink = null;
 	@GraphChild private clearcoatNormalTexture: TextureLink = null;
+
+	public copy(other: this, resolve = COPY_IDENTITY): this {
+		super.copy(other, resolve);
+
+		this._clearcoatFactor = other._clearcoatFactor;
+		this._clearcoatRoughnessFactor = other._clearcoatRoughnessFactor;
+		this._clearcoatNormalScale = other._clearcoatNormalScale;
+
+		if (other.clearcoatTexture) {
+			this.setClearcoatTexture(resolve(other.clearcoatTexture.getChild()));
+			this.clearcoatTexture.copy(other.clearcoatTexture);
+		}
+		if (other.clearcoatRoughnessTexture) {
+			this.setClearcoatRoughnessTexture(resolve(other.clearcoatRoughnessTexture.getChild()));
+			this.clearcoatRoughnessTexture.copy(other.clearcoatRoughnessTexture);
+		}
+		if (other.clearcoatNormalTexture) {
+			this.setClearcoatNormalTexture(resolve(other.clearcoatNormalTexture.getChild()));
+			this.clearcoatNormalTexture.copy(other.clearcoatNormalTexture);
+		}
+
+		return this;
+	}
 
 	/**********************************************************************************************
 	 * Clearcoat.

--- a/packages/extensions/test/materials-clearcoat.test.js
+++ b/packages/extensions/test/materials-clearcoat.test.js
@@ -46,3 +46,29 @@ test('@gltf-transform/extensions::materials-clearcoat', t => {
 	t.ok(roundtripMat.getExtension(Clearcoat).getClearcoatTexture(), 'reads clearcoatTexture');
 	t.end();
 });
+
+test('@gltf-transform/extensions::materials-clearcoat | copy', t => {
+	const doc = new Document();
+	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
+	const clearcoat = clearcoatExtension.createClearcoat()
+		.setClearcoatFactor(0.9)
+		.setClearcoatRoughnessFactor(0.1)
+		.setClearcoatNormalScale(0.5)
+		.setClearcoatTexture(doc.createTexture('cc'))
+		.setClearcoatRoughnessTexture(doc.createTexture('ccrough'))
+		.setClearcoatNormalTexture(doc.createTexture('ccnormal'));
+	doc.createMaterial()
+		.setExtension(Clearcoat, clearcoat);
+
+	const doc2 = doc.clone();
+	const clearcoat2 = doc2.getRoot().listMaterials()[0].getExtension(Clearcoat);
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsClearcoat');
+	t.ok(clearcoat2, 'copy Clearcoat');
+	t.equals(clearcoat2.getClearcoatFactor(), 0.9, 'copy clearcoatFactor');
+	t.equals(clearcoat2.getClearcoatRoughnessFactor(), 0.1, 'copy clearcoatFactor');
+	t.equals(clearcoat2.getClearcoatNormalScale(), 0.5, 'copy clearcoatFactor');
+	t.equals(clearcoat2.getClearcoatTexture().getName(), 'cc', 'copy clearcoatTexture');
+	t.equals(clearcoat2.getClearcoatRoughnessTexture().getName(), 'ccrough', 'copy clearcoatRoughnessTexture');
+	t.equals(clearcoat2.getClearcoatNormalTexture().getName(), 'ccnormal', 'copy clearcoatNormalTexture');
+	t.end();
+});

--- a/packages/extensions/test/materials-unlit.test.js
+++ b/packages/extensions/test/materials-unlit.test.js
@@ -33,3 +33,15 @@ test('@gltf-transform/extensions::materials-unlit', t => {
 	t.equal(mat.getExtension(Unlit), null, 'unlit is detached');
 	t.end();
 });
+
+test('@gltf-transform/extensions::materials-unlit | copy', t => {
+	const doc = new Document();
+	const unlitExtension = doc.createExtension(MaterialsUnlit);
+	doc.createMaterial()
+		.setExtension(Unlit, unlitExtension.createUnlit());
+
+	const doc2 = doc.clone();
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsUnlit');
+	t.ok(doc2.getRoot().listMaterials()[0].getExtension(Unlit), 'copy Unlit');
+	t.end();
+});

--- a/packages/extensions/test/mesh-quantization.test.js
+++ b/packages/extensions/test/mesh-quantization.test.js
@@ -8,7 +8,7 @@ const { MeshQuantization } = require('../');
 
 const WRITER_OPTIONS = {basename: 'extensionTest'};
 
-test('@gltf-transform/extensions::materials-unlit', t => {
+test('@gltf-transform/extensions::mesh-quantization', t => {
 	const doc = new Document();
 	const quantizationExtension = doc.createExtension(MeshQuantization);
 	let nativeDoc;
@@ -20,5 +20,13 @@ test('@gltf-transform/extensions::materials-unlit', t => {
 
 	nativeDoc = new NodeIO(fs, path).createNativeDocument(doc, WRITER_OPTIONS);
 	t.equal(nativeDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
+	t.end();
+});
+
+test('@gltf-transform/extensions::mesh-quantization | copy', t => {
+	const doc = new Document();
+	doc.createExtension(MeshQuantization);
+
+	t.equals(doc.clone().getRoot().listExtensionsUsed().length, 1, 'copy MeshQuantization');
 	t.end();
 });


### PR DESCRIPTION
- [x] Issues with ctor params when cloning ExtensionProperty.
- [x] Unit tests on .copy() implementations.
- [x] Extensions (and Extension docs) don't implement .copy().
