### PR TITLE
[core] Track channel usage for textures

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -112,3 +112,11 @@ export enum VertexLayout {
 	 */
 	SEPARATE = 'separate',
 }
+
+/** Texture channels. */
+export enum TextureChannel {
+	R = 0x1000,
+	G = 0x0100,
+	B = 0x0010,
+	A = 0x0001,
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -3,11 +3,11 @@
 export { Document, Transform } from './document';
 export { JSONDocument } from './json-document';
 export { Extension } from './extension';
-export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, AttributeLink, IndexLink, COPY_IDENTITY } from './properties';
+export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, TextureLink, AttributeLink, IndexLink, COPY_IDENTITY } from './properties';
 export { Graph, GraphChild, GraphChildList, Link } from './graph/';
 export { NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
 export { BufferUtils, ColorUtils, FileUtils, ImageUtils, ImageUtilsFormat, Logger, MathUtils, uuid } from './utils/';
-export { TypedArray, TypedArrayConstructor, PropertyType, VertexLayout, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';
+export { TypedArray, TypedArrayConstructor, PropertyType, TextureChannel, VertexLayout, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';
 export { GLTF } from './types/gltf';
 
 /** [[include:CONCEPTS.md]] */

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -28,18 +28,29 @@ export class Graph<T extends GraphNode> {
 		return this;
 	}
 
+	/** Returns a list of all parent->child links on this graph. */
 	public getLinks(): Link<T, T>[] {
 		return Array.from(this._links);
 	}
 
-	public listParents(node: T): T[] {
-		const links = this._childRefs.get(node) || this._emptySet;
-		return Array.from(links).map((link) => link.getParent());
+	/** Returns a list of all links on the graph having the given node as their child. */
+	public listParentLinks(node: T): Link<T, T>[] {
+		return Array.from(this._childRefs.get(node) || this._emptySet);
 	}
 
+	/** Returns a list of parent nodes for the given child node. */
+	public listParents(node: T): T[] {
+		return this.listParentLinks(node).map((link) => link.getParent());
+	}
+
+	/** Returns a list of all links on the graph having the given node as their parent. */
+	public listChildLinks(node: T): Link<T, T>[] {
+		return Array.from(this._parentRefs.get(node) || this._emptySet);
+	}
+
+	/** Returns a list of child nodes for the given parent node. */
 	public listChildren(node: T): T[] {
-		const links = this._parentRefs.get(node) || this._emptySet;
-		return Array.from(links).map((link) => link.getChild());
+		return this.listChildLinks(node).map((link) => link.getChild());
 	}
 
 	public disconnectChildren(node: T): this {

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -1,11 +1,14 @@
-import { PropertyType, vec3, vec4 } from '../constants';
+import { PropertyType, TextureChannel, vec3, vec4 } from '../constants';
 import { GraphChild, Link } from '../graph/index';
 import { GLTF } from '../types/gltf';
 import { ColorUtils } from '../utils';
 import { ExtensibleProperty } from './extensible-property';
 import { COPY_IDENTITY } from './property';
+import { TextureLink } from './property-links';
 import { Texture } from './texture';
 import { TextureInfo } from './texture-info';
+
+const { R, G, B, A } = TextureChannel;
 
 /**
  * # Material
@@ -78,12 +81,12 @@ export class Material extends ExtensibleProperty {
 	private _metallicFactor = 1;
 
 	/** @hidden Base color / albedo texture. */
-	@GraphChild private baseColorTexture: Link<this, Texture> | null = null;
+	@GraphChild private baseColorTexture: TextureLink | null = null;
 	@GraphChild private baseColorTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('baseColorTextureInfo', this, new TextureInfo(this.graph));
 
 	/** @hidden Emissive texture. */
-	@GraphChild private emissiveTexture: Link<this, Texture> | null = null;
+	@GraphChild private emissiveTexture: TextureLink | null = null;
 	@GraphChild private emissiveTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('emissiveTextureInfo', this, new TextureInfo(this.graph));
 
@@ -92,7 +95,7 @@ export class Material extends ExtensibleProperty {
 	 * so PNG files are preferred.
 	 * @hidden
 	 */
-	@GraphChild private normalTexture: Link<this, Texture> | null = null;
+	@GraphChild private normalTexture: TextureLink | null = null;
 	@GraphChild private normalTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('normalTextureInfo', this, new TextureInfo(this.graph));
 
@@ -101,7 +104,7 @@ export class Material extends ExtensibleProperty {
 	 * texture to be packed with `metallicRoughnessTexture`, optionally.
 	 * @hidden
 	 */
-	@GraphChild private occlusionTexture: Link<this, Texture> | null = null;
+	@GraphChild private occlusionTexture: TextureLink | null = null;
 	@GraphChild private occlusionTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('occlusionTextureInfo', this, new TextureInfo(this.graph));
 
@@ -111,7 +114,7 @@ export class Material extends ExtensibleProperty {
 	 * `occlusionTexture`, optionally.
 	 * @hidden
 	*/
-	@GraphChild private metallicRoughnessTexture: Link<this, Texture> | null = null;
+	@GraphChild private metallicRoughnessTexture: TextureLink | null = null;
 	@GraphChild private metallicRoughnessTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('metallicRoughnessTextureInfo', this, new TextureInfo(this.graph));
 
@@ -307,7 +310,8 @@ export class Material extends ExtensibleProperty {
 
 	/** Sets base color / albedo texture. See {@link getBaseColorTexture}. */
 	public setBaseColorTexture(texture: Texture | null): this {
-		this.baseColorTexture = this.graph.link('baseColorTexture', this, texture);
+		this.baseColorTexture =
+			this.graph.linkTexture('baseColorTexture', R | G | B | A, this, texture);
 		return this;
 	}
 
@@ -364,7 +368,7 @@ export class Material extends ExtensibleProperty {
 
 	/** Sets emissive texture. See {@link getEmissiveTexture}. */
 	public setEmissiveTexture(texture: Texture | null): this {
-		this.emissiveTexture = this.graph.link('emissiveTexture', this, texture);
+		this.emissiveTexture = this.graph.linkTexture('emissiveTexture', R | G | B, this, texture);
 		return this;
 	}
 
@@ -407,7 +411,7 @@ export class Material extends ExtensibleProperty {
 
 	/** Sets normal (surface detail) texture. See {@link getNormalTexture}. */
 	public setNormalTexture(texture: Texture | null): this {
-		this.normalTexture = this.graph.link('normalTexture', this, texture);
+		this.normalTexture = this.graph.linkTexture('normalTexture', R | G | B, this, texture);
 		return this;
 	}
 
@@ -450,7 +454,7 @@ export class Material extends ExtensibleProperty {
 
 	/** Sets (ambient) occlusion texture. See {@link getOcclusionTexture}. */
 	public setOcclusionTexture(texture: Texture | null): this {
-		this.occlusionTexture = this.graph.link('occlusionTexture', this, texture);
+		this.occlusionTexture = this.graph.linkTexture('occlusionTexture', R, this, texture);
 		return this;
 	}
 
@@ -511,7 +515,8 @@ export class Material extends ExtensibleProperty {
 
 	/** Sets metallic/roughness texture. See {@link getMetallicRoughnessTexture}. */
 	public setMetallicRoughnessTexture(texture: Texture | null): this {
-		this.metallicRoughnessTexture = this.graph.link('metallicRoughnessTexture', this, texture);
+		this.metallicRoughnessTexture =
+			this.graph.linkTexture('metallicRoughnessTexture', G | B, this, texture);
 		return this;
 	}
 }

--- a/packages/core/src/properties/primitive.ts
+++ b/packages/core/src/properties/primitive.ts
@@ -140,8 +140,7 @@ export class Primitive extends ExtensibleProperty {
 		if (!accessor) return this;
 
 		// Add next attribute.
-		const link = this.graph.linkAttribute(semantic.toLowerCase(), this, accessor);
-		link.semantic = semantic;
+		const link = this.graph.linkAttribute(semantic, this, accessor);
 		return this.addGraphChild(this.attributes, link);
 	}
 

--- a/packages/core/src/properties/property-graph.ts
+++ b/packages/core/src/properties/property-graph.ts
@@ -1,8 +1,11 @@
 import { Graph } from '../graph';
 import { Accessor } from './accessor';
+import { ExtensionProperty } from './extension-property';
+import { Material } from './material';
 import { Primitive } from './primitive';
 import { Property } from './property';
-import { AttributeLink, IndexLink } from './property-links';
+import { AttributeLink, IndexLink, TextureLink } from './property-links';
+import { Texture } from './texture';
 
 /** @hidden */
 export class PropertyGraph extends Graph<Property> {
@@ -12,6 +15,7 @@ export class PropertyGraph extends Graph<Property> {
 	public linkAttribute(name: string, a: Property, b: Accessor | null): AttributeLink | null {
 		if (!b) return null;
 		const link = new AttributeLink(name, a, b);
+		link.semantic = name;
 		this.registerLink(link);
 		return link;
 	}
@@ -22,6 +26,17 @@ export class PropertyGraph extends Graph<Property> {
 	public linkIndex(name: string, a: Primitive, b: Accessor | null): IndexLink | null {
 		if (!b) return null;
 		const link = new IndexLink(name, a, b);
+		this.registerLink(link);
+		return link;
+	}
+
+	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: null): null;
+	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: Texture): TextureLink;
+	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: Texture | null): TextureLink | null;
+	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: Texture | null): TextureLink | null {
+		if (!b) return null;
+		const link = new TextureLink(name, a, b);
+		link.channels = channels;
 		this.registerLink(link);
 		return link;
 	}

--- a/packages/core/src/properties/property-graph.ts
+++ b/packages/core/src/properties/property-graph.ts
@@ -30,10 +30,18 @@ export class PropertyGraph extends Graph<Property> {
 		return link;
 	}
 
-	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: null): null;
-	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: Texture): TextureLink;
-	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: Texture | null): TextureLink | null;
-	public linkTexture(name: string, channels: number, a: Material | ExtensionProperty, b: Texture | null): TextureLink | null {
+	public linkTexture(
+		name: string, channels: number, a: Material | ExtensionProperty, b: null
+	): null;
+	public linkTexture(
+		name: string, channels: number, a: Material | ExtensionProperty, b: Texture
+	): TextureLink;
+	public linkTexture(
+		name: string, channels: number, a: Material | ExtensionProperty, b: Texture | null
+	): TextureLink | null;
+	public linkTexture(
+		name: string, channels: number, a: Material | ExtensionProperty, b: Texture | null
+	): TextureLink | null {
 		if (!b) return null;
 		const link = new TextureLink(name, a, b);
 		link.channels = channels;

--- a/packages/core/src/properties/property-links.ts
+++ b/packages/core/src/properties/property-links.ts
@@ -1,7 +1,10 @@
 import { Link } from '../graph';
 import { Accessor } from './accessor';
+import { ExtensionProperty } from './extension-property';
+import { Material } from './material';
 import { Primitive } from './primitive';
 import { Property } from './property';
+import { Texture } from './texture';
 
 /** @hidden */
 export class AttributeLink extends Link<Property, Accessor> {
@@ -15,4 +18,12 @@ export class AttributeLink extends Link<Property, Accessor> {
 /** @hidden */
 export class IndexLink extends Link<Primitive, Accessor> {
 	public copy (_other: this): this { return this; }
+}
+
+export class TextureLink extends Link<Material | ExtensionProperty, Texture> {
+	public channels = 0;
+	public copy (other: this): this {
+		this.channels = other.channels;
+		return this;
+	}
 }

--- a/packages/core/test/graph/graph.test.ts
+++ b/packages/core/test/graph/graph.test.ts
@@ -84,3 +84,28 @@ test('@gltf-transform/core::graph | prevents cross-graph linking', t => {
 	t.throws(() => rootA.addNode(nodeB), 'prevents linking node from another graph, unused');
 	t.end();
 });
+
+test('@gltf-transform/core::graph | list connections', t => {
+	const graph = new Graph();
+	const root = new TestNode(graph);
+	const node1 = new TestNode(graph);
+	const node2 = new TestNode(graph);
+
+	node1.addNode(node2);
+	root.addNode(node1);
+
+	t.equal(graph.getLinks().length, 2, 'getLinks()');
+	t.deepEqual(
+		graph.listParentLinks(node1).map(link => link.getParent()), [root], 'listParentLinks(A)'
+	);
+	t.deepEqual(
+		graph.listChildLinks(node1).map(link => link.getChild()), [node2], 'listChildLinks(A)'
+	);
+	t.deepEqual(
+		graph.listParentLinks(node2).map(link => link.getParent()), [node1], 'listParentLinks(B)'
+	);
+	t.deepEqual(
+		graph.listChildLinks(node2).map(link => link.getChild()), [], 'listParentLinks(B)'
+	);
+	t.end();
+});

--- a/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
@@ -1,5 +1,7 @@
-import { COPY_IDENTITY, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo } from '@gltf-transform/core';
+import { COPY_IDENTITY, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureChannel, TextureInfo, TextureLink } from '@gltf-transform/core';
 import { KHR_MATERIALS_CLEARCOAT } from '../constants';
+
+const { R, G, B } = TextureChannel;
 
 /** Documentation in {@link EXTENSIONS.md}. */
 export class Clearcoat extends ExtensionProperty {
@@ -12,15 +14,15 @@ export class Clearcoat extends ExtensionProperty {
 	private _clearcoatRoughnessFactor = 0.0;
 	private _clearcoatNormalScale = 1.0;
 
-	@GraphChild private clearcoatTexture: Link<this, Texture> | null = null;
+	@GraphChild private clearcoatTexture: TextureLink | null = null;
 	@GraphChild private clearcoatTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('clearcoatTextureInfo', this, new TextureInfo(this.graph));
 
-	@GraphChild private clearcoatRoughnessTexture: Link<this, Texture> | null = null;
+	@GraphChild private clearcoatRoughnessTexture: TextureLink | null = null;
 	@GraphChild private clearcoatRoughnessTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('clearcoatRoughnessTextureInfo', this, new TextureInfo(this.graph));
 
-	@GraphChild private clearcoatNormalTexture: Link<this, Texture> | null = null;
+	@GraphChild private clearcoatNormalTexture: TextureLink | null = null;
 	@GraphChild private clearcoatNormalTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('clearcoatNormalTextureInfo', this, new TextureInfo(this.graph));
 
@@ -89,7 +91,7 @@ export class Clearcoat extends ExtensionProperty {
 
 	/** Sets clearcoat texture. See {@link getClearcoatTexture}. */
 	public setClearcoatTexture(texture: Texture | null): this {
-		this.clearcoatTexture = this.graph.link('clearcoatTexture', this, texture);
+		this.clearcoatTexture = this.graph.linkTexture('clearcoatTexture', R, this, texture);
 		return this;
 	}
 
@@ -127,7 +129,7 @@ export class Clearcoat extends ExtensionProperty {
 	/** Sets clearcoat roughness texture. See {@link getClearcoatRoughnessTexture}. */
 	public setClearcoatRoughnessTexture(texture: Texture | null): this {
 		this.clearcoatRoughnessTexture
-			= this.graph.link('clearcoatRoughnessTexture', this, texture);
+			= this.graph.linkTexture('clearcoatRoughnessTexture', G, this, texture);
 		return this;
 	}
 
@@ -161,7 +163,8 @@ export class Clearcoat extends ExtensionProperty {
 
 	/** Sets clearcoat normal texture. See {@link getClearcoatNormalTexture}. */
 	public setClearcoatNormalTexture(texture: Texture | null): this {
-		this.clearcoatNormalTexture = this.graph.link('clearcoatNormalTexture', this, texture);
+		this.clearcoatNormalTexture =
+			this.graph.linkTexture('clearcoatNormalTexture', R | G | B, this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -1,5 +1,7 @@
-import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo, vec3, vec4 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureChannel, TextureInfo, TextureLink, vec3, vec4 } from '@gltf-transform/core';
 import { KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS } from '../constants';
+
+const { R, G, B, A } = TextureChannel;
 
 /** Documentation in {@link EXTENSIONS.md}. */
 export class PBRSpecularGlossiness extends ExtensionProperty {
@@ -12,11 +14,11 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	private _specularFactor: vec3 = [1.0, 1.0, 1.0];
 	private _glossinessFactor = 1.0;
 
-	@GraphChild private diffuseTexture: Link<this, Texture> | null = null;
+	@GraphChild private diffuseTexture: TextureLink | null = null;
 	@GraphChild private diffuseTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('diffuseTextureInfo', this, new TextureInfo(this.graph));
 
-	@GraphChild private specularGlossinessTexture: Link<this, Texture> | null = null;
+	@GraphChild private specularGlossinessTexture: TextureLink | null = null;
 	@GraphChild private specularGlossinessTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('specularGlossinessTextureInfo', this, new TextureInfo(this.graph));
 
@@ -87,7 +89,8 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 
 	/** Sets diffuse texture. See {@link getDiffuseTexture}. */
 	public setDiffuseTexture(texture: Texture | null): this {
-		this.diffuseTexture = this.graph.link('diffuseTexture', this, texture);
+		this.diffuseTexture =
+			this.graph.linkTexture('diffuseTexture', R | G | B | A, this, texture);
 		return this;
 	}
 
@@ -139,7 +142,7 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	/** Spec/gloss texture; linear multiplier. */
 	public setSpecularGlossinessTexture(texture: Texture | null): this {
 		this.specularGlossinessTexture
-			= this.graph.link('specularGlossinessTexture', this, texture);
+			= this.graph.linkTexture('specularGlossinessTexture', R | G | B, this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -142,7 +142,7 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 	/** Spec/gloss texture; linear multiplier. */
 	public setSpecularGlossinessTexture(texture: Texture | null): this {
 		this.specularGlossinessTexture
-			= this.graph.linkTexture('specularGlossinessTexture', R | G | B, this, texture);
+			= this.graph.linkTexture('specularGlossinessTexture', R | G | B | A, this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-sheen/sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/sheen.ts
@@ -1,5 +1,7 @@
-import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo, vec3 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureChannel, TextureInfo, TextureLink, vec3 } from '@gltf-transform/core';
 import { KHR_MATERIALS_SHEEN } from '../constants';
+
+const { R, G, B, A } = TextureChannel;
 
 /** Documentation in {@link EXTENSIONS.md}. */
 export class Sheen extends ExtensionProperty {
@@ -11,11 +13,11 @@ export class Sheen extends ExtensionProperty {
 	private _sheenColorFactor: vec3 = [0.0, 0.0, 0.0];
 	private _sheenRoughnessFactor = 0.0;
 
-	@GraphChild private sheenColorTexture: Link<this, Texture> | null = null;
+	@GraphChild private sheenColorTexture: TextureLink | null = null;
 	@GraphChild private sheenColorTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('sheenColorTextureInfo', this, new TextureInfo(this.graph));
 
-	@GraphChild private sheenRoughnessTexture: Link<this, Texture> | null = null;
+	@GraphChild private sheenRoughnessTexture: TextureLink | null = null;
 	@GraphChild private sheenRoughnessTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('sheenRoughnessTextureInfo', this, new TextureInfo(this.graph));
 
@@ -84,7 +86,8 @@ export class Sheen extends ExtensionProperty {
 
 	/** Sets sheen color texture. See {@link getSheenColorTexture}. */
 	public setSheenColorTexture(texture: Texture | null): this {
-		this.sheenColorTexture = this.graph.link('sheenColorTexture', this, texture);
+		this.sheenColorTexture =
+			this.graph.linkTexture('sheenColorTexture', R | G | B, this, texture);
 		return this;
 	}
 
@@ -122,7 +125,8 @@ export class Sheen extends ExtensionProperty {
 	 * roughness, independent of the base layer's roughness.
 	 */
 	public setSheenRoughnessTexture(texture: Texture | null): this {
-		this.sheenRoughnessTexture = this.graph.link('sheenRoughnessTexture', this, texture);
+		this.sheenRoughnessTexture =
+			this.graph.linkTexture('sheenRoughnessTexture', A, this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -1,5 +1,7 @@
-import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo, vec3 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureChannel, TextureInfo, TextureLink, vec3 } from '@gltf-transform/core';
 import { KHR_MATERIALS_SPECULAR } from '../constants';
+
+const { R, G, B, A } = TextureChannel;
 
 /** Documentation in {@link EXTENSIONS.md}. */
 export class Specular extends ExtensionProperty {
@@ -11,7 +13,7 @@ export class Specular extends ExtensionProperty {
 	private _specularFactor = 1.0;
 	private _specularColorFactor: vec3 = [1.0, 1.0, 1.0];
 
-	@GraphChild private specularTexture: Link<this, Texture> | null = null;
+	@GraphChild private specularTexture: TextureLink | null = null;
 	@GraphChild private specularTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('specularTextureInfo', this, new TextureInfo(this.graph));
 
@@ -90,7 +92,8 @@ export class Specular extends ExtensionProperty {
 
 	/** Sets specular texture. See {@link getSpecularTexture}. */
 	public setSpecularTexture(texture: Texture | null): this {
-		this.specularTexture = this.graph.link('specularTexture', this, texture);
+		this.specularTexture =
+			this.graph.linkTexture('specularTexture', R | G | B | A, this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-transmission/transmission.ts
+++ b/packages/extensions/src/khr-materials-transmission/transmission.ts
@@ -1,5 +1,7 @@
-import { COPY_IDENTITY, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo } from '@gltf-transform/core';
+import { COPY_IDENTITY, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureChannel, TextureInfo, TextureLink } from '@gltf-transform/core';
 import { KHR_MATERIALS_TRANSMISSION } from '../constants';
+
+const { R } = TextureChannel;
 
 /** Documentation in {@link EXTENSIONS.md}. */
 export class Transmission extends ExtensionProperty {
@@ -10,7 +12,7 @@ export class Transmission extends ExtensionProperty {
 
 	private _transmissionFactor = 0.0;
 
-	@GraphChild private transmissionTexture: Link<this, Texture> | null = null;
+	@GraphChild private transmissionTexture: TextureLink | null = null;
 	@GraphChild private transmissionTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('transmissionTextureInfo', this, new TextureInfo(this.graph));
 
@@ -66,7 +68,7 @@ export class Transmission extends ExtensionProperty {
 
 	/** Sets transmission texture. See {@link getTransmissionTexture}. */
 	public setTransmissionTexture(texture: Texture | null): this {
-		this.transmissionTexture = this.graph.link('transmissionTexture', this, texture);
+		this.transmissionTexture = this.graph.linkTexture('transmissionTexture', R, this, texture);
 		return this;
 	}
 }

--- a/packages/extensions/src/khr-materials-volume/volume.ts
+++ b/packages/extensions/src/khr-materials-volume/volume.ts
@@ -1,5 +1,7 @@
-import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureInfo, vec3 } from '@gltf-transform/core';
+import { COPY_IDENTITY, ColorUtils, ExtensionProperty, GraphChild, Link, PropertyType, Texture, TextureChannel, TextureInfo, TextureLink, vec3 } from '@gltf-transform/core';
 import { KHR_MATERIALS_VOLUME } from '../constants';
+
+const { G } = TextureChannel;
 
 /** Documentation in {@link EXTENSIONS.md}. */
 export class Volume extends ExtensionProperty {
@@ -12,7 +14,7 @@ export class Volume extends ExtensionProperty {
 	private _attenuationDistance = Infinity;
 	private _attenuationColor = [1, 1, 1] as vec3;
 
-	@GraphChild private thicknessTexture: Link<this, Texture> | null = null;
+	@GraphChild private thicknessTexture: TextureLink | null = null;
 	@GraphChild private thicknessTextureInfo: Link<this, TextureInfo> =
 		this.graph.link('thicknessTextureInfo', this, new TextureInfo(this.graph));
 
@@ -79,7 +81,7 @@ export class Volume extends ExtensionProperty {
 	 * thicknessFactor.
 	 */
 	public setThicknessTexture(texture: Texture | null): this {
-		this.thicknessTexture = this.graph.link('thicknessTexture', this, texture);
+		this.thicknessTexture = this.graph.linkTexture('thicknessTexture', G, this, texture);
 		return this;
 	}
 

--- a/packages/lib/src/inspect.ts
+++ b/packages/lib/src/inspect.ts
@@ -123,8 +123,7 @@ function listTextures (doc: Document): InspectPropertyReport<InspectTextureRepor
 			.filter((parent) => parent.propertyType !== 'Root')
 			.length;
 
-		const slots = doc.getGraph().getLinks()
-			.filter((link) => link.getChild() === texture)
+		const slots = doc.getGraph().listParentLinks(texture)
 			.map((link) => link.getName())
 			.filter((name) => name !== 'texture');
 

--- a/packages/lib/src/quantize.ts
+++ b/packages/lib/src/quantize.ts
@@ -92,8 +92,8 @@ function quantizePrimitive(
 		if (attribute.getComponentSize() <= bits / 8) continue;
 
 		// Avoid quantizing accessors used for multiple purposes.
-		const usage = doc.getGraph().getLinks()
-			.filter((link) => link.getChild() === attribute && link.getParent() !== root)
+		const usage = doc.getGraph().listParentLinks(attribute)
+			.filter((link) => link.getParent() !== root)
 			.map((link) => link.getName());
 		if (new Set(usage).size > 1) {
 			logger.warn(`${NAME}: Skipping ${semantic}; attribute usage conflict.`);


### PR DESCRIPTION
Fixes #220.

Requires extensions and materials to identify channels in use when linking a texture. Enables future work to identify channel usage when applying KTX compression, particularly when textures are reused by multiple extensions, without requiring knowledge of the extension details elsewhere in the library.