### PR TITLE
[core][cli] Add vertex layout options.

### DIFF
--- a/docs/CLI_HELP.md
+++ b/docs/CLI_HELP.md
@@ -1,5 +1,5 @@
 
-  gltf-transform 0.9.4 — Commandline interface for the glTF-Transform SDK.
+  gltf-transform 0.9.5-alpha.0 — Commandline interface for the glTF-Transform SDK.
 
   USAGE 
   
@@ -56,4 +56,6 @@
     -h, --help                           Display global help or command-related help.           
     -V, --version                        Display version.                                       
     -v, --verbose                        Verbose mode: will also output debug messages.         
+    -vl, --vertex-layout <layout>        Vertex layout method                                   
+                                         one of "interleaved","separate", default: "interleaved"
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.9.4",
+  "version": "0.9.5-alpha.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "packages": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gltf-transform/cli",
-  "version": "0.9.4",
+  "version": "0.9.5-alpha.0",
   "repository": "github:donmccurdy/glTF-Transform",
   "description": "CLI interface to glTF Transform",
   "main": "dist/cli.js",
@@ -21,9 +21,9 @@
   "homepage": "https://github.com/donmccurdy/glTF-Transform#readme",
   "dependencies": {
     "@caporal/core": "^2.0.2",
-    "@gltf-transform/core": "^0.9.4",
-    "@gltf-transform/extensions": "^0.9.4",
-    "@gltf-transform/lib": "^0.9.4",
+    "@gltf-transform/core": "^0.9.5-alpha.0",
+    "@gltf-transform/extensions": "^0.9.5-alpha.0",
+    "@gltf-transform/lib": "^0.9.5-alpha.0",
     "@types/node": "^14.14.25",
     "cli-table3": "^0.6.0",
     "command-exists": "^1.2.9",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import minimatch from 'minimatch';
 import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
-import { Logger, NodeIO, PropertyType } from '@gltf-transform/core';
+import { Logger, NodeIO, PropertyType, VertexLayout } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
 import { AOOptions, CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, ResampleOptions, SequenceOptions, UnweldOptions, WeldOptions, ao, center, dedup, instance, metalRough, partition, prune, resample, sequence, tangents, unweld, weld } from '@gltf-transform/lib';
 import { InspectFormat, inspect } from './inspect';
@@ -781,6 +781,14 @@ so this workflow is not a replacement for video playback.
 			.transform(sequence({...options, pattern} as SequenceOptions));
 	});
 
+program.option('-vl, --vertex-layout <layout>', 'Vertex layout method', {
+	global: true,
+	default: VertexLayout.INTERLEAVED,
+	validator: [VertexLayout.INTERLEAVED, VertexLayout.SEPARATE],
+	action: ({options}) => {
+		io.setVertexLayout(options.vertexLayout as VertexLayout);
+	},
+});
 program.disableGlobalOption('--quiet');
 program.disableGlobalOption('--no-color');
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gltf-transform/core",
-  "version": "0.9.4",
+  "version": "0.9.5-alpha.0",
   "repository": "github:donmccurdy/glTF-Transform",
   "description": "glTF 2.0 SDK for JavaScript, TypeScript, and Node.js",
   "main": "dist/core.js",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -97,3 +97,9 @@ export enum PropertyType {
 	TEXTURE = 'Texture',
 	TEXTURE_INFO = 'TextureInfo',
 }
