### PR TITLE
[core] Make TextureInfo an ExtensibleProperty subclass.

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,7 +1,7 @@
 export { Document, Transform } from './document';
 export { Extension } from './extension';
-export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, TextureLink, COPY_IDENTITY } from './properties';
-export { Graph, GraphChild } from './graph/';
+export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, COPY_IDENTITY } from './properties';
+export { Graph, GraphChild, Link } from './graph/';
 export { NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
 export { BufferUtils, ColorUtils, FileUtils, ImageUtils, MathUtils, Logger, uuid } from './utils/';
 export { TypedArray, TypedArrayConstructor, PropertyType, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -1,9 +1,8 @@
 import { PropertyType, vec3, vec4 } from '../constants';
-import { GraphChild } from '../graph/index';
+import { GraphChild, Link } from '../graph/index';
 import { ColorUtils } from '../utils';
 import { ExtensibleProperty } from './extensible-property';
 import { COPY_IDENTITY } from './property';
-import { TextureLink } from './property-links';
 import { Texture } from './texture';
 import { TextureInfo } from './texture-info';
 
@@ -78,24 +77,32 @@ export class Material extends ExtensibleProperty {
 	private _metallicFactor = 1;
 
 	/** @hidden Base color / albedo texture. */
-	@GraphChild private baseColorTexture: TextureLink = null;
+	@GraphChild private baseColorTexture: Link<this, Texture> = null;
+	@GraphChild private baseColorTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('baseColorTextureInfo', this, new TextureInfo(this.graph));
 
 	/** @hidden Emissive texture. */
-	@GraphChild private emissiveTexture: TextureLink = null;
+	@GraphChild private emissiveTexture: Link<this, Texture> = null;
+	@GraphChild private emissiveTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('emissiveTextureInfo', this, new TextureInfo(this.graph));
 
 	/**
 	 * Normal (surface detail) texture. Normal maps often suffer artifacts with JPEG compression,
 	 * so PNG files are preferred.
 	 * @hidden
 	 */
-	@GraphChild private normalTexture: TextureLink = null;
+	@GraphChild private normalTexture: Link<this, Texture> = null;
+	@GraphChild private normalTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('normalTextureInfo', this, new TextureInfo(this.graph));
 
 	/**
 	 * (Ambient) Occlusion texture. Occlusion data is stored in the `.r` channel, allowing this
 	 * texture to be packed with `metallicRoughnessTexture`, optionally.
 	 * @hidden
 	 */
-	@GraphChild private occlusionTexture: TextureLink = null;
+	@GraphChild private occlusionTexture: Link<this, Texture> = null;
+	@GraphChild private occlusionTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('occlusionTextureInfo', this, new TextureInfo(this.graph));
 
 	/**
 	 * Metallic/roughness PBR texture. Roughness data is stored in the `.g` channel and metallic
@@ -103,7 +110,9 @@ export class Material extends ExtensibleProperty {
 	 * `occlusionTexture`, optionally.
 	 * @hidden
 	*/
-	@GraphChild private metallicRoughnessTexture: TextureLink = null;
+	@GraphChild private metallicRoughnessTexture: Link<this, Texture> = null;
+	@GraphChild private metallicRoughnessTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('metallicRoughnessTextureInfo', this, new TextureInfo(this.graph));
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
@@ -120,23 +129,23 @@ export class Material extends ExtensibleProperty {
 
 		if (other.baseColorTexture) {
 			this.setBaseColorTexture(resolve(other.baseColorTexture.getChild()));
-			this.baseColorTexture.copy(other.baseColorTexture);
+			this.getBaseColorTextureInfo().copy(resolve(other.baseColorTextureInfo.getChild()));
 		}
 		if (other.emissiveTexture) {
 			this.setEmissiveTexture(resolve(other.emissiveTexture.getChild()));
-			this.emissiveTexture.copy(other.emissiveTexture);
+			this.getEmissiveTextureInfo().copy(resolve(other.emissiveTextureInfo.getChild()));
 		}
 		if (other.normalTexture) {
 			this.setNormalTexture(resolve(other.normalTexture.getChild()));
-			this.normalTexture.copy(other.normalTexture);
+			this.getNormalTextureInfo().copy(resolve(other.normalTextureInfo.getChild()));
 		}
 		if (other.occlusionTexture) {
 			this.setOcclusionTexture(resolve(other.occlusionTexture.getChild()));
-			this.occlusionTexture.copy(other.occlusionTexture);
+			this.getOcclusionTextureInfo().copy(resolve(other.occlusionTextureInfo.getChild()));
 		}
 		if (other.metallicRoughnessTexture) {
 			this.setMetallicRoughnessTexture(resolve(other.metallicRoughnessTexture.getChild()));
-			this.metallicRoughnessTexture.copy(other.metallicRoughnessTexture);
+			this.getMetallicRoughnessTextureInfo().copy(resolve(other.metallicRoughnessTextureInfo.getChild()));
 		}
 
 		return this;
@@ -255,12 +264,12 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getBaseColorTextureInfo(): TextureInfo {
-		return this.baseColorTexture ? this.baseColorTexture.getTextureInfo() : null;
+		return this.baseColorTexture ? this.baseColorTextureInfo.getChild() : null;
 	}
 
 	/** Sets base color / albedo texture. See {@link getBaseColorTexture}. */
 	public setBaseColorTexture(texture: Texture): this {
-		this.baseColorTexture = this.graph.linkTexture('baseColorTexture', this, texture);
+		this.baseColorTexture = this.graph.link('baseColorTexture', this, texture);
 		return this;
 	}
 
@@ -312,12 +321,12 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getEmissiveTextureInfo(): TextureInfo {
-		return this.emissiveTexture ? this.emissiveTexture.getTextureInfo() : null;
+		return this.emissiveTexture ? this.emissiveTextureInfo.getChild() : null;
 	}
 
 	/** Sets emissive texture. See {@link getEmissiveTexture}. */
 	public setEmissiveTexture(texture: Texture): this {
-		this.emissiveTexture = this.graph.linkTexture('emissiveTexture', this, texture);
+		this.emissiveTexture = this.graph.link('emissiveTexture', this, texture);
 		return this;
 	}
 
@@ -355,12 +364,12 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getNormalTextureInfo(): TextureInfo {
-		return this.normalTexture ? this.normalTexture.getTextureInfo() : null;
+		return this.normalTexture ? this.normalTextureInfo.getChild() : null;
 	}
 
 	/** Sets normal (surface detail) texture. See {@link getNormalTexture}. */
 	public setNormalTexture(texture: Texture): this {
-		this.normalTexture = this.graph.linkTexture('normalTexture', this, texture);
+		this.normalTexture = this.graph.link('normalTexture', this, texture);
 		return this;
 	}
 
@@ -398,12 +407,12 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getOcclusionTextureInfo(): TextureInfo {
-		return this.occlusionTexture ? this.occlusionTexture.getTextureInfo() : null;
+		return this.occlusionTexture ? this.occlusionTextureInfo.getChild() : null;
 	}
 
 	/** Sets (ambient) occlusion texture. See {@link getOcclusionTexture}. */
 	public setOcclusionTexture(texture: Texture): this {
-		this.occlusionTexture = this.graph.linkTexture('occlusionTexture', this, texture);
+		this.occlusionTexture = this.graph.link('occlusionTexture', this, texture);
 		return this;
 	}
 
@@ -459,12 +468,12 @@ export class Material extends ExtensibleProperty {
 	 * attached, {@link TextureInfo} is `null`.
 	 */
 	public getMetallicRoughnessTextureInfo(): TextureInfo {
-		return this.metallicRoughnessTexture ? this.metallicRoughnessTexture.getTextureInfo() : null;
+		return this.metallicRoughnessTexture ? this.metallicRoughnessTextureInfo.getChild() : null;
 	}
 
 	/** Sets metallic/roughness texture. See {@link getMetallicRoughnessTexture}. */
 	public setMetallicRoughnessTexture(texture: Texture): this {
-		this.metallicRoughnessTexture = this.graph.linkTexture('metallicRoughnessTexture', this, texture);
+		this.metallicRoughnessTexture = this.graph.link('metallicRoughnessTexture', this, texture);
 		return this;
 	}
 }

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -255,7 +255,7 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getBaseColorTextureInfo(): TextureInfo {
-		return this.baseColorTexture ? this.baseColorTexture.textureInfo : null;
+		return this.baseColorTexture ? this.baseColorTexture.getTextureInfo() : null;
 	}
 
 	/** Sets base color / albedo texture. See {@link getBaseColorTexture}. */
@@ -312,7 +312,7 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getEmissiveTextureInfo(): TextureInfo {
-		return this.emissiveTexture ? this.emissiveTexture.textureInfo : null;
+		return this.emissiveTexture ? this.emissiveTexture.getTextureInfo() : null;
 	}
 
 	/** Sets emissive texture. See {@link getEmissiveTexture}. */
@@ -355,7 +355,7 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getNormalTextureInfo(): TextureInfo {
-		return this.normalTexture ? this.normalTexture.textureInfo : null;
+		return this.normalTexture ? this.normalTexture.getTextureInfo() : null;
 	}
 
 	/** Sets normal (surface detail) texture. See {@link getNormalTexture}. */
@@ -398,7 +398,7 @@ export class Material extends ExtensibleProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getOcclusionTextureInfo(): TextureInfo {
-		return this.occlusionTexture ? this.occlusionTexture.textureInfo : null;
+		return this.occlusionTexture ? this.occlusionTexture.getTextureInfo() : null;
 	}
 
 	/** Sets (ambient) occlusion texture. See {@link getOcclusionTexture}. */
@@ -459,7 +459,7 @@ export class Material extends ExtensibleProperty {
 	 * attached, {@link TextureInfo} is `null`.
 	 */
 	public getMetallicRoughnessTextureInfo(): TextureInfo {
-		return this.metallicRoughnessTexture ? this.metallicRoughnessTexture.textureInfo : null;
+		return this.metallicRoughnessTexture ? this.metallicRoughnessTexture.getTextureInfo() : null;
 	}
 
 	/** Sets metallic/roughness texture. See {@link getMetallicRoughnessTexture}. */

--- a/packages/core/src/properties/property-graph.ts
+++ b/packages/core/src/properties/property-graph.ts
@@ -1,23 +1,11 @@
 import { Graph } from '../graph';
 import { Accessor } from './accessor';
-import { ExtensionProperty } from './extension-property';
-import { Material } from './material';
 import { Primitive } from './primitive';
 import { PrimitiveTarget } from './primitive-target';
-import { AttributeLink, IndexLink, TextureLink } from './property-links';
-import { Texture } from './texture';
-import { TextureInfo } from './texture-info';
+import { AttributeLink, IndexLink } from './property-links';
 
 /** @hidden */
 export class PropertyGraph extends Graph {
-	public linkTexture(name: string, a: Material | ExtensionProperty, b: Texture): TextureLink {
-		if (!b) return null;
-		const link = new TextureLink(name, a, b)
-			.setTextureInfoLink(this.link(name + 'Info', a, new TextureInfo(this)));
-		this.registerLink(link);
-		return link;
-	}
-
 	public linkAttribute(name: string, a: Primitive|PrimitiveTarget, b: Accessor): AttributeLink {
 		if (!b) return null;
 		const link = new AttributeLink(name, a, b);

--- a/packages/core/src/properties/property-graph.ts
+++ b/packages/core/src/properties/property-graph.ts
@@ -6,12 +6,14 @@ import { Primitive } from './primitive';
 import { PrimitiveTarget } from './primitive-target';
 import { AttributeLink, IndexLink, TextureLink } from './property-links';
 import { Texture } from './texture';
+import { TextureInfo } from './texture-info';
 
 /** @hidden */
 export class PropertyGraph extends Graph {
 	public linkTexture(name: string, a: Material | ExtensionProperty, b: Texture): TextureLink {
 		if (!b) return null;
-		const link = new TextureLink(name, a, b);
+		const link = new TextureLink(name, a, b)
+			.setTextureInfoLink(this.link(name + 'Info', a, new TextureInfo(this)));
 		this.registerLink(link);
 		return link;
 	}

--- a/packages/core/src/properties/property-links.ts
+++ b/packages/core/src/properties/property-links.ts
@@ -1,31 +1,7 @@
 import { Link } from '../graph';
 import { Accessor } from './accessor';
-import { ExtensionProperty } from './extension-property';
-import { Material } from './material';
 import { Primitive } from './primitive';
 import { PrimitiveTarget } from './primitive-target';
-import { Texture } from './texture';
-import { TextureInfo } from './texture-info';
-
-/** @hidden */
-export class TextureLink extends Link<Material|ExtensionProperty, Texture> {
-	private _textureInfo: Link<Material|ExtensionProperty, TextureInfo>;
-	public copy (other: this): this {
-		this._textureInfo.getChild().copy(other._textureInfo.getChild());
-		return this;
-	}
-	public getTextureInfo(): TextureInfo {
-		return this._textureInfo.getChild();
-	}
-	public setTextureInfoLink(link: Link<Material|ExtensionProperty, TextureInfo>): this {
-		this._textureInfo = link;
-		return this;
-	}
-	public dispose(): void {
-		this._textureInfo.dispose();
-		super.dispose();
-	}
-}
 
 /** @hidden */
 export class AttributeLink extends Link<Primitive|PrimitiveTarget, Accessor> {

--- a/packages/core/src/properties/property-links.ts
+++ b/packages/core/src/properties/property-links.ts
@@ -9,10 +9,21 @@ import { TextureInfo } from './texture-info';
 
 /** @hidden */
 export class TextureLink extends Link<Material|ExtensionProperty, Texture> {
-	public textureInfo = new TextureInfo();
+	private _textureInfo: Link<Material|ExtensionProperty, TextureInfo>;
 	public copy (other: this): this {
-		this.textureInfo.copy(other.textureInfo);
+		this._textureInfo.getChild().copy(other._textureInfo.getChild());
 		return this;
+	}
+	public getTextureInfo(): TextureInfo {
+		return this._textureInfo.getChild();
+	}
+	public setTextureInfoLink(link: Link<Material|ExtensionProperty, TextureInfo>): this {
+		this._textureInfo = link;
+		return this;
+	}
+	public dispose(): void {
+		this._textureInfo.dispose();
+		super.dispose();
 	}
 }
 

--- a/packages/core/src/properties/texture-info.ts
+++ b/packages/core/src/properties/texture-info.ts
@@ -6,7 +6,14 @@ import { ExtensibleProperty } from './extensible-property';
  *
  * *Settings associated with a particular use of a {@link Texture}.*
  *
- * Different materials may reuse the same texture but with different texture coordinates.
+ * Different materials may reuse the same texture but with different texture coordinates,
+ * minFilter/magFilter, or wrapS/wrapT settings. The TextureInfo class contains settings
+ * derived from both the "TextureInfo" and "Sampler" properties in the glTF specification,
+ * consolidated here for simplicity.
+ *
+ * TextureInfo properties cannot be directly created. For any material texture slot, such as
+ * baseColorTexture, there will be a corresponding method to obtain the TextureInfo for that slot.
+ * For example, see {@link Material.getBaseColorTextureInfo}.
  *
  * References:
  * - [glTF → Texture Info](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/README.md#reference-textureinfo)

--- a/packages/core/src/properties/texture-info.ts
+++ b/packages/core/src/properties/texture-info.ts
@@ -1,4 +1,5 @@
 import { PropertyType } from '../constants';
+import { ExtensibleProperty } from './extensible-property';
 
 /**
  * # TextureInfo
@@ -12,7 +13,7 @@ import { PropertyType } from '../constants';
  *
  * @category Properties
  */
-export class TextureInfo {
+export class TextureInfo extends ExtensibleProperty {
 	public readonly propertyType = PropertyType.TEXTURE_INFO;
 
 	private _texCoord = 0;

--- a/packages/core/test/properties/material.test.ts
+++ b/packages/core/test/properties/material.test.ts
@@ -1,7 +1,7 @@
 require('source-map-support').install();
 
 import * as test from 'tape';
-import { Document, TextureInfo } from '../../';
+import { Document, Property, TextureInfo } from '../../';
 
 test('@gltf-transform/core::material | properties', t => {
 	const doc = new Document();
@@ -144,7 +144,7 @@ test('@gltf-transform/core::material | texture linking', t => {
 
 	const mat = doc.createMaterial('mat');
 
-	const toType = (p) => p.propertyType;
+	const toType = (p: Property): string => p.propertyType;
 
 	mat.setBaseColorTexture(tex1);
 	t.equals(mat.getBaseColorTexture(), tex1, 'sets baseColorTexture');
@@ -163,6 +163,35 @@ test('@gltf-transform/core::material | texture linking', t => {
 	mat.setBaseColorTexture(null);
 	t.equals(mat.getBaseColorTexture(), null, 'deletes baseColorTexture');
 	t.deepEqual(tex3.listParents().map(toType), ['Root'], 'unlinks old baseColorTexture');
+
+	t.end();
+});
+
+test('@gltf-transform/core::material | texture info linking', t => {
+	const doc = new Document();
+
+	const mat = doc.createMaterial('mat');
+	const tex1 = doc.createTexture('tex1');
+	const tex2 = doc.createTexture('tex2');
+	const tex3 = doc.createTexture('tex3');
+
+	t.equals(mat.getBaseColorTextureInfo(), null, 'textureInfo == null');
+
+	mat.setBaseColorTexture(tex1);
+	mat.getBaseColorTextureInfo().setTexCoord(2);
+
+	const textureInfo = mat.getBaseColorTextureInfo();
+	t.ok(textureInfo, 'textureInfo != null');
+	t.equals(textureInfo.getTexCoord(), 2, 'textureInfo.texCoord === 2');
+
+	mat.setBaseColorTexture(tex2);
+	t.equals(mat.getBaseColorTextureInfo(), textureInfo, 'textureInfo unchanged');
+
+	mat.setBaseColorTexture(null);
+	t.equals(mat.getBaseColorTextureInfo(), null, 'textureInfo == null');
+
+	mat.setBaseColorTexture(tex3);
+	t.equals(mat.getBaseColorTextureInfo(), textureInfo, 'textureInfo unchanged');
 
 	t.end();
 });

--- a/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
@@ -66,7 +66,7 @@ export class Clearcoat extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getClearcoatTextureInfo(): TextureInfo {
-		return this.clearcoatTexture ? this.clearcoatTexture.textureInfo : null;
+		return this.clearcoatTexture ? this.clearcoatTexture.getTextureInfo() : null;
 	}
 
 	/** Sets clearcoat texture. See {@link getClearcoatTexture}. */
@@ -101,7 +101,7 @@ export class Clearcoat extends ExtensionProperty {
 	 * attached, {@link TextureInfo} is `null`.
 	 */
 	public getClearcoatRoughnessTextureInfo(): TextureInfo {
-		return this.clearcoatRoughnessTexture ? this.clearcoatRoughnessTexture.textureInfo : null;
+		return this.clearcoatRoughnessTexture ? this.clearcoatRoughnessTexture.getTextureInfo() : null;
 	}
 
 	/** Sets clearcoat roughness texture. See {@link getClearcoatRoughnessTexture}. */
@@ -135,7 +135,7 @@ export class Clearcoat extends ExtensionProperty {
 	 * attached, {@link TextureInfo} is `null`.
 	 */
 	public getClearcoatNormalTextureInfo(): TextureInfo {
-		return this.clearcoatNormalTexture ? this.clearcoatNormalTexture.textureInfo : null;
+		return this.clearcoatNormalTexture ? this.clearcoatNormalTexture.getTextureInfo() : null;
 	}
 
 	/** Sets clearcoat normal texture. See {@link getClearcoatNormalTexture}. */

--- a/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
@@ -1,4 +1,4 @@
-import { COPY_IDENTITY, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink } from '@gltf-transform/core';
+import { COPY_IDENTITY, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo } from '@gltf-transform/core';
 import { KHR_MATERIALS_CLEARCOAT } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -12,9 +12,17 @@ export class Clearcoat extends ExtensionProperty {
 	private _clearcoatRoughnessFactor = 0.0;
 	private _clearcoatNormalScale = 1.0;
 
-	@GraphChild private clearcoatTexture: TextureLink = null;
-	@GraphChild private clearcoatRoughnessTexture: TextureLink = null;
-	@GraphChild private clearcoatNormalTexture: TextureLink = null;
+	@GraphChild private clearcoatTexture: Link<this, Texture> = null;
+	@GraphChild private clearcoatTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('clearcoatTextureInfo', this, new TextureInfo(this.graph));
+
+	@GraphChild private clearcoatRoughnessTexture: Link<this, Texture> = null;
+	@GraphChild private clearcoatRoughnessTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('clearcoatRoughnessTextureInfo', this, new TextureInfo(this.graph));
+
+	@GraphChild private clearcoatNormalTexture: Link<this, Texture> = null;
+	@GraphChild private clearcoatNormalTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('clearcoatNormalTextureInfo', this, new TextureInfo(this.graph));
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
@@ -25,15 +33,15 @@ export class Clearcoat extends ExtensionProperty {
 
 		if (other.clearcoatTexture) {
 			this.setClearcoatTexture(resolve(other.clearcoatTexture.getChild()));
-			this.clearcoatTexture.copy(other.clearcoatTexture);
+			this.getClearcoatTextureInfo().copy(resolve(other.clearcoatTextureInfo.getChild()));
 		}
 		if (other.clearcoatRoughnessTexture) {
 			this.setClearcoatRoughnessTexture(resolve(other.clearcoatRoughnessTexture.getChild()));
-			this.clearcoatRoughnessTexture.copy(other.clearcoatRoughnessTexture);
+			this.getClearcoatRoughnessTextureInfo().copy(resolve(other.clearcoatRoughnessTextureInfo.getChild()));
 		}
 		if (other.clearcoatNormalTexture) {
 			this.setClearcoatNormalTexture(resolve(other.clearcoatNormalTexture.getChild()));
-			this.clearcoatNormalTexture.copy(other.clearcoatNormalTexture);
+			this.getClearcoatNormalTextureInfo().copy(resolve(other.clearcoatNormalTextureInfo.getChild()));
 		}
 
 		return this;
@@ -66,12 +74,12 @@ export class Clearcoat extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getClearcoatTextureInfo(): TextureInfo {
-		return this.clearcoatTexture ? this.clearcoatTexture.getTextureInfo() : null;
+		return this.clearcoatTexture ? this.clearcoatTextureInfo.getChild() : null;
 	}
 
 	/** Sets clearcoat texture. See {@link getClearcoatTexture}. */
 	public setClearcoatTexture(texture: Texture): this {
-		this.clearcoatTexture = this.graph.linkTexture('clearcoatTexture', this, texture);
+		this.clearcoatTexture = this.graph.link('clearcoatTexture', this, texture);
 		return this;
 	}
 
@@ -101,12 +109,12 @@ export class Clearcoat extends ExtensionProperty {
 	 * attached, {@link TextureInfo} is `null`.
 	 */
 	public getClearcoatRoughnessTextureInfo(): TextureInfo {
-		return this.clearcoatRoughnessTexture ? this.clearcoatRoughnessTexture.getTextureInfo() : null;
+		return this.clearcoatRoughnessTexture ? this.clearcoatRoughnessTextureInfo.getChild() : null;
 	}
 
 	/** Sets clearcoat roughness texture. See {@link getClearcoatRoughnessTexture}. */
 	public setClearcoatRoughnessTexture(texture: Texture): this {
-		this.clearcoatRoughnessTexture = this.graph.linkTexture('clearcoatRoughnessTexture', this, texture);
+		this.clearcoatRoughnessTexture = this.graph.link('clearcoatRoughnessTexture', this, texture);
 		return this;
 	}
 
@@ -135,12 +143,12 @@ export class Clearcoat extends ExtensionProperty {
 	 * attached, {@link TextureInfo} is `null`.
 	 */
 	public getClearcoatNormalTextureInfo(): TextureInfo {
-		return this.clearcoatNormalTexture ? this.clearcoatNormalTexture.getTextureInfo() : null;
+		return this.clearcoatNormalTexture ? this.clearcoatNormalTextureInfo.getChild() : null;
 	}
 
 	/** Sets clearcoat normal texture. See {@link getClearcoatNormalTexture}. */
 	public setClearcoatNormalTexture(texture: Texture): this {
-		this.clearcoatNormalTexture = this.graph.linkTexture('clearcoatNormalTexture', this, texture);
+		this.clearcoatNormalTexture = this.graph.link('clearcoatNormalTexture', this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -70,7 +70,7 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getDiffuseTextureInfo(): TextureInfo {
-		return this.diffuseTexture ? this.diffuseTexture.textureInfo : null;
+		return this.diffuseTexture ? this.diffuseTexture.getTextureInfo() : null;
 	}
 
 	/** Sets diffuse texture. See {@link getDiffuseTexture}. */
@@ -119,7 +119,7 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getSpecularGlossinessTextureInfo(): TextureInfo {
-		return this.specularGlossinessTexture ? this.specularGlossinessTexture.textureInfo : null;
+		return this.specularGlossinessTexture ? this.specularGlossinessTexture.getTextureInfo() : null;
 	}
 
 	/** Spec/gloss texture; linear multiplier. */

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -1,4 +1,4 @@
-import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, vec3, vec4 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo, vec3, vec4 } from '@gltf-transform/core';
 import { KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -12,8 +12,13 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	private _specularFactor: vec3 = [1.0, 1.0, 1.0];
 	private _glossinessFactor = 1.0;
 
-	@GraphChild private diffuseTexture: TextureLink = null;
-	@GraphChild private specularGlossinessTexture: TextureLink = null;
+	@GraphChild private diffuseTexture: Link<this, Texture> = null;
+	@GraphChild private diffuseTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('diffuseTextureInfo', this, new TextureInfo(this.graph));
+
+	@GraphChild private specularGlossinessTexture: Link<this, Texture> = null;
+	@GraphChild private specularGlossinessTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('specularGlossinessTextureInfo', this, new TextureInfo(this.graph));
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
@@ -22,14 +27,13 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 		this._specularFactor = other._specularFactor;
 		this._glossinessFactor = other._glossinessFactor;
 
-
 		if (other.diffuseTexture) {
 			this.setDiffuseTexture(resolve(other.diffuseTexture.getChild()));
-			this.diffuseTexture.copy(other.diffuseTexture);
+			this.getDiffuseTextureInfo().copy(resolve(other.diffuseTextureInfo.getChild()));
 		}
 		if (other.specularGlossinessTexture) {
 			this.setSpecularGlossinessTexture(resolve(other.specularGlossinessTexture.getChild()));
-			this.specularGlossinessTexture.copy(other.specularGlossinessTexture);
+			this.getSpecularGlossinessTextureInfo().copy(resolve(other.specularGlossinessTextureInfo.getChild()));
 		}
 
 		return this;
@@ -70,12 +74,12 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getDiffuseTextureInfo(): TextureInfo {
-		return this.diffuseTexture ? this.diffuseTexture.getTextureInfo() : null;
+		return this.diffuseTexture ? this.diffuseTextureInfo.getChild() : null;
 	}
 
 	/** Sets diffuse texture. See {@link getDiffuseTexture}. */
 	public setDiffuseTexture(texture: Texture): this {
-		this.diffuseTexture = this.graph.linkTexture('diffuseTexture', this, texture);
+		this.diffuseTexture = this.graph.link('diffuseTexture', this, texture);
 		return this;
 	}
 
@@ -119,12 +123,12 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getSpecularGlossinessTextureInfo(): TextureInfo {
-		return this.specularGlossinessTexture ? this.specularGlossinessTexture.getTextureInfo() : null;
+		return this.specularGlossinessTexture ? this.specularGlossinessTextureInfo.getChild() : null;
 	}
 
 	/** Spec/gloss texture; linear multiplier. */
 	public setSpecularGlossinessTexture(texture: Texture): this {
-		this.specularGlossinessTexture = this.graph.linkTexture('specularGlossinessTexture', this, texture);
+		this.specularGlossinessTexture = this.graph.link('specularGlossinessTexture', this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -77,7 +77,7 @@ export class Specular extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getSpecularTextureInfo(): TextureInfo {
-		return this.specularTexture ? this.specularTexture.textureInfo : null;
+		return this.specularTexture ? this.specularTexture.getTextureInfo() : null;
 	}
 
 	/** Sets specular texture. See {@link getSpecularTexture}. */

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -1,4 +1,4 @@
-import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink, vec3 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo, vec3 } from '@gltf-transform/core';
 import { KHR_MATERIALS_SPECULAR } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -11,7 +11,9 @@ export class Specular extends ExtensionProperty {
 	private _specularFactor = 1.0;
 	private _specularColorFactor: vec3 = [1.0, 1.0, 1.0];
 
-	@GraphChild private specularTexture: TextureLink = null;
+	@GraphChild private specularTexture: Link<this, Texture> = null;
+	@GraphChild private specularTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('specularTextureInfo', this, new TextureInfo(this.graph));
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
@@ -20,7 +22,7 @@ export class Specular extends ExtensionProperty {
 
 		if (other.specularTexture) {
 			this.setSpecularTexture(resolve(other.specularTexture.getChild()));
-			this.specularTexture.copy(other.specularTexture);
+			this.getSpecularTextureInfo().copy(resolve(other.specularTextureInfo.getChild()));
 		}
 
 		return this;
@@ -77,12 +79,12 @@ export class Specular extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getSpecularTextureInfo(): TextureInfo {
-		return this.specularTexture ? this.specularTexture.getTextureInfo() : null;
+		return this.specularTexture ? this.specularTextureInfo.getChild() : null;
 	}
 
 	/** Sets specular texture. See {@link getSpecularTexture}. */
 	public setSpecularTexture(texture: Texture): this {
-		this.specularTexture = this.graph.linkTexture('specularTexture', this, texture);
+		this.specularTexture = this.graph.link('specularTexture', this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-transmission/transmission.ts
+++ b/packages/extensions/src/khr-materials-transmission/transmission.ts
@@ -53,7 +53,7 @@ export class Transmission extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getTransmissionTextureInfo(): TextureInfo {
-		return this.transmissionTexture ? this.transmissionTexture.textureInfo : null;
+		return this.transmissionTexture ? this.transmissionTexture.getTextureInfo() : null;
 	}
 
 	/** Sets transmission texture. See {@link getTransmissionTexture}. */

--- a/packages/extensions/src/khr-materials-transmission/transmission.ts
+++ b/packages/extensions/src/khr-materials-transmission/transmission.ts
@@ -1,4 +1,4 @@
-import { COPY_IDENTITY, ExtensionProperty, GraphChild, PropertyType, Texture, TextureInfo, TextureLink } from '@gltf-transform/core';
+import { COPY_IDENTITY, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo } from '@gltf-transform/core';
 import { KHR_MATERIALS_TRANSMISSION } from '../constants';
 
 /** Documentation in {@link EXTENSIONS.md}. */
@@ -10,7 +10,9 @@ export class Transmission extends ExtensionProperty {
 
 	private _transmissionFactor = 0.0;
 
-	@GraphChild private transmissionTexture: TextureLink = null;
+	@GraphChild private transmissionTexture: Link<this, Texture> = null;
+	@GraphChild private transmissionTextureInfo: Link<this, TextureInfo> =
+		this.graph.link('transmissionTextureInfo', this, new TextureInfo(this.graph));
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
@@ -19,7 +21,7 @@ export class Transmission extends ExtensionProperty {
 
 		if (other.transmissionTexture) {
 			this.setTransmissionTexture(resolve(other.transmissionTexture.getChild()));
-			this.transmissionTexture.copy(other.transmissionTexture);
+			this.getTransmissionTextureInfo().copy(resolve(other.transmissionTextureInfo.getChild()));
 		}
 
 		return this;
@@ -53,12 +55,12 @@ export class Transmission extends ExtensionProperty {
 	 * {@link TextureInfo} is `null`.
 	 */
 	public getTransmissionTextureInfo(): TextureInfo {
-		return this.transmissionTexture ? this.transmissionTexture.getTextureInfo() : null;
+		return this.transmissionTexture ? this.transmissionTextureInfo.getChild() : null;
 	}
 
 	/** Sets transmission texture. See {@link getTransmissionTexture}. */
 	public setTransmissionTexture(texture: Texture): this {
-		this.transmissionTexture = this.graph.linkTexture('transmissionTexture', this, texture);
+		this.transmissionTexture = this.graph.link('transmissionTexture', this, texture);
 		return this;
 	}
 }


### PR DESCRIPTION
Progress on #39 and #48.

Remaining:

- [x] ~Changing the texture assigned to a material slot will reset the TextureInfo properties... that seems bad?~
- [x] ~Additional tests.~
- [x] ~Check documentation.~
