### PR TITLE
[cli] Resize KTX 2.0 textures when necessary.

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -408,6 +408,14 @@ UASTC for normal maps and ETC1S for other textures, for example.`.trim()),
 		{validator: program.NUMBER}
 	)
 	.option(
+		'--power-of-two',
+		'Resizes any non-power-of-two textures to the closest power-of-two'
+		+ ' dimensions, not exceeding 2048x2048px. Required for '
+		+ ' compatibility on some older devices and APIs, particularly '
+		+ ' WebGL 1.0.',
+		{validator: program.BOOLEAN}
+	)
+	.option(
 		'--rdo-threshold <rdo_threshold>',
 		'Set endpoint and selector RDO quality threshold. Lower'
 		+ ' is higher quality but less quality per output bit (try 1.0-3.0).'
@@ -469,6 +477,14 @@ for textures where the quality is sufficient.`.trim()),
 		+ '\n3     | Slower    | 48.01dB'
 		+ '\n4     | Very slow | 48.24dB',
 		{validator: [0, 1, 2, 3, 4], default: UASTC_DEFAULTS.level}
+	)
+	.option(
+		'--power-of-two',
+		'Resizes any non-power-of-two textures to the closest power-of-two'
+		+ ' dimensions, not exceeding 2048x2048px. Required for '
+		+ ' compatibility on some older devices and APIs, particularly '
+		+ ' WebGL 1.0.',
+		{validator: program.BOOLEAN}
 	)
 	.option(
 		'--rdo-quality <uastc_rdo_q>',

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -1,13 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { spawnSync } = require('child_process');
 const fs = require('fs');
 const minimatch = require('minimatch');
 const tmp = require('tmp');
 
-import { sync as commandExistsSync } from 'command-exists';
-import { BufferUtils, Document, FileUtils, ImageUtils, Texture, Transform } from '@gltf-transform/core';
+import { BufferUtils, Document, FileUtils, ImageUtils, Logger, Texture, Transform, vec2 } from '@gltf-transform/core';
 import { TextureBasisu } from '@gltf-transform/extensions';
-import { formatBytes } from '../util';
+import { commandExistsSync, formatBytes, spawnSync } from '../util';
 
 tmp.setGracefulCleanup();
 
@@ -35,25 +33,48 @@ export const Filter = {
 	QUADRATIC_MIX: 'quadratic_mix',
 };
 
-const GLOBAL_OPTIONS = {
+interface GlobalOptions {
+	mode: string;
+	slots?: string;
+	filter?: string;
+	filterScale?: number;
+	powerOfTwo?: boolean;
+}
+
+export interface ETC1SOptions extends GlobalOptions {
+	quality?: number;
+	compression?: number;
+}
+
+export interface UASTCOptions extends GlobalOptions {
+	level: number;
+	rdoQuality: number;
+	rdoDictSize: number;
+}
+
+const GLOBAL_DEFAULTS = {
 	filter: Filter.LANCZOS4,
 	filterScale: 1,
+	powerOfTwo: false,
+	slots: '*',
 };
 
 export const ETC1S_DEFAULTS = {
 	quality: 128,
 	compression: 1,
-	...GLOBAL_OPTIONS,
+	...GLOBAL_DEFAULTS,
 };
 
 export const UASTC_DEFAULTS = {
 	level: 2,
 	rdoQuality: 1,
 	rdoDictsize: 32768,
-	...GLOBAL_OPTIONS,
+	...GLOBAL_DEFAULTS,
 };
 
-export const toktx = function (options): Transform {
+export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform {
+	options = {...(options.mode === Mode.ETC1S ? ETC1S_DEFAULTS : UASTC_DEFAULTS), ...options};
+
 	return (doc: Document): void =>  {
 		const logger = doc.getLogger();
 
@@ -93,7 +114,11 @@ export const toktx = function (options): Transform {
 				const inBytes = texture.getImage().byteLength;
 				fs.writeFileSync(inPath, Buffer.from(texture.getImage()));
 
-				const params = [...createParams(slots, options), outPath, inPath];
+				const params = [
+					...createParams(slots, texture.getSize(), logger, options),
+					outPath,
+					inPath
+				];
 				logger.debug(`• toktx ${params.join(' ')}`);
 
 				// Run `toktx` CLI tool.
@@ -133,11 +158,11 @@ function getTextureSlots (doc: Document, texture: Texture): string[] {
 }
 
 /** Create CLI parameters from the given options. Attempts to write only non-default options. */
-function createParams (slots: string[], options): string[] {
+function createParams (slots: string[], size: vec2, logger: Logger, options): string[] {
 	const params = [];
 	params.push('--genmipmap');
-	if (options.filter !== GLOBAL_OPTIONS.filter) params.push('--filter', options.filter);
-	if (options.filterScale !== GLOBAL_OPTIONS.filterScale) params.push('--fscale', options.filterScale);
+	if (options.filter !== GLOBAL_DEFAULTS.filter) params.push('--filter', options.filter);
+	if (options.filterScale !== GLOBAL_DEFAULTS.filterScale) params.push('--fscale', options.filterScale);
 
 	if (options.mode === Mode.UASTC) {
 		params.push('--uastc', options.level);
@@ -163,9 +188,65 @@ function createParams (slots: string[], options): string[] {
 		}
 	}
 
-	if (!slots.find((slot) => minimatch(slot, '*{color,emissive}*', {nocase: true}))) {
+	if (slots.length
+			&& !slots.find((slot) => minimatch(slot, '*{color,emissive}*', {nocase: true}))) {
 		params.push('--linear');
 	}
 
+	let width: number;
+	let height: number;
+	if (options.powerOfTwo) {
+		width = preferredPowerOfTwo(size[0], 2048);
+		height = preferredPowerOfTwo(size[1], 2048);
+	} else {
+		if (!isPowerOfTwo(size[0]) || !isPowerOfTwo(size[1])) {
+			logger.warn(
+				`Texture dimensions ${size[0]}x${size[1]} are NPOT, and may`
+				+ ' fail in older APIs (including WebGL 1.0) on certain devices.'
+			);
+		}
+		width = isMultipleOfFour(size[0]) ? size[0] : ceilMultipleOfFour(size[0]);
+		height = isMultipleOfFour(size[1]) ? size[1] : ceilMultipleOfFour(size[1]);
+	}
+
+	if (width !== size[0] || height !== size[1]) {
+		params.push('--resize', `${width}x${height}`);
+	}
+
 	return params;
+}
+
+function isPowerOfTwo (value: number): boolean {
+	if (value <= 2) return true;
+	return (value & (value - 1)) === 0 && value !== 0;
+}
+
+function preferredPowerOfTwo (value: number, max: number): number {
+	if (value <= 2) return value;
+	if (value <= 4) return 4;
+
+	const lo = floorPowerOfTwo(value);
+	const hi = ceilPowerOfTwo(value);
+
+	if (hi > max) return lo;
+	if (hi - value > value - lo) return lo;
+	return hi;
+}
+
+function floorPowerOfTwo (value: number): number {
+	return Math.pow(2, Math.floor(Math.log(value) / Math.LN2));
+}
+
+function ceilPowerOfTwo (value: number): number {
+	return Math.pow(2, Math.ceil(Math.log(value) / Math.LN2));
+}
+
+function isMultipleOfFour (value: number): boolean {
+	return value % 4 === 0;
+}
+
+function ceilMultipleOfFour (value: number): number {
+	if (value <= 2) return value;
+	if (value <= 4) return 4;
+	return value % 4 ? value + 4 - value % 4 : value;
 }

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -1,4 +1,21 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { spawnSync: _spawnSync } = require('child_process');
+
+import { sync as _commandExistsSync } from 'command-exists';
 import { Document, FileUtils, Logger, NodeIO, Transform } from '@gltf-transform/core';
+
+// Mock for tests.
+
+export let spawnSync = _spawnSync;
+export let commandExistsSync = _commandExistsSync;
+
+export function mockSpawnSync (_spawnSync: unknown): void {
+	spawnSync = _spawnSync;
+}
+
+export function mockCommandExistsSync (_commandExistsSync: unknown): void {
+	commandExistsSync = _commandExistsSync;
+}
 
 // Utilities.
 

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -1,0 +1,54 @@
+require('source-map-support').install();
+
+import * as fs from 'fs';
+import * as test from 'tape';
+import { Document, Logger, vec2 } from '@gltf-transform/core';
+import { Mode, mockCommandExistsSync, mockSpawnSync, toktx } from '../';
+
+test('@gltf-transform/cli::toktx | resize', async t => {
+	t.equals(
+		await getParams({mode: Mode.ETC1S}, [508, 508]),
+		'--genmipmap --bcmp',
+		'508x508 → no change'
+	);
+
+	t.equals(
+		await getParams({mode: Mode.ETC1S}, [507, 509]),
+		'--genmipmap --bcmp --resize 508x512',
+		'507x509 → 508x512'
+	);
+
+	t.equals(
+		await getParams({mode: Mode.ETC1S, powerOfTwo: true}, [508, 508]),
+		'--genmipmap --bcmp --resize 512x512',
+		'508x508+powerOfTwo → 512x512'
+	);
+
+	t.equals(
+		await getParams({mode: Mode.ETC1S, powerOfTwo: true}, [5, 3]),
+		'--genmipmap --bcmp --resize 4x4',
+		'5x3+powerOfTwo → 4x4'
+	);
+
+	t.end();
+});
+
+async function getParams(options: object, size: vec2): Promise<string> {
+	const doc = new Document().setLogger(new Logger(Logger.Verbosity.SILENT));
+	const tex = doc.createTexture()
+		.setImage(new ArrayBuffer(10))
+		.setMimeType('image/png');
+	tex.getSize = (): vec2 => size;
+
+	let actualParams: string[];
+	mockSpawnSync((_, params: string[]) => {
+		actualParams = params;
+		fs.writeFileSync(params[params.length - 2], new ArrayBuffer(8));
+		return {status: 0};
+	});
+	mockCommandExistsSync(() => true);
+
+	await doc.transform(toktx(options));
+
+	return actualParams.slice(0, -2).join(' ');
+}


### PR DESCRIPTION
Fixes #144.

Current design is to resize to previous power of two by default, printing a warning. The `--npot` flag gives the option to use a multiple of four texture size instead, which is not supported in WebGL 1.0. Still debating whether to reverse that default.

Remaining:

- [x] Resolve issue with UASTC and `--npot`.
- [x] Resolve https://github.com/BabylonJS/Babylon.js/issues/9503.
- [x] Ensure source dimensions of 1px or 2px are not resized.
