### PR TITLE
[core] Add ColorUtils and hex/vec3/vec4 helpers.

### DIFF
--- a/docs/theme/layouts/default.hbs
+++ b/docs/theme/layouts/default.hbs
@@ -216,6 +216,11 @@
 			</a>
 		</li>
 		<li class="tsd-kind-class">
+			<a href="/classes/colorutils.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/colorutils.html'}} active{{/ifCond}}">
+				Color<wbr>Utils
+			</a>
+		</li>
+		<li class="tsd-kind-class">
 			<a href="/classes/fileutils.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/fileutils.html'}} active{{/ifCond}}">
 				File<wbr>Utils
 			</a>

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -3,7 +3,7 @@ export { Extension } from './extension';
 export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, TextureLink, TextureSampler, COPY_IDENTITY } from './properties';
 export { Graph, GraphChild } from './graph/';
 export { NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
-export { BufferUtils, FileUtils, ImageUtils, MathUtils, Logger, uuid } from './utils/';
+export { BufferUtils, ColorUtils, FileUtils, ImageUtils, MathUtils, Logger, uuid } from './utils/';
 export { PropertyType, vec2, vec3, vec4, mat3, mat4 } from './constants';
 
 /** [[include:CONCEPTS.md]] */

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -160,6 +160,15 @@ export class Material extends ExtensibleProperty {
 	 * Alpha.
 	 */
 
+	/** Returns material alpha, equivalent to baseColorFactor[3]. */
+	public getAlpha(): number { return this._baseColorFactor[3]; }
+
+	/** Sets material alpha, equivalent to baseColorFactor[3]. */
+	public setAlpha(alpha: number): this {
+		this._baseColorFactor[3] = alpha;
+		return this;
+	}
+
 	/**
 	 * Returns the mode of the material's alpha channels, which are provided by `baseColorFactor`
 	 * and `baseColorTexture`.

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -1,5 +1,6 @@
 import { PropertyType, vec3, vec4 } from '../constants';
 import { GraphChild } from '../graph/index';
+import { ColorUtils } from '../utils';
 import { ExtensibleProperty } from './extensible-property';
 import { COPY_IDENTITY } from './property';
 import { TextureLink } from './property-links';
@@ -201,12 +202,29 @@ export class Material extends ExtensibleProperty {
 	 * Base color.
 	 */
 
-	/** Base color / albedo; linear multiplier. See {@link getBaseColorTexture}. */
+	/** Base color / albedo factor in linear space. See {@link getBaseColorTexture}. */
 	public getBaseColorFactor(): vec4 { return this._baseColorFactor; }
 
-	/** Sets the base color / albedo; linear multiplier. See {@link getBaseColorTexture}. */
+	/** Sets the base color / albedo factor in linear space. See {@link getBaseColorTexture}. */
 	public setBaseColorFactor(baseColorFactor: vec4): this {
 		this._baseColorFactor = baseColorFactor;
+		return this;
+	}
+
+	/**
+	 * Base color / albedo as hexadecimal in sRGB colorspace. Converted automatically from
+	 * baseColorFactor in linear space. See {@link getBaseColorTexture}.
+	 */
+	public getBaseColorHex(): number {
+		return ColorUtils.factorToHex(this._baseColorFactor);
+	}
+
+	/**
+	 * Sets base color / albedo as hexadecimal in sRGB colorspace. Converted automatically to
+	 * baseColorFactor in linear space. See {@link getBaseColorTexture}.
+	 */
+	public setBaseColorHex(hex: number): this {
+		ColorUtils.hexToFactor(hex, this._baseColorFactor);
 		return this;
 	}
 
@@ -256,6 +274,23 @@ export class Material extends ExtensibleProperty {
 	/** Sets the emissive color; linear multiplier. See {@link getEmissiveTexture}. */
 	public setEmissiveFactor(emissiveFactor: vec3): this {
 		this._emissiveFactor = emissiveFactor;
+		return this;
+	}
+
+	/**
+	 * Emissive as hexadecimal in sRGB colorspace. Converted automatically from
+	 * emissiveFactor in linear space. See {@link getBaseColorTexture}.
+	 */
+	public getEmissiveHex(): number {
+		return ColorUtils.factorToHex(this._emissiveFactor);
+	}
+
+	/**
+	 * Sets emissive as hexadecimal in sRGB colorspace. Converted automatically to
+	 * emissiveFactor in linear space. See {@link getEmissiveTexture}.
+	 */
+	public setEmissiveHex(hex: number): this {
+		ColorUtils.hexToFactor(hex, this._emissiveFactor);
 		return this;
 	}
 

--- a/packages/core/src/utils/color-utils.ts
+++ b/packages/core/src/utils/color-utils.ts
@@ -1,0 +1,46 @@
+import { vec3, vec4 } from '../constants';
+
+/**
+ * # ColorUtils
+ *
+ * *Common utilities for working with colors in vec3, vec4, or hexadecimal form.*
+ *
+ * @category Utilities
+ */
+export class ColorUtils {
+	/** Converts sRGB hexadecimal to linear components. */
+	static hexToFactor<T = vec3 | vec4>(hex: number, target: T): T {
+		hex = Math.floor( hex );
+		target[0] = ( hex >> 16 & 255 ) / 255;
+		target[1] = ( hex >> 8 & 255 ) / 255;
+		target[2] = ( hex & 255 ) / 255;
+		return this.convertSRGBToLinear<T>(target, target);
+	}
+
+	/** Converts linear components to sRGB hexadecimal. */
+	static factorToHex<T = vec3 | vec4>(factor: T): number {
+		const target = [...factor as unknown as number[]] as unknown as T;
+		const [r, g, b] = this.convertLinearToSRGB(factor, target) as unknown as number[];
+		return ( r * 255 ) << 16 ^ ( g * 255 ) << 8 ^ ( b * 255 ) << 0;
+	}
+
+	/** Converts sRGB components to linear components. */
+	static convertSRGBToLinear<T = vec3 | vec4>(source: T, target: T): T {
+		for (let i = 0 ; i < 3; i++) {
+			target[i] = ( source[i] < 0.04045 )
+				? source[i] * 0.0773993808
+				: Math.pow( source[i] * 0.9478672986 + 0.0521327014, 2.4 );
+		}
+		return target;
+	}
+
+	/** Converts linear components to sRGB components. */
+	static convertLinearToSRGB<T = vec3 | vec4>(source: T, target: T): T {
+		for (let i = 0; i < 3; i++) {
+			target[i] = ( source[i] < 0.0031308 )
+				? source[i] * 12.92
+				: 1.055 * ( Math.pow( source[i], 0.41666 ) ) - 0.055;
+		}
+		return target;
+	}
+}

--- a/packages/core/src/utils/color-utils.ts
+++ b/packages/core/src/utils/color-utils.ts
@@ -5,10 +5,25 @@ import { vec3, vec4 } from '../constants';
  *
  * *Common utilities for working with colors in vec3, vec4, or hexadecimal form.*
  *
+ * Provides methods to convert linear components (vec3, vec4) to sRGB hex values. All colors in
+ * the glTF specification, excluding color textures, are linear. Hexadecimal values, in sRGB
+ * colorspace, are accessible through helper functions in the API as a convenience.
+ *
+ * ```typescript
+ * // Hex (sRGB) to factor (linear).
+ * const factor = ColorUtils.hexToFactor(0xFFCCCC, []);
+ *
+ * // Factor (linear) to hex (sRGB).
+ * const hex = ColorUtils.factorToHex([1, .25, .25])
+ * ```
+ *
  * @category Utilities
  */
 export class ColorUtils {
-	/** Converts sRGB hexadecimal to linear components. */
+	/**
+	 * Converts sRGB hexadecimal to linear components.
+	 * @typeParam T vec3 or vec4 linear components.
+	 */
 	static hexToFactor<T = vec3 | vec4>(hex: number, target: T): T {
 		hex = Math.floor( hex );
 		target[0] = ( hex >> 16 & 255 ) / 255;
@@ -17,14 +32,20 @@ export class ColorUtils {
 		return this.convertSRGBToLinear<T>(target, target);
 	}
 
-	/** Converts linear components to sRGB hexadecimal. */
+	/**
+	 * Converts linear components to sRGB hexadecimal.
+	 * @typeParam T vec3 or vec4 linear components.
+	 */
 	static factorToHex<T = vec3 | vec4>(factor: T): number {
 		const target = [...factor as unknown as number[]] as unknown as T;
 		const [r, g, b] = this.convertLinearToSRGB(factor, target) as unknown as number[];
 		return ( r * 255 ) << 16 ^ ( g * 255 ) << 8 ^ ( b * 255 ) << 0;
 	}
 
-	/** Converts sRGB components to linear components. */
+	/**
+	 * Converts sRGB components to linear components.
+	 * @typeParam T vec3 or vec4 linear components.
+	 */
 	static convertSRGBToLinear<T = vec3 | vec4>(source: T, target: T): T {
 		for (let i = 0 ; i < 3; i++) {
 			target[i] = ( source[i] < 0.04045 )
@@ -34,7 +55,10 @@ export class ColorUtils {
 		return target;
 	}
 
-	/** Converts linear components to sRGB components. */
+	/**
+	 * Converts linear components to sRGB components.
+	 * @typeParam T vec3 or vec4 linear components.
+	 */
 	static convertLinearToSRGB<T = vec3 | vec4>(source: T, target: T): T {
 		for (let i = 0; i < 3; i++) {
 			target[i] = ( source[i] < 0.0031308 )

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './buffer-utils';
+export * from './color-utils';
 export * from './file-utils';
 export * from './image-utils';
 export * from './graph-utils';

--- a/packages/core/test/properties/material.test.js
+++ b/packages/core/test/properties/material.test.js
@@ -33,6 +33,18 @@ test('@gltf-transform/core::material | factors', t => {
 	t.end();
 });
 
+test('@gltf-transform/core::material | hex', t => {
+	const doc = new Document();
+
+	const mat = doc.createMaterial('mat')
+		.setAlpha(0.9)
+		.setBaseColorHex(0x00FF00);
+
+	t.equal(mat.getAlpha(), 0.9, 'alpha');
+	t.equal(mat.getBaseColorHex(), 65024, 'baseColorHex');
+	t.end();
+});
+
 test('@gltf-transform/core::material | textures', t => {
 	const doc = new Document();
 

--- a/packages/core/test/utils/color-utils.test.js
+++ b/packages/core/test/utils/color-utils.test.js
@@ -1,0 +1,20 @@
+require('source-map-support').install();
+
+const test = require('tape');
+const { ColorUtils } = require('../../');
+
+test('@gltf-transform/core::color-utils', t => {
+	t.deepEquals(ColorUtils.hexToFactor(0xFF0000, []), [1, 0, 0], 'hexToFactor');
+	t.deepEquals(ColorUtils.factorToHex([1, 0, 0]), 16646144, 'factorToHex');
+	t.deepEquals(
+		ColorUtils.convertSRGBToLinear([.5, .5, .5], []),
+		[0.2140411404715882, 0.2140411404715882, 0.2140411404715882],
+		'convertSRGBToLinear'
+	);
+	t.deepEquals(
+		ColorUtils.convertLinearToSRGB([.5, .5, .5], []),
+		[0.7353606352856507, 0.7353606352856507, 0.7353606352856507],
+		'convertLinearToSRGB'
+	);
+	t.end();
+});

--- a/packages/extensions/src/khr-lights-punctual/light.ts
+++ b/packages/extensions/src/khr-lights-punctual/light.ts
@@ -1,4 +1,5 @@
 import { COPY_IDENTITY, ExtensionProperty, PropertyType, vec3 } from '@gltf-transform/core';
+import { ColorUtils } from '@gltf-transform/core';
 import { KHR_LIGHTS_PUNCTUAL } from '../constants';
 
 export enum LightType {
@@ -40,12 +41,21 @@ export class Light extends ExtensionProperty {
 	 * COLOR.
 	 */
 
-	/** RGB value for light's color in linear space.. */
+	/** Components (R, G, B) of light's color in linear space. */
 	public getColor(): vec3 { return this._color; }
 
-	/** RGB value for light's color in linear space.. */
+	/** Components (R, G, B) of light's color in linear space. */
 	public setColor(color: vec3): this {
 		this._color = color;
+		return this;
+	}
+
+	/** Hex light color in sRGB colorspace. */
+	public getColorHex(): number { return ColorUtils.factorToHex(this._color); }
+
+	/** Hex light color in sRGB colorspace. */
+	public setColorHex(hex: number): this {
+		ColorUtils.hexToFactor(hex, this._color);
 		return this;
 	}
 

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -1,4 +1,4 @@
-import { COPY_IDENTITY, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, TextureSampler, vec3, vec4 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, TextureSampler, vec3, vec4 } from '@gltf-transform/core';
 import { KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -45,6 +45,15 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	/** Diffuse; linear multiplier. See {@link getDiffuseTexture}. */
 	public setDiffuseFactor(diffuseFactor: vec4): this {
 		this._diffuseFactor = diffuseFactor;
+		return this;
+	}
+
+	/** Diffuse; hex color in sRGB colorspace. */
+	public getDiffuseHex(): number { return ColorUtils.factorToHex(this._diffuseFactor); }
+
+	/** Diffuse; hex color in sRGB colorspace. */
+	public setDiffuseHex(hex: number): this {
+		ColorUtils.hexToFactor(hex, this._diffuseFactor);
 		return this;
 	}
 

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -1,4 +1,4 @@
-import { COPY_IDENTITY, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, TextureSampler, vec3 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, TextureSampler, vec3 } from '@gltf-transform/core';
 import { KHR_MATERIALS_SPECULAR } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -39,13 +39,23 @@ export class Specular extends ExtensionProperty {
 		return this;
 	}
 
-
-	/** Specular color; linear multiplier. See {@link getSpecularTexture}. */
+	/** Specular color; components in linear space. See {@link getSpecularTexture}. */
 	public getSpecularColorFactor(): vec3 { return this._specularColorFactor; }
 
-	/** Specular color; linear multiplier. See {@link getSpecularTexture}. */
+	/** Specular color; components in linear space. See {@link getSpecularTexture}. */
 	public setSpecularColorFactor(specularColorFactor: vec3): this {
 		this._specularColorFactor = specularColorFactor;
+		return this;
+	}
+
+	/** Specular color; hexadecimal in sRGB colorspace. See {@link getSpecularTexture} */
+	public getSpecularColorHex(): number {
+		return ColorUtils.factorToHex(this._specularColorFactor);
+	}
+
+	/** Specular color; hexadecimal in sRGB colorspace. See {@link getSpecularTexture} */
+	public setSpecularColorHex(hex: number): this {
+		ColorUtils.hexToFactor(hex, this._specularColorFactor);
 		return this;
 	}
 

--- a/packages/extensions/test/lights-punctual.test.js
+++ b/packages/extensions/test/lights-punctual.test.js
@@ -80,3 +80,12 @@ test('@gltf-transform/extensions::lights-punctual | copy', t => {
 	t.equal(light2.getOuterConeAngle(), 0.75, 'copy outerConeAngle');
 	t.end();
 });
+
+test('@gltf-transform/extensions::lights-punctual | hex', t => {
+	const doc = new Document();
+	const lightsExtension = doc.createExtension(LightsPunctual);
+	const light = lightsExtension.createLight()
+		.setColorHex(0x111111)
+	t.equals(light.getColorHex(), 0x111111, 'colorHex');
+	t.end();
+});

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.js
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.js
@@ -70,3 +70,12 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness | copy', t =
 	t.equals(specGloss2.getSpecularGlossinessTexture().getName(), 'specGloss', 'copy specularGlossinessTexture');
 	t.end();
 });
+
+test('@gltf-transform/extensions::materials-pbr-specular-glossiness | hex', t => {
+	const doc = new Document();
+	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+	const specGloss = specGlossExtension.createPBRSpecularGlossiness()
+		.setDiffuseHex(0x0000FF);
+	t.equals(specGloss.getDiffuseHex(), 254, 'diffuseHex');
+	t.end();
+});

--- a/packages/extensions/test/materials-specular.test.js
+++ b/packages/extensions/test/materials-specular.test.js
@@ -66,3 +66,13 @@ test('@gltf-transform/extensions::materials-specular | copy', t => {
 	t.equals(specular2.getSpecularTexture().getName(), 'spec', 'copy specularTexture');
 	t.end();
 });
+
+
+test('@gltf-transform/extensions::materials-specular | hex', t => {
+	const doc = new Document();
+	const specularExtension = doc.createExtension(MaterialsSpecular);
+	const specular = specularExtension.createSpecular()
+		.setSpecularColorHex(0x252525)
+	t.equals(specular.getSpecularColorHex(), 0x252525, 'specularColorHex');
+	t.end();
+});


### PR DESCRIPTION
Fixes #53.

To do:

- [x] Extension color methods
- [x] getAlpha/setAlpha
- [x] Tests
- [x] Docs