### PR TITLE
[core] - test for node output including optional identity values

### DIFF
--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -4,7 +4,7 @@ import { Link } from '../graph';
 import { JSONDocument } from '../json-document';
 import { Accessor, AnimationSampler, AttributeLink, Camera, IndexLink, Material, Property } from '../properties';
 import { GLTF } from '../types/gltf';
-import { BufferUtils, Logger } from '../utils';
+import { BufferUtils, Logger, MathUtils } from '../utils';
 import { UniqueURIGenerator, WriterContext } from './writer-context';
 
 const BufferViewTarget = {
@@ -556,9 +556,18 @@ export class GLTFWriter {
 
 		json.nodes = root.listNodes().map((node, index) => {
 			const nodeDef = context.createPropertyDef(node) as GLTF.INode;
-			nodeDef.translation = node.getTranslation();
-			nodeDef.rotation = node.getRotation();
-			nodeDef.scale = node.getScale();
+
+			if (!MathUtils.eq(node.getTranslation(), [0, 0, 0])) {
+				nodeDef.translation = node.getTranslation();
+			}
+			
+			if (!MathUtils.eq(node.getRotation(), [0, 0, 0, 1])) {
+				nodeDef.rotation = node.getRotation();
+			}
+
+			if (!MathUtils.eq(node.getScale(), [1, 1, 1])) {
+				nodeDef.scale = node.getScale();
+			}
 
 			if (node.getWeights().length) {
 				nodeDef.weights = node.getWeights();

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -101,3 +101,37 @@ test('@gltf-transform/core::node | extras', t => {
 
 	t.end();
 });
+
+test('@gltf-transform/core::node | identity transforms', t => {
+	const io = new NodeIO();
+	const doc = new Document();
+
+	doc.createNode('A');
+	doc.createNode('B').setTranslation([1, 2, 1]);
+	doc.createNode('C').setTranslation([1, 2, 1]).setRotation([1, 0, 0, 0]).setScale([1, 2, 1]);
+
+	const writerOptions = {isGLB: false, basename: 'test'};
+	const { nodes } = io.writeJSON(doc, writerOptions).json;
+
+	const a = nodes.find((n) => n.name === 'A');
+	const b = nodes.find((n) => n.name === 'B');
+	const c = nodes.find((n) => n.name === 'C');
+
+	t.deepEqual(a, {
+		name: 'a',
+	}, 'exclude identity transforms');
+
+	t.deepEqual(b, {
+		name: 'B',
+		translation: [1, 2, 1],
+	}, 'has only set transform info');
+
+	t.deepEqual(c, {
+		name: 'C',
+		translation: [1, 2, 1],
+		rotation: [1, 0, 0, 0],
+		scale: [1, 2, 1],
+	}, 'has transform info');
+
+	t.end();
+});

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -117,8 +117,10 @@ test('@gltf-transform/core::node | identity transforms', t => {
 	const b = nodes.find((n) => n.name === 'B');
 	const c = nodes.find((n) => n.name === 'C');
 
+	console.warn(b);
+
 	t.deepEqual(a, {
-		name: 'a',
+		name: 'A',
 	}, 'exclude identity transforms');
 
 	t.deepEqual(b, {

--- a/packages/core/test/properties/skin.test.ts
+++ b/packages/core/test/properties/skin.test.ts
@@ -65,9 +65,6 @@ test('@gltf-transform/core::skin', t => {
 		name: 'armature',
 		skin: 0,
 		children: [0, 1, 2],
-		translation: [0, 0, 0],
-		rotation: [0, 0, 0, 1],
-		scale: [1, 1, 1],
 	}, 'attaches skin to node');
 
 	t.deepEqual(jsonDoc.json.skins[0], {


### PR DESCRIPTION
Adds a failing test to go along with question from #191

I can fill in a 'fix' if you have a preference about where to address the issue (Still getting bearings in the project while testing it out)