### PR TITLE
Add PNG/JPEG/WebP optimization via Squoosh CLI

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -535,12 +535,10 @@ program
 		'Target Butteraugli distance for auto optimizer.',
 		{validator: program.NUMBER, default: 1.4}
 	)
-	.action(async ({args, options, logger}) => {
-		const doc = await io.read(args.input as string)
-			.setLogger(logger as unknown as Logger)
-			.transform(webp(options as unknown as WebPOptions));
-		io.write(args.output as string, doc);
-	});
+	.action(({args, options, logger}) =>
+		Session.create(io, logger, args.input, args.output)
+			.transform(webp(options as unknown as WebPOptions))
+	);
 
 // OXIPNG
 program
@@ -573,12 +571,10 @@ program
 		'Target Butteraugli distance for auto optimizer.',
 		{validator: program.NUMBER, default: 1.4}
 	)
-	.action(async ({args, options, logger}) => {
-		const doc = await io.read(args.input as string)
-			.setLogger(logger as unknown as Logger)
-			.transform(oxipng(options as unknown as OxiPNGOptions));
-		io.write(args.output as string, doc);
-	});
+	.action(({args, options, logger}) =>
+		Session.create(io, logger, args.input, args.output)
+			.transform(oxipng(options as unknown as OxiPNGOptions))
+	);
 
 // MOZJPEG
 program
@@ -611,12 +607,10 @@ program
 		'Target Butteraugli distance for auto optimizer.',
 		{validator: program.NUMBER, default: 1.4}
 	)
-	.action(async ({args, options, logger}) => {
-		const doc = await io.read(args.input as string)
-			.setLogger(logger as unknown as Logger)
-			.transform(mozjpeg(options as unknown as MozJPEGOptions));
-		io.write(args.output as string, doc);
-	});
+	.action(({args, options, logger}) =>
+		Session.create(io, logger, args.input, args.output)
+			.transform(mozjpeg(options as unknown as MozJPEGOptions))
+	);
 
 program.disableGlobalOption('--quiet');
 program.disableGlobalOption('--no-color');

--- a/packages/cli/src/transforms/index.ts
+++ b/packages/cli/src/transforms/index.ts
@@ -1,4 +1,5 @@
 export * from './draco';
 export * from './merge';
+export * from './squoosh';
 export * from './toktx';
 export * from './unlit';

--- a/packages/cli/src/transforms/squoosh.ts
+++ b/packages/cli/src/transforms/squoosh.ts
@@ -114,6 +114,10 @@ const squoosh = function (options: SquooshOptions): Transform {
 			);
 		}
 
+		if (doc.getRoot().listTextures().length > 1) {
+			logger.info('This may take some time. For more detailed progress, use "--verbose".');
+		}
+
 		let numCompressed = 0;
 
 		doc.getRoot()