+
+/** Vertex layout method. */
+export enum VertexLayout {
+	INTERLEAVED = 'interleaved',
+	SEPARATE = 'separate',
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -7,7 +7,7 @@ export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera
 export { Graph, GraphChild, GraphChildList, Link } from './graph/';
 export { NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
 export { BufferUtils, ColorUtils, FileUtils, ImageUtils, ImageUtilsFormat, MathUtils, Logger, uuid } from './utils/';
-export { TypedArray, TypedArrayConstructor, PropertyType, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';
+export { TypedArray, TypedArrayConstructor, PropertyType, VertexLayout, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';
 export { GLTF } from './types/gltf';
 
 /** [[include:CONCEPTS.md]] */

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -138,6 +138,7 @@ export class NodeIO extends PlatformIO {
 			isGLB: false,
 			logger: this._logger,
 			dependencies: this._dependencies,
+			vertexLayout: this._vertexLayout,
 		});
 		const {_fs: fs, _path: path} = this;
 		const dir = path.dirname(uri);

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -1,4 +1,4 @@
-import { GLB_BUFFER } from '../constants';
+import { GLB_BUFFER, VertexLayout } from '../constants';
 import { Document } from '../document';
 import { Extension } from '../extension';
 import { JSONDocument } from '../json-document';
@@ -25,6 +25,7 @@ export abstract class PlatformIO {
 	protected _logger = Logger.DEFAULT_INSTANCE;
 	protected _extensions: typeof Extension[] = [];
 	protected _dependencies: {[key: string]: unknown} = {};
+	protected _vertexLayout = VertexLayout.INTERLEAVED;
 
 	/** Sets the {@link Logger} used by this I/O instance. Defaults to Logger.DEFAULT_INSTANCE. */
 	public setLogger(logger: Logger): this {
@@ -47,6 +48,11 @@ export abstract class PlatformIO {
 		return this;
 	}
 
+	public setVertexLayout(layout: VertexLayout): this {
+		this._vertexLayout = layout;
+		return this;
+	}
+
 	/**********************************************************************************************
 	 * JSON.
 	 */
@@ -65,6 +71,7 @@ export abstract class PlatformIO {
 		if (options.isGLB && doc.getRoot().listBuffers().length !== 1) {
 			throw new Error('GLB must have exactly 1 buffer.');
 		}
+		options.vertexLayout = this._vertexLayout;
 		options.dependencies = {...this._dependencies, ...options.dependencies};
 		return GLTFWriter.write(doc, options);
 	}
@@ -136,6 +143,7 @@ export abstract class PlatformIO {
 			isGLB: true,
 			logger: this._logger,
 			dependencies: this._dependencies,
+			vertexLayout: this._vertexLayout,
 		});
 
 		const jsonText = JSON.stringify(json);

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -1,4 +1,4 @@
-import { GLB_BUFFER, NAME, PropertyType, VERSION } from '../constants';
+import { GLB_BUFFER, NAME, PropertyType, VERSION, VertexLayout } from '../constants';
 import { Document } from '../document';
 import { Link } from '../graph';
 import { JSONDocument } from '../json-document';
@@ -23,6 +23,7 @@ export interface WriterOptions {
 	logger?: Logger;
 	basename?: string;
 	isGLB?: boolean;
+	vertexLayout?: VertexLayout,
 	dependencies?: {[key: string]: unknown};
 }
 
@@ -30,6 +31,7 @@ const DEFAULT_OPTIONS: WriterOptions = {
 	logger: Logger.DEFAULT_INSTANCE,
 	basename: '',
 	isGLB: true,
+	vertexLayout: VertexLayout.INTERLEAVED,
 	dependencies: {},
 };
 
@@ -311,19 +313,34 @@ export class GLTFWriter {
 			for (const usage in usageGroups) {
 				if (groupByParent.has(usage)) {
 					// Accessors grouped by (first) parent, including vertex and instance
-					// attributes. Instanced data is not interleaved, see:
-					// https://github.com/KhronosGroup/glTF/pull/1888
+					// attributes.
 					for (const parentAccessors of Array.from(accessorParents.values())) {
 						const accessors = Array.from(parentAccessors)
 							.filter((a) => bufferAccessorsSet.has(a))
 							.filter((a) => context.getAccessorUsage(a) === usage);
 						if (!accessors.length) continue;
 
-						const result = usage === BufferViewUsage.ARRAY_BUFFER
-							? interleaveAccessors(accessors, bufferIndex, bufferByteLength)
-							: concatAccessors(accessors, bufferIndex, bufferByteLength);
-						bufferByteLength += result.byteLength;
-						buffers.push(...result.buffers);
+						if (usage !== BufferViewUsage.ARRAY_BUFFER
+								|| options.vertexLayout === VertexLayout.INTERLEAVED) {
+							// Instanced data is not interleaved, see:
+							// https://github.com/KhronosGroup/glTF/pull/1888
+							const result = usage === BufferViewUsage.ARRAY_BUFFER
+								? interleaveAccessors(accessors, bufferIndex, bufferByteLength)
+								: concatAccessors(accessors, bufferIndex, bufferByteLength);
+							bufferByteLength += result.byteLength;
+							buffers.push(...result.buffers);
+						} else {
+							for (const accessor of accessors) {
+								const result = concatAccessors(
+									[accessor],
+									bufferIndex,
+									bufferByteLength,
+									BufferViewTarget.ARRAY_BUFFER
+								);
+								bufferByteLength += result.byteLength;
+								buffers.push(...result.buffers);
+							}
+						}
 					}
 				} else {
 					// Accessors concatenated end-to-end, including indices, IBMs, and other data.
@@ -560,7 +577,7 @@ export class GLTFWriter {
 			if (!MathUtils.eq(node.getTranslation(), [0, 0, 0])) {
 				nodeDef.translation = node.getTranslation();
 			}
-			
+
 			if (!MathUtils.eq(node.getRotation(), [0, 0, 0, 1])) {
 				nodeDef.rotation = node.getRotation();
 			}

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gltf-transform/extensions",
-  "version": "0.9.4",
+  "version": "0.9.5-alpha.0",
   "repository": "github:donmccurdy/glTF-Transform",
   "description": "Adds extension support to @gltf-transform/core",
   "main": "dist/extensions.js",
@@ -21,7 +21,7 @@
   "author": "Don McCurdy <dm@donmccurdy.com>",
   "license": "MIT",
   "dependencies": {
-    "@gltf-transform/core": "^0.9.4",
+    "@gltf-transform/core": "^0.9.5-alpha.0",
     "ktx-parse": "^0.0.5"
   },
   "files": [

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gltf-transform/lib",
-  "version": "0.9.4",
+  "version": "0.9.5-alpha.0",
   "repository": "github:donmccurdy/glTF-Transform",
   "description": "Library of functions built on the core glTF-Transform API",
   "main": "dist/lib.js",
@@ -21,8 +21,8 @@
   "author": "Don McCurdy <dm@donmccurdy.com>",
   "license": "MIT",
   "dependencies": {
-    "@gltf-transform/core": "^0.9.4",
-    "@gltf-transform/extensions": "^0.9.4",
+    "@gltf-transform/core": "^0.9.5-alpha.0",
+    "@gltf-transform/extensions": "^0.9.5-alpha.0",
     "@types/ndarray": "^1.0.8",
     "geo-ambient-occlusion": "^3.0.2",
     "get-pixels": "^3.3.2",


### PR DESCRIPTION
Allows selection of interleaved or separate vertex buffer views. Default is interleaved.

Usage:

```
gltf-transform cp --vertex-layout separate input.glb output.glb
```

```js
import {NodeIO, VertexLayout} from '@gltf-transform/core';
const io = new NodeIO();
io.setVertexLayout(VertexLayout.SEPARATE);
io.write('path.glb', doc);
```

Remaining:

- [x] Unit tests.