### PR TITLE
Add variant transform.

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
 import { Logger, NodeIO, PropertyType } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
-import { AOOptions, CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, ResampleOptions, SequenceOptions, UnweldOptions, WeldOptions, ao, center, dedup, instance, metalRough, partition, prune, resample, sequence, unweld, weld } from '@gltf-transform/lib';
+import { AOOptions, CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, ResampleOptions, SequenceOptions, UnweldOptions, WeldOptions, ao, center, dedup, instance, metalRough, partition, prune, resample, sequence, unweld, variant, weld } from '@gltf-transform/lib';
 import { inspect } from './inspect';
 import { DracoCLIOptions, ETC1S_DEFAULTS, Filter, Mode, UASTC_DEFAULTS, draco, merge, toktx, unlit } from './transforms';
 import { Session, formatBytes } from './util';
@@ -299,6 +299,28 @@ https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)
 			.transform(instance({...options} as InstanceOptions))
+	);
+
+// VARIANT
+program
+	.command('variant', 'TODO')
+	.help(`
+TODO
+
+https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_variants.
+	`.trim())
+	.argument('<path...>', `${INPUT_DESC}(s). Final path is used to write output.`)
+	.action(({args, options, logger}) => {
+		const paths = typeof args.path === 'string'
+			? args.path.split(',')
+			: args.path as string[];
+		const output = paths.pop();
+		return Session.create(io, logger, '', output)
+			.transform(
+				merge({io, paths, partition: !!options.partition}),
+				variant(),
+			);
+	}
 	);
 
 program.command('', '\n\n🕋 GEOMETRY ─────────────────────────────────────────');

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -11,4 +11,5 @@ export * from './prune';
 export * from './resample';
 export * from './sequence';
 export * from './unweld';
+export * from './variant';
 export * from './weld';

--- a/packages/lib/src/variant.ts
+++ b/packages/lib/src/variant.ts
@@ -1,0 +1,92 @@
+import { Document, Mesh, Node, PropertyType, Scene, Transform } from '@gltf-transform/core';
+import { MappingList, MaterialsVariants } from '@gltf-transform/extensions';
+import { dedup } from './dedup';
+import { prune } from './prune';
+
+const NAME = 'variant';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface VariantOptions {}
+
+const DEFAULT_OPTIONS: VariantOptions = {};
+
+/** TODO */
+export function variant (_options: VariantOptions = DEFAULT_OPTIONS): Transform {
+
+	return async (doc: Document): Promise<void> => {
+		const logger = doc.getLogger();
+		const root = doc.getRoot();
+
+		// TODO(bug): It would be very useful if duplicate _extensions_ could be detected. I'm not
+		// sure how to implement that reusably, without adding it to the ExtensionProperty API.
+		// Perhaps a toHashKey() method would be enough.
+		//
+		// As it is, this extension does not attempt to detect reuse of materials or their
+		// extensions. Switching variants will therefore replace _all_ materials, and that's not
+		// exactly ideal.
+		await doc.transform(dedup({propertyTypes: [PropertyType.TEXTURE]}));
+
+		if (root.listScenes().length < 2) {
+			throw new Error(`${NAME}: At least two (2) scenes are required to create variants.`);
+		}
+
+		const variantExtension = doc.createExtension(MaterialsVariants);
+		const scenes = root.listScenes();
+		const dstScene = scenes[0];
+
+		for (let i = 1; i < scenes.length; i++) {
+			logger.debug(`${NAME}: Melding "${scenes[i].getName()}" into base scene.`);
+			meld(variantExtension, scenes[i], dstScene);
+		}
+
+		await doc.transform(prune());
+
+		logger.debug(`${NAME}: Complete.`);
+	};
+
+}
+
+function meld(variantExtension: MaterialsVariants, srcScene: Scene, dstScene: Scene): void {
+	const srcMeshes = listMeshes(srcScene);
+	const dstMeshes = listMeshes(dstScene);
+
+	const variant = variantExtension.createVariant(srcScene.getName());
+
+	if (srcMeshes.length !== dstMeshes.length) {
+		throw new Error(
+			`${NAME}: Mismatch in number of meshes for scenes`
+			+ ` "${srcScene.getName()}" and "${dstScene.getName()}".`
+		);
+	}
+
+	for (let i = 0; i < dstMeshes.length; i++) {
+		const dstPrims = dstMeshes[i].listPrimitives();
+		const srcPrims = srcMeshes[i].listPrimitives();
+
+		for (let j = 0; j < dstPrims.length; j++) {
+			const dstPrim = dstPrims[j];
+			const srcPrim = srcPrims[j];
+
+			const mapping = variantExtension.createMapping()
+				.setMaterial(srcPrim.getMaterial())
+				.addVariant(variant);
+
+			const mappingList = dstPrim.getExtension<MappingList>('KHR_materials_variants')
+				|| variantExtension.createMappingList();
+			mappingList.addMapping(mapping);
+
+			dstPrim.setExtension('KHR_materials_variants', mappingList);
+		}
+	}
+
+	srcScene.dispose();
+}
+
+function listMeshes(scene: Scene): Mesh[] {
+	const meshes = [];
+	scene.traverse((node: Node) => {
+		const mesh = node.getMesh();
+		if (mesh) meshes.push(mesh);
+	});
+	return meshes;
+}


### PR DESCRIPTION
Fixes #64.

As it is, this extension does not attempt to detect reuse of materials or their
extensions. Switching variants will therefore replace _all_ materials, and that's not
exactly ideal. That is harder to fix, though, and requires detecting duplicate materials.
This could be accomplished by extending `dedup`, or implementing a general `equals`
or `hashKey` function. Extensions, in particular, complicate that.

Remaining:

- [ ] Improve variant naming logic
- [ ] Documentation
- [ ] Unit tests