--- a/packages/cli/src/transforms/squoosh.ts
+++ b/packages/cli/src/transforms/squoosh.ts
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const minimatch = require('minimatch');
+const tmp = require('tmp');
+
+import { sync as commandExistsSync } from 'command-exists';
+import { BufferUtils, Document, FileUtils, ImageUtils, Transform } from '@gltf-transform/core';
+import { TextureWebP } from '@gltf-transform/extensions';
+import { formatBytes, getTextureSlots } from '../util';
+
+tmp.setGracefulCleanup();
+
+// Configuration: https://github.com/GoogleChromeLabs/squoosh/blob/visdf/cli/src/codecs.js
+
+export interface WebPOptions {
+	rounds: number;
+	distance: number;
+	slots?: string;
+	formats?: string;
+	quality?: number;
+	lossless?: boolean;
+}
+
+export interface MozJPEGOptions {
+	rounds: number;
+	distance: number;
+	slots?: string;
+	formats?: string;
+	quality?: number;
+}
+
+export interface OxiPNGOptions {
+	rounds: number;
+	distance: number;
+	slots?: string;
+	formats?: string;
+	effort?: number;
+}
+
+const DEFAULT_OPTIONS = {rounds: 6, distance: 1.4, slots: '*'};
+const WEBP_DEFAULT_OPTIONS: WebPOptions = {...DEFAULT_OPTIONS};
+const MOZJPEG_DEFAULT_OPTIONS: MozJPEGOptions = {formats: 'jpeg', ...DEFAULT_OPTIONS};
+const OXIPNG_DEFAULT_OPTIONS: OxiPNGOptions = {formats: 'png', ...DEFAULT_OPTIONS};
+
+interface SquooshOptions {
+	slots?: string;
+	formats?: string;
+	flags: string[];
+	outExtension: string;
+	outMimeType: string;
+}
+
+function createDefaultFlags(options: {distance: number; rounds: number}): string[] {
+	return [
+		'--optimizer-butteraugli-target', options.distance + '',
+		'--max-optimizer-rounds', options.rounds + '',
+	];
+}
+
+export const webp = function (options: WebPOptions = WEBP_DEFAULT_OPTIONS): Transform {
+	options = {...WEBP_DEFAULT_OPTIONS, ...options};
+
+	return (doc: Document): void => {
+		doc.createExtension(TextureWebP).setRequired(true);
+		const config = {quality: options.quality, lossless: options.lossless ? 1 : 0};
+		return squoosh({
+			formats: options.formats,
+			slots: options.slots,
+			flags: ['--webp', `"${JSON.stringify(config)}"`, ...createDefaultFlags(options)],
+			outExtension: 'webp',
+			outMimeType: 'image/webp',
+		})(doc);
+	};
+}
+
+export const mozjpeg = function (options: MozJPEGOptions = MOZJPEG_DEFAULT_OPTIONS): Transform {
+	options = {...MOZJPEG_DEFAULT_OPTIONS, ...options};
+	const config = {quality: options.quality};
+	return (doc: Document): void => {
+		return squoosh({
+			formats: options.formats,
+			slots: options.slots,
+			flags: ['--mozjpeg', `"${JSON.stringify(config)}"`, ...createDefaultFlags(options)],
+			outExtension: 'jpg',
+			outMimeType: 'image/jpeg',
+		})(doc);
+	};
+}
+
+export const oxipng = function (options: OxiPNGOptions = OXIPNG_DEFAULT_OPTIONS): Transform {
+	options = {...OXIPNG_DEFAULT_OPTIONS, ...options};
+	const config = {effort: options.effort};
+	return (doc: Document): void => {
+		return squoosh({
+			formats: options.formats,
+			slots: options.slots,
+			flags: ['--oxipng', `"${JSON.stringify(config)}"`, ...createDefaultFlags(options)],
+			outExtension: 'png',
+			outMimeType: 'image/png',
+		})(doc);
+	};
+}
+
+/** Uses Squoosh CLI to compress textures with the specified encoder. */
+const squoosh = function (options: SquooshOptions): Transform {
+	return (doc: Document): void => {
+		const logger = doc.getLogger();
+
+		if (!commandExistsSync('squoosh-cli') && !process.env.CI) {
+			throw new Error(
+				'Command "squoosh-cli" not found. Please install "@squoosh/cli" from NPM.'
+			);
+		}
+
+		let numCompressed = 0;
+
+		doc.getRoot()
+			.listTextures()
+			.forEach((texture, textureIndex) => {
+				const slots = getTextureSlots(doc, texture);
+				const label = texture.getURI()
+					|| texture.getName()
+					|| `${textureIndex + 1}/${doc.getRoot().listTextures().length}`;
+
+				// Filter textures by 'formats' and 'slots' patterns.
+				if (options.formats !== '*'
+						&& texture.getMimeType() !== `image/${options.formats}`) {
+					logger.debug(`• Skipping ${label}, excluded by formats "${options.formats}".`);
+					return;
+				} else if (options.slots !== '*'
+						&& !slots.find((slot) => minimatch(slot, options.slots, {nocase: true}))) {
+					logger.debug(`• Skipping ${label}, excluded by slots "${options.slots}".`);
+					return;
+				}
+
+				// Create temporary in/out paths for the 'squoosh-cli' tool.
+				const inExtension = texture.getURI()
+					? FileUtils.extension(texture.getURI())
+					: ImageUtils.mimeTypeToExtension(texture.getMimeType());
+				const inPath = tmp.tmpNameSync({postfix: '.' + inExtension});
+				const outDir = tmp.dirSync().name;
+				const outPath = options.outExtension
+					? path.join(outDir, path.basename(inPath)
+						.replace('.' + inExtension, '.' + options.outExtension))
+					: path.join(outDir, path.basename(inPath));
+
+				const inBytes = texture.getImage().byteLength;
+				fs.writeFileSync(inPath, Buffer.from(texture.getImage()));
+
+				logger.debug(
+					`• squoosh-cli ${options.flags.join(' ')} --output-dir ${outDir} ${inPath}`
+				);
+
+				// Run `squoosh-cli` CLI tool.
+				const {status, error} = spawnSync(
+					'squoosh-cli',
+					[...options.flags, '--output-dir', outDir, inPath],
+					{stdio: [process.stderr]}
+				);
+
+				if (status !== 0) {
+					logger.error('• Texture compression failed.');
+					throw error || new Error('Texture compression failed');
+				}
+
+				texture
+					.setImage(BufferUtils.trim(fs.readFileSync(outPath)))
+					.setMimeType('image/' + options.outExtension);
+				if (texture.getURI()) {
+					texture.setURI(
+						FileUtils.basename(texture.getURI()) + '.' + options.outExtension
+					);
+				}
+
+				numCompressed++;
+
+				const outBytes = texture.getImage().byteLength;
+				logger.info(
+					`• Texture ${label} (${slots.join(', ')})`
+					+ ` ${formatBytes(inBytes)} → ${formatBytes(outBytes)}.`
+				);
+			});
+
+		if (numCompressed === 0) {
+			logger.warn('No textures were found, or none were selected for compression.');
+		}
+	};
+}

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -61,6 +61,10 @@ export const toktx = function (options): Transform {
 			throw new Error('Command "toktx" not found. Please install KTX-Software, from:\n\nhttps://github.com/KhronosGroup/KTX-Software');
 		}
 
