### PR TITLE
[lib] Move inspect() from CLI, improve features.

### DIFF
--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -28,8 +28,14 @@ doc.transform(
 Transforms are functions applying a modification to the {@link Document}. This project includes a few simple transforms already, and more are likely to be added in the future.
 
 | transform                           | compatibility | description                                                                                                                                                                     |
-|-----------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|-------------------------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [ao](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/ao.ts)                 | Node.js, Web  | Bakes per-vertex ambient occlusion. Cheaper but lower-quality than AO baked with a UV map. Powered by [geo-ambient-occlusion](https://github.com/wwwtyro/geo-ambient-occlusion) |
 | [colorspace](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/colorspace.ts) | Node.js, Web  | Vertex color colorspace correction.                                                                                                                                             |
-| [dedup](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/dedup.ts)           | Node.js, Web  | Prunes duplicate accessors and textures. Based on a [gist by mattdesl](https://gist.github.com/mattdesl/aea40285e2d73916b6b9101b36d84da8).                            |
-| [partition](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/partition.ts)           | Node.js, Web  | Partitions the binary payload of a glTF file so separate mesh data is in separate .bin files.                                                                                       |
+| [dedup](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/dedup.ts)           | Node.js, Web  | Prunes duplicate accessors and textures. Based on a [gist by mattdesl](https://gist.github.com/mattdesl/aea40285e2d73916b6b9101b36d84da8).                                      |
+| [partition](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/partition.ts)   | Node.js, Web  | Partitions the binary payload of a glTF file so separate mesh data is in separate .bin files.                                                                                   |
+
+## Other functions
+
+| function | compatibility | description |
+|----------|---------------|-------------|
+| [inspect](https://github.com/donmccurdy/glTF-Transform/tree/master/packages/lib/src/inspect.ts)       | Node.js, Web  | Inspects the contents of a glTF file and returns a report. |

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -31,8 +31,7 @@ program
 	.help('Inspect the contents of the model.')
 	.argument('<input>', 'Path to glTF 2.0 (.glb, .gltf) model')
 	.action(({args, logger}) => {
-		const doc = io.read(args.input).setLogger(logger);
-		inspect(doc);
+		inspect(io.readNativeDocument(args.input), io, logger);
 	});
 
 // VALIDATE

--- a/packages/cli/src/inspect.js
+++ b/packages/cli/src/inspect.js
@@ -44,8 +44,8 @@ function formatPropertyReport(property, index) {
 		const value = property[key];
 		if (Array.isArray(value)) {
 			row[key] = value.join(', ');
-		} else if (key === 'size') {
-			row[key] = formatBytes(value);
+		} else if (key.match(/size/i)) {
+			row[key] = value > 0 ? formatBytes(value) : '';
 		} else if (typeof value === 'number') {
 			row[key] = formatLong(value);
 		} else {

--- a/packages/cli/src/inspect.js
+++ b/packages/cli/src/inspect.js
@@ -1,10 +1,11 @@
 const Table = require('cli-table');
-const { Texture } = require('@gltf-transform/core');
-const { formatBytes, formatHeader, formatParagraph } = require('./util');
+const { inspect: inspectDoc } = require('@gltf-transform/lib');
+const { formatBytes, formatHeader, formatLong, formatParagraph } = require('./util');
 
 function inspect (doc) {
 	const logger = doc.getLogger();
 
+	// TODO(feature): Should really be able to get at least this far without parsing.
 	const table = new Table();
 	table.push(
 		{generator: doc.getRoot().getAsset().generator},
@@ -15,185 +16,43 @@ function inspect (doc) {
 	console.log(formatHeader('info'));
 	console.log(table.toString() + '\n');
 
-	for (const type of ['scenes', 'meshes', 'materials', 'textures', 'animations']) {
-		let result;
-		switch (type) {
-			case 'scenes': result = listScenes(doc); break;
-			case 'meshes': result = listMeshes(doc); break;
-			case 'materials': result = listMaterials(doc); break;
-			case 'textures': result = listTextures(doc); break;
-			case 'animations': result = listAnimations(doc); break;
-		}
-		const {head, rows, warnings} = result;
+	const report = inspectDoc(doc);
+	for (const type in report) {
+		const properties = report[type].properties;
 
 		console.log(formatHeader(type));
-		if (rows.length === 0) {
+		if (!properties.length) {
 			console.log(`No ${type} found.\n`);
 			continue;
 		}
 
-		const table = new Table({head});
-		table.push(...rows);
+		const formattedProperties = properties.map(formatPropertyReport);
+		const table = new Table({head: Object.keys(formattedProperties[0])});
+		table.push(...formattedProperties.map((p) => Object.values(p)));
 
 		console.log(table.toString());
-		warnings.forEach((warning) => logger.warn(formatParagraph(warning)));
+		if (report[type].warnings) {
+			report[type].warnings.forEach((warning) => logger.warn(formatParagraph(warning)));
+		}
 		console.log('\n');
 	}
 }
 
-/** List scenes. */
-function listScenes (doc) {
-	const rows = doc.getRoot().listScenes().map((scene, index) => {
-		const root = scene.listNodes()[0];
-		return [
-			index,
-			scene.getName(),
-			root ? root.getName() : '',
-		];
-	});
-
-	return {
-		rows,
-		head: ['index', 'name', 'rootName'],
-		warnings: [],
-	};
-}
-
-/** List meshes. */
-function listMeshes (doc) {
-	const rows = doc.getRoot().listMeshes().map((mesh, index) => {
-		const instances = mesh.listParents()
-			.filter((parent) => parent.propertyType !== 'Root')
-			.length;
-		let size = 0;
-		mesh.listPrimitives().forEach((prim) => {
-			for (const attr of prim.listAttributes()) {
-				size += attr.getArray().byteLength;
-			}
-			if (prim.getIndices()) size += prim.getIndices().getArray().byteLength;
-		});
-		return [
-			index,
-			mesh.getName(),
-			instances,
-			formatBytes(size)
-		];
-	});
-
-	return {
-		rows,
-		head: ['index', 'name', 'instances', 'size'],
-		warnings: [
-			'Estimated mesh sizes do not include morph targets, and may overestimate'
-			+ ' total sizes if multiple meshes are sharing the same accessors.'
-		],
-	};
-}
-
-/** List materials. */
-function listMaterials (doc) {
-	const rows = doc.getRoot().listMaterials().map((material, index) => {
-		const instances = material.listParents()
-			.filter((parent) => parent.propertyType !== 'Root')
-			.length;
-
-		const slots = doc.getGraph().getLinks()
-			.filter((link) => link.getParent() === material && link.getChild() instanceof Texture)
-			.map((link) => link.getName());
-
-		return [
-			index,
-			material.getName(),
-			instances,
-			slots.join(', '),
-			material.getAlphaMode(),
-			material.getDoubleSided() ? 'x' : '',
-		];
-	});
-
-	return {
-		rows,
-		head: ['index', 'name', 'instances', 'textures', 'alphaMode', 'doubleSided'],
-		warnings: [],
-	};
-}
-
-/** List textures. */
-function listTextures (doc) {
-	const rows = doc.getRoot().listTextures().map((texture, index) => {
-		const instances = texture.listParents()
-			.filter((parent) => parent.propertyType !== 'Root')
-			.length;
-
-		const slots = doc.getGraph().getLinks()
-			.filter((link) => link.getChild() === texture)
-			.map((link) => link.getName())
-			.filter((name) => name !== 'texture');
-
-		// TODO: This requires a Buffer, currently?
-		// const dims = '';
-		// if (texture.getMimeType() === 'image/png') {
-		// 	dims = ImageUtils.getSizePNG(texture.getImage()).join('x');
-		// } else if (texture.getMimeType() === 'image/jpeg') {
-		// 	dims = ImageUtils.getSizeJPEG(texture.getImage()).join('x');
-		// }
-
-		return [
-			index,
-			texture.getName(),
-			texture.getURI(),
-			Array.from(new Set(slots)).join(', '),
-			instances,
-			texture.getMimeType(),
-			formatBytes(texture.getImage().byteLength)
-		]
-	});
-
-	return {
-		rows,
-		head: ['index', 'name', 'uri', 'slots', 'instances', 'mimeType', 'size'],
-		warnings: [],
-	};
-}
-
-/** List animations. */
-function listAnimations (doc) {
-	const rows = doc.getRoot().listAnimations().map((anim, index) => {
-		let minTime = Infinity;
-		let maxTime = -Infinity;
-		anim.listSamplers().forEach((sampler) => {
-			minTime = Math.min(minTime, sampler.getInput().getMin([])[0]);
-			maxTime = Math.max(maxTime, sampler.getInput().getMax([])[0]);
-		});
-
-		let size = 0;
-		const accessors = new Set();
-		anim.listSamplers().forEach((sampler) => {
-			accessors.add(sampler.getInput());
-			accessors.add(sampler.getOutput());
-		});
-		Array.from(accessors)
-			.map((accessor) => accessor.getArray().byteLength)
-			.forEach((byteLength) => (size += byteLength));
-
-		return [
-			index,
-			anim.getName(),
-			anim.listChannels().length,
-			anim.listSamplers().length,
-			(maxTime - minTime).toFixed(3) + 's',
-			formatBytes(size),
-		]
-	});
-
-	return {
-		rows,
-		head: ['index', 'name', 'channels', 'samplers', 'duration', 'size'],
-		warnings: [
-			'Estimated animation sizes may overestimate total sizes if multiple animations'
-			+ ' are sharing the same accessors.'
-		],
+function formatPropertyReport(property, index) {
+	const row = {index};
+	for (const key in property) {
+		const value = property[key];
+		if (Array.isArray(value)) {
+			row[key] = value.join(', ');
+		} else if (key === 'size') {
+			row[key] = formatBytes(value);
+		} else if (typeof value === 'number') {
+			row[key] = formatLong(value);
+		} else {
+			row[key] = value;
+		}
 	}
+	return row;
 }
 
 module.exports = {inspect};

--- a/packages/cli/src/inspect.js
+++ b/packages/cli/src/inspect.js
@@ -2,20 +2,31 @@ const Table = require('cli-table');
 const { inspect: inspectDoc } = require('@gltf-transform/lib');
 const { formatBytes, formatHeader, formatLong, formatParagraph } = require('./util');
 
-function inspect (doc) {
-	const logger = doc.getLogger();
-
-	// TODO(feature): Should really be able to get at least this far without parsing.
+function inspect (nativeDoc, io, logger) {
+	// Summary (does not require parsing).
+	const extensionsUsed = nativeDoc.json.extensionsUsed || [];
+	const extensionsRequired = nativeDoc.json.extensionsRequired || [];
 	const table = new Table();
 	table.push(
-		{generator: doc.getRoot().getAsset().generator},
-		{version: doc.getRoot().getAsset().version},
-		{extensionsUsed: doc.getRoot().listExtensionsUsed().join(', ') || 'none'},
-		{extensionsRequired: doc.getRoot().listExtensionsRequired().join(', ') || 'none'},
+		{generator: nativeDoc.json.asset.generator},
+		{version: nativeDoc.json.asset.version},
+		{extensionsUsed: extensionsUsed.join(', ') || 'none'},
+		{extensionsRequired: extensionsRequired.join(', ') || 'none'},
 	);
 	console.log(formatHeader('info'));
 	console.log(table.toString() + '\n');
 
+	// Parse.
+	let doc;
+	try {
+		doc = io.createDocument(nativeDoc);
+	} catch (e) {
+		logger.warn('Unable to parse document.');
+		logger.error(e.message);
+		return;
+	}
+
+	// Detailed report.
 	const report = inspectDoc(doc);
 	for (const type in report) {
 		const properties = report[type].properties;
@@ -48,6 +59,8 @@ function formatPropertyReport(property, index) {
 			row[key] = value > 0 ? formatBytes(value) : '';
 		} else if (typeof value === 'number') {
 			row[key] = formatLong(value);
+		} else if (typeof value === 'boolean') {
+			row[key] = value ? '✓' : '';
 		} else {
 			row[key] = value;
 		}

--- a/packages/cli/src/inspect.js
+++ b/packages/cli/src/inspect.js
@@ -50,7 +50,7 @@ function inspect (nativeDoc, io, logger) {
 }
 
 function formatPropertyReport(property, index) {
-	const row = {index};
+	const row = {'#': index};
 	for (const key in property) {
 		const value = property[key];
 		if (Array.isArray(value)) {

--- a/packages/cli/src/inspect.js
+++ b/packages/cli/src/inspect.js
@@ -8,7 +8,7 @@ function inspect (nativeDoc, io, logger) {
 	const extensionsRequired = nativeDoc.json.extensionsRequired || [];
 	const table = new Table();
 	table.push(
-		{generator: nativeDoc.json.asset.generator},
+		{generator: nativeDoc.json.asset.generator || ''},
 		{version: nativeDoc.json.asset.version},
 		{extensionsUsed: extensionsUsed.join(', ') || 'none'},
 		{extensionsRequired: extensionsRequired.join(', ') || 'none'},

--- a/packages/cli/src/util.js
+++ b/packages/cli/src/util.js
@@ -1,5 +1,9 @@
 // Utilities.
 
+function formatLong(x) {
+    return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
 function formatBytes(bytes, decimals = 2) {
     if (bytes === 0) return '0 Bytes';
 
@@ -24,4 +28,4 @@ function formatHeader(title) {
 		+ '\n ────────────────────────────────────────────';
 }
 
-module.exports = {formatBytes, formatHeader, formatParagraph};
+module.exports = {formatLong, formatBytes, formatHeader, formatParagraph};

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -21,7 +21,7 @@ test('@gltf-transform/cli::copy', t => {
 	cli
 		.exec(['copy', input, output])
 		.then(() => {
-			const doc2 = io.readGLB(output);
+			const doc2 = io.read(output);
 			t.ok(doc2, 'roundtrip document');
 			t.equal(doc2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'roundtrip material');
 			t.end();

--- a/packages/core/src/io/io.ts
+++ b/packages/core/src/io/io.ts
@@ -135,7 +135,7 @@ class NodeIO extends PlatformIO {
 
 	/** Loads a local path and returns a {@link NativeDocument} struct. */
 	public readNativeDocument (uri: string): NativeDocument {
-		const isGLB = !!uri.match(/\.glb$/);
+		const isGLB = !!(uri.match(/\.glb$/) || uri.match(/^data:application\/octet-stream;/));
 		return isGLB ? this.readGLB(uri) : this.readGLTF(uri);
 	}
 
@@ -235,7 +235,7 @@ class WebIO extends PlatformIO {
 
 	/** Loads a URI and returns a {@link NativeDocument} struct. */
 	public readNativeDocument (uri: string): Promise<NativeDocument> {
-		const isGLB = !!uri.match(/\.glb$/);
+		const isGLB = !!(uri.match(/\.glb$/) || uri.match(/^data:application\/octet-stream;/));
 		return isGLB ? this.readGLB(uri) : this.readGLTF(uri);
 	}
 

--- a/packages/core/src/io/io.ts
+++ b/packages/core/src/io/io.ts
@@ -38,8 +38,8 @@ abstract class PlatformIO {
 		return GLTFWriter.write(doc, options);
 	}
 
-	/** Converts a GLB-formatted ArrayBuffer to a {@link Document}. */
-	public unpackGLB(glb: ArrayBuffer): Document {
+	/** Converts a GLB-formatted ArrayBuffer to a {@link NativeDocument}. */
+	public unpackGLBToNativeDocument(glb: ArrayBuffer): NativeDocument {
 		// Decode and verify GLB header.
 		const header = new Uint32Array(glb, 0, 3);
 		if (header[0] !== 0x46546C67) {
@@ -66,7 +66,12 @@ abstract class PlatformIO {
 		const binaryByteLength = binaryChunkHeader[0];
 		const binary = glb.slice(binaryByteOffset, binaryByteOffset + binaryByteLength);
 
-		return this.createDocument({json, resources: {[GLB_BUFFER]: binary}});
+		return {json, resources: {[GLB_BUFFER]: binary}};
+	}
+
+	/** Converts a GLB-formatted ArrayBuffer to a {@link Document}. */
+	public unpackGLB(glb: ArrayBuffer): Document {
+		return this.createDocument(this.unpackGLBToNativeDocument(glb));
 	}
 
 	/** Converts a {@link Document} to a GLB-formatted ArrayBuffer. */
@@ -128,10 +133,16 @@ class NodeIO extends PlatformIO {
 
 	/* Public. */
 
-	/** Loads a local path and returns a {@link Document} instance. */
-	public read (uri: string): Document {
+	/** Loads a local path and returns a {@link NativeDocument} struct. */
+	public readNativeDocument (uri: string): NativeDocument {
 		const isGLB = !!uri.match(/\.glb$/);
 		return isGLB ? this.readGLB(uri) : this.readGLTF(uri);
+	}
+
+	/** Loads a local path and returns a {@link Document} instance. */
+	public read (uri: string): Document {
+		const nativeDoc = this.readNativeDocument(uri);
+		return GLTFReader.read(nativeDoc, {extensions: this._extensions});
 	}
 
 	/** Writes a {@link Document} instance to a local path. */
@@ -142,13 +153,13 @@ class NodeIO extends PlatformIO {
 
 	/* Internal. */
 
-	private readGLB (uri: string): Document {
+	private readGLB (uri: string): NativeDocument {
 		const buffer: Buffer = this.fs.readFileSync(uri);
 		const arrayBuffer = BufferUtils.trim(buffer);
-		return this.unpackGLB(arrayBuffer);
+		return this.unpackGLBToNativeDocument(arrayBuffer);
 	}
 
-	private readGLTF (uri: string): Document {
+	private readGLTF (uri: string): NativeDocument {
 		const dir = this.path.dirname(uri);
 		const nativeDoc = {
 			json: JSON.parse(this.fs.readFileSync(uri, 'utf8')),
@@ -166,8 +177,8 @@ class NodeIO extends PlatformIO {
 				nativeDoc.resources[resourceUUID] = BufferUtils.createBufferFromDataURI(resource.uri);
 				resource.uri = resourceUUID;
 			}
-		})
-		return GLTFReader.read(nativeDoc, {extensions: this._extensions});
+		});
+		return nativeDoc;
 	}
 
 	private writeGLTF (uri: string, doc: Document): void {
@@ -222,15 +233,21 @@ class WebIO extends PlatformIO {
 
 	/* Public. */
 
-	/** Loads a URI and returns a {@link Document} instance. */
-	public read (uri: string): Promise<Document> {
+	/** Loads a URI and returns a {@link NativeDocument} struct. */
+	public readNativeDocument (uri: string): Promise<NativeDocument> {
 		const isGLB = !!uri.match(/\.glb$/);
 		return isGLB ? this.readGLB(uri) : this.readGLTF(uri);
 	}
 
+	/** Loads a URI and returns a {@link Document} instance. */
+	public read (uri: string): Promise<Document> {
+		return this.readNativeDocument(uri)
+			.then((nativeDoc) => this.createDocument(nativeDoc));
+	}
+
 	/* Internal. */
 
-	private readGLTF (uri: string): Promise<Document> {
+	private readGLTF (uri: string): Promise<NativeDocument> {
 		const nativeDoc = {json: {}, resources: {}} as NativeDocument;
 		return fetch(uri, this.fetchConfig)
 		.then((response) => response.json())
@@ -246,15 +263,14 @@ class WebIO extends PlatformIO {
 					});
 				}
 			});
-			return Promise.all(pendingResources)
-			.then(() => this.createDocument(nativeDoc));
+			return Promise.all(pendingResources).then(() => nativeDoc);
 		});
 	}
 
-	private readGLB (uri: string): Promise<Document> {
+	private readGLB (uri: string): Promise<NativeDocument> {
 		return fetch(uri, this.fetchConfig)
 			.then((response) => response.arrayBuffer())
-			.then((arrayBuffer) => this.unpackGLB(arrayBuffer));
+			.then((arrayBuffer) => this.unpackGLBToNativeDocument(arrayBuffer));
 	}
 }
 

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -103,8 +103,8 @@ export class Texture extends ExtensibleProperty {
 			isPNG = this.uri.match(/\.png$/);
 		}
 		return isPNG
-			? ImageUtils.getSizePNG(Buffer.from(this.image))
-			: ImageUtils.getSizeJPEG(Buffer.from(this.image));
+			? ImageUtils.getSizePNG(this.image)
+			: ImageUtils.getSizeJPEG(this.image);
 	}
 }
 

--- a/packages/core/src/utils/image-utils.ts
+++ b/packages/core/src/utils/image-utils.ts
@@ -1,4 +1,5 @@
 import { vec2 } from '../constants';
+import { BufferUtils } from './buffer-utils';
 
 // Used to detect "fried" png's: http://www.jongware.com/pngdefry.html
 const PNG_FRIED_CHUNK_NAME = 'CgBI';
@@ -17,39 +18,42 @@ const PNG_FRIED_CHUNK_NAME = 'CgBI';
  */
 class ImageUtils {
 	/** Returns the size of a JPEG image. */
-	public static getSizeJPEG (buffer: Buffer): vec2 {
+	public static getSizeJPEG (buffer: ArrayBuffer): vec2 {
 		// Skip 4 chars, they are for signature
-		buffer = buffer.slice(4);
+		let view = new DataView(buffer, 4);
 
 		let i, next;
-		while (buffer.length) {
+		while (view.byteLength) {
 			// read length of the next block
-			i = buffer.readUInt16BE(0);
+			i = view.getUint16(0, false);
+			// i = buffer.readUInt16BE(0);
 
 			// ensure correct format
-			validateBuffer(buffer, i);
+			validateBuffer(view, i);
 
 			// 0xFFC0 is baseline standard(SOF)
 			// 0xFFC1 is baseline optimized(SOF)
 			// 0xFFC2 is progressive(SOF2)
-			next = buffer[i + 1];
+			next = view.getUint8(i + 1);
 			if (next === 0xC0 || next === 0xC1 || next === 0xC2) {
-				return [buffer.readUInt16BE(i + 7), buffer.readUInt16BE(i + 5)]
+				return [view.getUint16(i + 7, false), view.getUint16(i + 5, false)]
 			}
 
 			// move to the next block
-			buffer = buffer.slice(i + 2);
+			view = new DataView(buffer, view.byteOffset + i + 2);
 		}
 
 		throw new TypeError('Invalid JPG, no size found');
 	}
 
 	/** Returns the size of a PNG image. */
-	public static getSizePNG (buffer: Buffer): vec2 {
-		if (buffer.toString('ascii', 12, 16) === PNG_FRIED_CHUNK_NAME) {
-			return [buffer.readUInt32BE(32), buffer.readUInt32BE(36)];
+	public static getSizePNG (buffer: ArrayBuffer): vec2 {
+		const view = new DataView(buffer);
+		const magic = BufferUtils.decodeText(buffer.slice(12, 16));
+		if (magic === PNG_FRIED_CHUNK_NAME) {
+			return [view.getUint32(32, false), view.getUint32(36, false)];
 		}
-		return [buffer.readUInt32BE(16), buffer.readUInt32BE(20)];
+		return [view.getUint32(16, false), view.getUint32(20, false)];
 	}
 
 	public static mimeTypeToExtension(mimeType: string): string {
@@ -63,13 +67,13 @@ class ImageUtils {
 	}
 }
 
-function validateBuffer (buffer: Buffer, i: number): void {
+function validateBuffer (view: DataView, i: number): void {
     // index should be within buffer limits
-    if (i > buffer.length) {
+    if (i > view.byteLength) {
         throw new TypeError('Corrupt JPG, exceeded buffer limits');
     }
     // Every JPEG block must begin with a 0xFF
-    if (buffer[i] !== 0xFF) {
+    if (view.getUint8(i) !== 0xFF) {
         throw new TypeError('Invalid JPG, marker table corrupted');
     }
 }

--- a/packages/core/test/io.test.js
+++ b/packages/core/test/io.test.js
@@ -23,7 +23,7 @@ test('@gltf-transform/core::io | web', {skip: IS_NODEJS}, t => {
 	const io = new WebIO();
 	t.equals(!!io, true, 'Creates WebIO');
 
-	io.readGLB(SAMPLE_GLB)
+	io.read(SAMPLE_GLB)
 		.then((doc) => {
 			t.equals(doc.getRoot().listBuffers().length, 1, 'reads a GLB with Fetch API');
 		})

--- a/packages/core/test/utils/image-utils.test.js
+++ b/packages/core/test/utils/image-utils.test.js
@@ -4,7 +4,7 @@ const IS_NODEJS = typeof window === 'undefined';
 
 const test = require('tape');
 const { createCanvas } = require('canvas');
-const { ImageUtils } = require('../../');
+const { ImageUtils, BufferUtils } = require('../../');
 
 test('@gltf-transform/core::image-utils', {skip: !IS_NODEJS}, t => {
 	let canvas, ctx, buffer;
@@ -13,13 +13,13 @@ test('@gltf-transform/core::image-utils', {skip: !IS_NODEJS}, t => {
 	ctx = canvas.getContext("2d");
 	ctx.fillStyle = "#222222";
 	buffer = canvas.toBuffer("image/png");
-	t.deepEquals(ImageUtils.getSizePNG(buffer), [100, 50], 'gets PNG size');
+	t.deepEquals(ImageUtils.getSizePNG(BufferUtils.trim(buffer)), [100, 50], 'gets PNG size');
 
 	canvas = createCanvas(16, 32);
 	ctx = canvas.getContext("2d");
 	ctx.fillStyle = "#222222";
 	buffer = canvas.toBuffer("image/jpeg");
-	t.deepEquals(ImageUtils.getSizeJPEG(buffer), [16, 32], 'gets JPEG size');
+	t.deepEquals(ImageUtils.getSizeJPEG(BufferUtils.trim(buffer)), [16, 32], 'gets JPEG size');
 
 	t.end();
 });

--- a/packages/lib/src/inspect.ts
+++ b/packages/lib/src/inspect.ts
@@ -265,5 +265,3 @@ function getGLPrimitiveCount(prim: Primitive): number {
 			throw new Error('Unexpected mode: ' + prim.getMode());
 	}
 }
-
-module.exports = {inspect};

--- a/packages/lib/src/inspect.ts
+++ b/packages/lib/src/inspect.ts
@@ -115,12 +115,13 @@ function listTextures (doc: Document): PropertyReport<TextureReport> {
 			.filter((name) => name !== 'texture');
 
 		let resolution: vec2;
+		let channels: number;
 		if (texture.getMimeType() === 'image/png') {
 			resolution = ImageUtils.getSizePNG(texture.getImage());
+			channels = 4;
 		} else if (texture.getMimeType() === 'image/jpeg') {
 			resolution = ImageUtils.getSizeJPEG(texture.getImage());
-		} else {
-			resolution = [-1, -1];
+			channels = 3;
 		}
 
 		return {
@@ -129,8 +130,9 @@ function listTextures (doc: Document): PropertyReport<TextureReport> {
 			slots: Array.from(new Set(slots)),
 			instances,
 			mimeType: texture.getMimeType(),
-			resolution: Math.min(...resolution) > 0 ? resolution.join('x') : '',
-			size: texture.getImage().byteLength
+			resolution: resolution ? resolution.join('x') : '',
+			size: texture.getImage().byteLength,
+			memSize: resolution ? resolution[0] * resolution[1] * channels : null,
 		};
 	});
 
@@ -216,6 +218,7 @@ interface TextureReport {
 	mimeType: string;
 	resolution: string;
 	size: number;
+	memSize: number;
 }
 
 interface AnimationReport {

--- a/packages/lib/src/inspect.ts
+++ b/packages/lib/src/inspect.ts
@@ -1,0 +1,229 @@
+import { Accessor, Document, ImageUtils, Texture, vec2 } from '@gltf-transform/core';
+
+export function inspect (doc: Document): Report {
+	return {
+		scenes: listScenes(doc),
+		meshes: listMeshes(doc),
+		materials: listMaterials(doc),
+		textures: listTextures(doc),
+		animations: listAnimations(doc),
+	};
+}
+
+/** List scenes. */
+function listScenes (doc): PropertyReport<SceneReport> {
+	const scenes = doc.getRoot().listScenes().map((scene) => {
+		const root = scene.listNodes()[0];
+		return {
+			name: scene.getName(),
+			rootName: root ? root.getName() : '',
+		};
+	});
+	return {properties: scenes};
+}
+
+/** List meshes. */
+function listMeshes (doc: Document): PropertyReport<MeshReport> {
+	const meshes: MeshReport[] = doc.getRoot().listMeshes().map((mesh) => {
+		const instances = mesh.listParents()
+			.filter((parent) => parent.propertyType !== 'Root')
+			.length;
+		let tris = 0;
+		let verts = 0;
+		let indexed = 0;
+		const componentTypes: Set<string> = new Set();
+		const semantics: Set<string> = new Set();
+		const meshAccessors: Set<Accessor> = new Set();
+
+		mesh.listPrimitives().forEach((prim) => {
+			prim.listSemantics().forEach((s) => semantics.add(s));
+			for (const attr of prim.listAttributes()) {
+				componentTypes.add(attr.getArray().constructor.name);
+				meshAccessors.add(attr);
+			}
+			for (const targ of prim.listTargets()) {
+				for (const attr of targ.listAttributes()) {
+					componentTypes.add(attr.getArray().constructor.name);
+					meshAccessors.add(attr);
+				}
+			}
+			if (prim.getIndices()) {
+				const indices = prim.getIndices();
+				componentTypes.add(indices.getArray().constructor.name);
+				tris += indices.getCount() / 3;
+				indexed++;
+				meshAccessors.add(indices);
+			} else {
+				// TODO(bug): Consider mode!
+				tris += prim.getAttribute('POSITION').getCount() / 3;
+			}
+			verts += prim.getAttribute('POSITION').getCount();
+		});
+
+		let size = 0;
+		Array.from(meshAccessors).forEach((a) => (size += a.getArray().byteLength));
+
+		return {
+			name: mesh.getName(),
+			primitives: mesh.listPrimitives().length,
+			primitivesIndexed: indexed,
+			vertices: verts,
+			triangles: tris,
+			components: Array.from(componentTypes).sort().map((s) => s.replace('Array', '')),
+			attributes: Array.from(semantics).sort(),
+			instances: instances,
+			size: size,
+		};
+	});
+
+	return {properties: meshes};
+}
+
+/** List materials. */
+function listMaterials (doc: Document): PropertyReport<MaterialReport> {
+	const materials: MaterialReport[] = doc.getRoot().listMaterials().map((material) => {
+		const instances = material.listParents()
+			.filter((parent) => parent.propertyType !== 'Root')
+			.length;
+
+		const slots = doc.getGraph().getLinks()
+			.filter((link) => link.getParent() === material && link.getChild() instanceof Texture)
+			.map((link) => link.getName());
+
+		return {
+			name: material.getName(),
+			instances,
+			textures: slots,
+			alphaMode: material.getAlphaMode(),
+			doubleSided: material.getDoubleSided(),
+		};
+	});
+
+	return {properties: materials};
+}
+
+/** List textures. */
+function listTextures (doc: Document): PropertyReport<TextureReport> {
+	const textures: TextureReport[] = doc.getRoot().listTextures().map((texture) => {
+		const instances = texture.listParents()
+			.filter((parent) => parent.propertyType !== 'Root')
+			.length;
+
+		const slots = doc.getGraph().getLinks()
+			.filter((link) => link.getChild() === texture)
+			.map((link) => link.getName())
+			.filter((name) => name !== 'texture');
+
+		let resolution: vec2;
+		if (texture.getMimeType() === 'image/png') {
+			resolution = ImageUtils.getSizePNG(texture.getImage());
+		} else if (texture.getMimeType() === 'image/jpeg') {
+			resolution = ImageUtils.getSizeJPEG(texture.getImage());
+		} else {
+			resolution = [-1, -1];
+		}
+
+		return {
+			name: texture.getName(),
+			uri: texture.getURI(),
+			slots: Array.from(new Set(slots)),
+			instances,
+			mimeType: texture.getMimeType(),
+			resolution: Math.min(...resolution) > 0 ? resolution.join('x') : '',
+			size: texture.getImage().byteLength
+		};
+	});
+
+	return {properties: textures};
+}
+
+/** List animations. */
+function listAnimations (doc: Document): PropertyReport<AnimationReport> {
+	const animations: AnimationReport[] = doc.getRoot().listAnimations().map((anim) => {
+		let minTime = Infinity;
+		let maxTime = -Infinity;
+		anim.listSamplers().forEach((sampler) => {
+			minTime = Math.min(minTime, sampler.getInput().getMin([])[0]);
+			maxTime = Math.max(maxTime, sampler.getInput().getMax([])[0]);
+		});
+
+		let size = 0;
+		const accessors: Set<Accessor> = new Set();
+		anim.listSamplers().forEach((sampler) => {
+			accessors.add(sampler.getInput());
+			accessors.add(sampler.getOutput());
+		});
+		Array.from(accessors).forEach((accessor) => {
+			size += accessor.getArray().byteLength;
+		});
+
+		return {
+			name: anim.getName(),
+			channels: anim.listChannels().length,
+			samplers: anim.listSamplers().length,
+			duration: Math.round((maxTime - minTime) * 1000) / 1000,
+			size: size,
+		};
+	});
+
+	return {properties: animations}
+}
+
+interface Report {
+	scenes: PropertyReport<SceneReport>;
+	meshes: PropertyReport<MeshReport>;
+	materials: PropertyReport<MaterialReport>;
+	textures: PropertyReport<TextureReport>;
+	animations: PropertyReport<AnimationReport>;
+}
+
+interface PropertyReport<T> {
+	properties: T[];
+	errors?: string[];
+	warnings?: string[];
+}
+
+interface SceneReport {
+	name: string;
+	rootName: string;
+}
+
+interface MeshReport {
+	name: string;
+	primitives: number;
+	primitivesIndexed: number;
+	vertices: number;
+	triangles: number;
+	components: string[];
+	attributes: string[];
+	instances: number;
+	size: number;
+}
+
+interface MaterialReport {
+	name: string;
+	instances: number;
+	textures: string[];
+	alphaMode: GLTF.MaterialAlphaMode;
+	doubleSided: boolean;
+}
+
+interface TextureReport {
+	name: string;
+	uri: string;
+	slots: string[];
+	instances: number;
+	mimeType: string;
+	resolution: string;
+	size: number;
+}
+
+interface AnimationReport {
+	name: string;
+	channels: number;
+	samplers: number;
+	duration: number;
+	size: number;
+}
+
+module.exports = {inspect};

--- a/packages/lib/src/lib.ts
+++ b/packages/lib/src/lib.ts
@@ -2,3 +2,4 @@ export * from './ao';
 export * from './colorspace';
 export * from './dedup';
 export * from './partition';
+export * from './inspect';

--- a/packages/lib/test/dedup.test.js
+++ b/packages/lib/test/dedup.test.js
@@ -9,18 +9,18 @@ const { Document, NodeIO } = require ('@gltf-transform/core');
 const { dedup } = require('../');
 
 test('@gltf-transform/lib::dedup | accessors', t => {
-  const io = new NodeIO(fs, path);
-  const doc = io.read(path.join(__dirname, 'in/many-cubes.gltf'));
-  t.equal(doc.getRoot().listAccessors().length, 1503, 'begins with duplicate accessors');
+	const io = new NodeIO(fs, path);
+	const doc = io.read(path.join(__dirname, 'in/many-cubes.gltf'));
+	t.equal(doc.getRoot().listAccessors().length, 1503, 'begins with duplicate accessors');
 
-  dedup({accessors: false})(doc);
+	dedup({accessors: false})(doc);
 
-  t.equal(doc.getRoot().listAccessors().length, 1503, 'has no effect when disabled');
+	t.equal(doc.getRoot().listAccessors().length, 1503, 'has no effect when disabled');
 
-  dedup()(doc);
+	dedup()(doc);
 
-  t.equal(doc.getRoot().listAccessors().length, 3, 'prunes duplicate accessors');
-  t.end();
+	t.equal(doc.getRoot().listAccessors().length, 3, 'prunes duplicate accessors');
+	t.end();
 });
 
 test('@gltf-transform/lib::dedup | textures', t => {

--- a/packages/lib/test/inspect.test.js
+++ b/packages/lib/test/inspect.test.js
@@ -1,0 +1,29 @@
+require('source-map-support').install();
+
+const fs = require('fs');
+const path = require('path');
+const test = require('tape');
+
+const { Logger, NodeIO } = require ('@gltf-transform/core');
+const { inspect } = require('../');
+
+test('@gltf-transform/lib::inspect', t => {
+
+	const io = new NodeIO(fs, path);
+	const doc = io.read(path.join(__dirname, 'in/TwoCubes.glb'))
+		.setLogger(new Logger(Logger.Verbosity.SILENT));
+
+	doc.createAnimation('TestAnim');
+	doc.createTexture('TestTex')
+		.setImage(new ArrayBuffer(10));
+
+	const report = inspect(doc);
+
+	t.ok(report, 'report');
+	t.equal(report.scenes.properties.length, 1, 'report.scenes');
+	t.equal(report.meshes.properties.length, 2, 'report.meshes');
+	t.equal(report.materials.properties.length, 2, 'report.materials');
+	t.equal(report.animations.properties.length, 1, 'report.animations');
+	t.equal(report.textures.properties.length, 1, 'report.textures');
+	t.end();
+});

--- a/packages/lib/test/partition.test.js
+++ b/packages/lib/test/partition.test.js
@@ -9,25 +9,25 @@ const { partition } = require('../');
 
 test('@gltf-transform/lib::partition', t => {
 
-  const io = new NodeIO(fs, path);
-  const doc = io.read(path.join(__dirname, 'in/TwoCubes.glb'))
-	.setLogger(new Logger(Logger.Verbosity.SILENT));
-  t.equal(doc.getRoot().listBuffers().length, 1, 'initialized with one buffer');
+	const io = new NodeIO(fs, path);
+	const doc = io.read(path.join(__dirname, 'in/TwoCubes.glb'))
+		.setLogger(new Logger(Logger.Verbosity.SILENT));
+	t.equal(doc.getRoot().listBuffers().length, 1, 'initialized with one buffer');
 
-  partition()(doc);
+	partition()(doc);
 
-  t.equal(doc.getRoot().listBuffers().length, 1, 'has no effect when disabled');
+	t.equal(doc.getRoot().listBuffers().length, 1, 'has no effect when disabled');
 
-  partition({meshes: ['CubeA', 'CubeB']})(doc);
+	partition({meshes: ['CubeA', 'CubeB']})(doc);
 
-  const nativeDoc = io.createNativeDocument(doc, {basename: 'partition-test', isGLB: false});
-  t.deepEqual(nativeDoc.json.buffers, [
-    { uri: 'CubeA.bin', byteLength: 324, name: 'CubeA' },
-    { uri: 'CubeB.bin', byteLength: 324, name: 'CubeB' }
-  ], 'partitions into two buffers');
+	const nativeDoc = io.createNativeDocument(doc, {basename: 'partition-test', isGLB: false});
+	t.deepEqual(nativeDoc.json.buffers, [
+		{ uri: 'CubeA.bin', byteLength: 324, name: 'CubeA' },
+		{ uri: 'CubeB.bin', byteLength: 324, name: 'CubeB' }
+	], 'partitions into two buffers');
 
-  const bufferReferences = nativeDoc.json.bufferViews.map((b) => b.buffer);
-  t.deepEquals(bufferReferences, [0,0,1,1], 'creates four buffer views');
+	const bufferReferences = nativeDoc.json.bufferViews.map((b) => b.buffer);
+	t.deepEquals(bufferReferences, [0,0,1,1], 'creates four buffer views');
 
-  t.end();
+	t.end();
 });


### PR DESCRIPTION
Fixes #45, Fixes #46.

Remaining:
- [x] Show at least generator and extensions even if we cannot parse.
- [x] print booleans as `x`
- [x] Consider mode in primitive vertex/tri estimates
- [x] Test coverage