+		if (doc.getRoot().listTextures().length > 1) {
+			logger.info('This may take some time. For more detailed progress, use "--verbose".');
+		}
+
 		doc.createExtension(TextureBasisu).setRequired(true);
 
 		let numCompressed = 0;

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -5,9 +5,9 @@ const minimatch = require('minimatch');
 const tmp = require('tmp');
 
 import { sync as commandExistsSync } from 'command-exists';
-import { BufferUtils, Document, FileUtils, ImageUtils, Texture, Transform } from '@gltf-transform/core';
+import { BufferUtils, Document, FileUtils, ImageUtils, Transform } from '@gltf-transform/core';
 import { TextureBasisu } from '@gltf-transform/extensions';
-import { formatBytes } from '../util';
+import { formatBytes, getTextureSlots } from '../util';
 
 tmp.setGracefulCleanup();
 
@@ -61,7 +61,7 @@ export const toktx = function (options): Transform {
 			throw new Error('Command "toktx" not found. Please install KTX-Software, from:\n\nhttps://github.com/KhronosGroup/KTX-Software');
 		}
 
-		doc.createExtension(TextureBasisu);
+		doc.createExtension(TextureBasisu).setRequired(true);
 
 		let numCompressed = 0;
 
@@ -122,14 +122,6 @@ export const toktx = function (options): Transform {
 			logger.warn('No textures were found, or none were selected for compression.');
 		}
 	};
-}
-
-/** Returns names of all texture slots using the given texture. */
-function getTextureSlots (doc: Document, texture: Texture): string[] {
-	return doc.getGraph().getLinks()
-		.filter((link) => link.getChild() === texture)
-		.map((link) => link.getName())
-		.filter((slot) => slot !== 'texture')
 }
 
 /** Create CLI parameters from the given options. Attempts to write only non-default options. */

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -1,4 +1,4 @@
-import { Document, FileUtils, Logger, NodeIO, Transform } from '@gltf-transform/core';
+import { Document, FileUtils, Logger, NodeIO, Texture, Transform } from '@gltf-transform/core';
 
 // Utilities.
 
@@ -74,4 +74,12 @@ export class Session {
 			);
 		}
 	}
+}
+
+/** Returns names of all texture slots using the given texture. */
+export function getTextureSlots (doc: Document, texture: Texture): string[] {
+	return doc.getGraph().getLinks()
+		.filter((link) => link.getChild() === texture)
+		.map((link) => link.getName())
+		.filter((slot) => slot !== 'texture')
 }


### PR DESCRIPTION
Fixes #12.

Remaining:

- [ ] Documentation
- [ ] Improve defaults, e.g. for normalTexture
- [ ] Unit tests
