### PR TITLE
[core] Ensure that copy() unsets existing properties.

### DIFF
--- a/packages/core/src/properties/accessor.ts
+++ b/packages/core/src/properties/accessor.ts
@@ -96,7 +96,8 @@ export class Accessor extends ExtensibleProperty {
 		this._out = other._out;
 
 		if (other._array) this._array = other._array.slice();
-		if (other.buffer) this.setBuffer(resolve(other.buffer.getChild()));
+
+		this.setBuffer(other.buffer ? resolve(other.buffer.getChild()) : null);
 
 		return this;
 	}

--- a/packages/core/src/properties/animation-channel.ts
+++ b/packages/core/src/properties/animation-channel.ts
@@ -45,8 +45,8 @@ export class AnimationChannel extends Property {
 
 		this._targetPath = other._targetPath;
 
-		if (other.targetNode) this.setTargetNode(resolve(other.targetNode.getChild()));
-		if (other.sampler) this.setSampler(resolve(other.sampler.getChild()));
+		this.setTargetNode(other.targetNode ? resolve(other.targetNode.getChild()) : null);
+		this.setSampler(other.sampler ? resolve(other.sampler.getChild()) : null);
 
 		return this;
 	}

--- a/packages/core/src/properties/animation-sampler.ts
+++ b/packages/core/src/properties/animation-sampler.ts
@@ -59,8 +59,8 @@ export class AnimationSampler extends Property {
 
 		this._interpolation = other._interpolation;
 
-		if (other.input) this.setInput(resolve(other.input.getChild()));
-		if (other.output) this.setOutput(resolve(other.output.getChild()));
+		this.setInput(other.input ? resolve(other.input.getChild()) : null);
+		this.setOutput(other.output ? resolve(other.output.getChild()) : null);
 
 		return this;
 	}

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -131,31 +131,37 @@ export class Material extends ExtensibleProperty {
 		this._roughnessFactor = other._roughnessFactor;
 		this._metallicFactor = other._metallicFactor;
 
-		if (other.baseColorTexture) {
-			this.setBaseColorTexture(resolve(other.baseColorTexture.getChild()));
-			this.getBaseColorTextureInfo()
-				.copy(resolve(other.baseColorTextureInfo.getChild()), resolve);
-		}
-		if (other.emissiveTexture) {
-			this.setEmissiveTexture(resolve(other.emissiveTexture.getChild()));
-			this.getEmissiveTextureInfo()
-				.copy(resolve(other.emissiveTextureInfo.getChild()), resolve);
-		}
-		if (other.normalTexture) {
-			this.setNormalTexture(resolve(other.normalTexture.getChild()));
-			this.getNormalTextureInfo()
-				.copy(resolve(other.normalTextureInfo.getChild()), resolve);
-		}
-		if (other.occlusionTexture) {
-			this.setOcclusionTexture(resolve(other.occlusionTexture.getChild()));
-			this.getOcclusionTextureInfo()
-				.copy(resolve(other.occlusionTextureInfo.getChild()), resolve);
-		}
-		if (other.metallicRoughnessTexture) {
-			this.setMetallicRoughnessTexture(resolve(other.metallicRoughnessTexture.getChild()));
-			this.getMetallicRoughnessTextureInfo()
-				.copy(resolve(other.metallicRoughnessTextureInfo.getChild()), resolve);
-		}
+		this.setBaseColorTexture(
+			other.baseColorTexture ? resolve(other.baseColorTexture.getChild()) : null
+		);
+		this.baseColorTextureInfo.getChild()
+			.copy(resolve(other.baseColorTextureInfo.getChild()), resolve);
+
+		this.setEmissiveTexture(
+			other.emissiveTexture ? resolve(other.emissiveTexture.getChild()) : null
+		);
+		this.emissiveTextureInfo.getChild()
+			.copy(resolve(other.emissiveTextureInfo.getChild()), resolve);
+
+		this.setNormalTexture(
+			other.normalTexture ? resolve(other.normalTexture.getChild()) : null
+		);
+		this.normalTextureInfo.getChild()
+			.copy(resolve(other.normalTextureInfo.getChild()), resolve);
+
+		this.setOcclusionTexture(
+			other.occlusionTexture ? resolve(other.occlusionTexture.getChild()) : null
+		);
+		this.occlusionTextureInfo.getChild()
+			.copy(resolve(other.occlusionTextureInfo.getChild()), resolve);
+
+		this.setMetallicRoughnessTexture(
+			other.metallicRoughnessTexture
+				? resolve(other.metallicRoughnessTexture.getChild())
+				: null
+		);
+		this.metallicRoughnessTextureInfo.getChild()
+			.copy(resolve(other.metallicRoughnessTextureInfo.getChild()), resolve);
 
 		return this;
 	}

--- a/packages/core/src/properties/node.ts
+++ b/packages/core/src/properties/node.ts
@@ -60,9 +60,9 @@ export class Node extends ExtensibleProperty {
 		this._scale = [...other._scale] as vec3;
 		this._weights = [...other._weights];
 
-		if (other.camera) this.setCamera(resolve(other.camera.getChild()));
-		if (other.mesh) this.setMesh(resolve(other.mesh.getChild()));
-		if (other.skin) this.setSkin(resolve(other.skin.getChild()));
+		this.setCamera(other.camera ? resolve(other.camera.getChild()) : null);
+		this.setMesh(other.mesh ? resolve(other.mesh.getChild()) : null);
+		this.setSkin(other.skin ? resolve(other.skin.getChild()) : null);
 
 		if (resolve !== COPY_IDENTITY) {
 			this.clearGraphChildList(this.children);

--- a/packages/core/src/properties/primitive.ts
+++ b/packages/core/src/properties/primitive.ts
@@ -59,8 +59,8 @@ export class Primitive extends ExtensibleProperty {
 
 		this._mode = other._mode;
 
-		if (other.indices) this.setIndices(resolve(other.indices.getChild()));
-		if (other.material) this.setMaterial(resolve(other.material.getChild()));
+		this.setIndices(other.indices ? resolve(other.indices.getChild()) : null);
+		this.setMaterial(other.material ? resolve(other.material.getChild()) : null);
 
 		this.clearGraphChildList(this.attributes);
 		other.listSemantics().forEach((semantic) => {

--- a/packages/core/src/properties/root.ts
+++ b/packages/core/src/properties/root.ts
@@ -100,9 +100,7 @@ export class Root extends Property {
 		other.skins.forEach((link) => this._addSkin(resolve(link.getChild())));
 		other.textures.forEach((link) => this._addTexture(resolve(link.getChild())));
 
-		if (other.defaultScene) {
-			this.setDefaultScene(resolve(other.defaultScene.getChild()));
-		}
+		this.setDefaultScene(other.defaultScene ? resolve(other.defaultScene.getChild()) : null);
 
 		return this;
 	}

--- a/packages/core/src/properties/skin.ts
+++ b/packages/core/src/properties/skin.ts
@@ -26,10 +26,10 @@ export class Skin extends ExtensibleProperty {
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
 
-		if (other.skeleton) this.setSkeleton(resolve(other.skeleton.getChild()));
-		if (other.inverseBindMatrices) {
-			this.setInverseBindMatrices(resolve(other.inverseBindMatrices.getChild()));
-		}
+		this.setSkeleton(other.skeleton ? resolve(other.skeleton.getChild()) : null);
+		this.setInverseBindMatrices(
+			other.inverseBindMatrices ? resolve(other.inverseBindMatrices.getChild()) : null
+		);
 
 		this.clearGraphChildList(this.joints);
 		other.joints.forEach((link) => this.addJoint(resolve(link.getChild())));

--- a/packages/core/test/properties/skin.test.ts
+++ b/packages/core/test/properties/skin.test.ts
@@ -101,6 +101,12 @@ test('@gltf-transform/core::skin | copy', t => {
 	t.deepEqual(b.listJoints(), a.listJoints(), 'copy joints');
 	t.equal(b.getSkeleton(), a.getSkeleton(), 'copy skeleton');
 	t.equal(b.getInverseBindMatrices(), a.getInverseBindMatrices(), 'copy inverseBindMatrices');
+
+	a.copy(doc.createSkin());
+
+	t.equal(a.getSkeleton(), null, 'unset skeleton');
+	t.equal(a.getInverseBindMatrices(), null, 'unset inverseBindMatrices');
+
 	t.end();
 });
 

--- a/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
@@ -33,21 +33,29 @@ export class Clearcoat extends ExtensionProperty {
 		this._clearcoatRoughnessFactor = other._clearcoatRoughnessFactor;
 		this._clearcoatNormalScale = other._clearcoatNormalScale;
 
-		if (other.clearcoatTexture) {
-			this.setClearcoatTexture(resolve(other.clearcoatTexture.getChild()));
-			this.getClearcoatTextureInfo()!
-				.copy(resolve(other.clearcoatTextureInfo.getChild()), resolve);
-		}
-		if (other.clearcoatRoughnessTexture) {
-			this.setClearcoatRoughnessTexture(resolve(other.clearcoatRoughnessTexture.getChild()));
-			this.getClearcoatRoughnessTextureInfo()!
-				.copy(resolve(other.clearcoatRoughnessTextureInfo.getChild()), resolve);
-		}
-		if (other.clearcoatNormalTexture) {
-			this.setClearcoatNormalTexture(resolve(other.clearcoatNormalTexture.getChild()));
-			this.getClearcoatNormalTextureInfo()!
-				.copy(resolve(other.clearcoatNormalTextureInfo.getChild()), resolve);
-		}
+		this.setClearcoatTexture(
+			other.clearcoatTexture
+				? resolve(other.clearcoatTexture.getChild())
+				: null
+		);
+		this.clearcoatTextureInfo.getChild()
+			.copy(resolve(other.clearcoatTextureInfo.getChild()), resolve);
+
+		this.setClearcoatRoughnessTexture(
+			other.clearcoatRoughnessTexture
+				? resolve(other.clearcoatRoughnessTexture.getChild())
+				: null
+		);
+		this.clearcoatRoughnessTextureInfo.getChild()
+			.copy(resolve(other.clearcoatRoughnessTextureInfo.getChild()), resolve);
+
+		this.setClearcoatNormalTexture(
+			other.clearcoatNormalTexture
+				? resolve(other.clearcoatNormalTexture.getChild())
+				: null
+		);
+		this.clearcoatNormalTextureInfo.getChild()
+			.copy(resolve(other.clearcoatNormalTextureInfo.getChild()), resolve);
 
 		return this;
 	}

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -29,16 +29,21 @@ export class PBRSpecularGlossiness extends ExtensionProperty {
 		this._specularFactor = other._specularFactor;
 		this._glossinessFactor = other._glossinessFactor;
 
-		if (other.diffuseTexture) {
-			this.setDiffuseTexture(resolve(other.diffuseTexture.getChild()));
-			this.getDiffuseTextureInfo()!
-				.copy(resolve(other.diffuseTextureInfo.getChild()), resolve);
-		}
-		if (other.specularGlossinessTexture) {
-			this.setSpecularGlossinessTexture(resolve(other.specularGlossinessTexture.getChild()));
-			this.getSpecularGlossinessTextureInfo()!
-				.copy(resolve(other.specularGlossinessTextureInfo.getChild()), resolve);
-		}
+		this.setDiffuseTexture(
+			other.diffuseTexture
+				? resolve(other.diffuseTexture.getChild())
+				: null
+		);
+		this.diffuseTextureInfo.getChild()
+			.copy(resolve(other.diffuseTextureInfo.getChild()), resolve);
+
+		this.setSpecularGlossinessTexture(
+			other.specularGlossinessTexture
+				? resolve(other.specularGlossinessTexture.getChild())
+				: null
+		);
+		this.specularGlossinessTextureInfo.getChild()
+			.copy(resolve(other.specularGlossinessTextureInfo.getChild()), resolve);
 
 		return this;
 	}

--- a/packages/extensions/src/khr-materials-sheen/sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/sheen.ts
@@ -27,16 +27,21 @@ export class Sheen extends ExtensionProperty {
 		this._sheenColorFactor = other._sheenColorFactor;
 		this._sheenRoughnessFactor = other._sheenRoughnessFactor;
 
-		if (other.sheenColorTexture) {
-			this.setSheenColorTexture(resolve(other.sheenColorTexture.getChild()));
-			this.getSheenColorTextureInfo()!
-				.copy(resolve(other.sheenColorTextureInfo.getChild()), resolve);
-		}
-		if (other.sheenRoughnessTexture) {
-			this.setSheenRoughnessTexture(resolve(other.sheenRoughnessTexture.getChild()));
-			this.getSheenRoughnessTextureInfo()!
-				.copy(resolve(other.sheenRoughnessTextureInfo.getChild()), resolve);
-		}
+		this.setSheenColorTexture(
+			other.sheenColorTexture
+				? resolve(other.sheenColorTexture.getChild())
+				: null
+		);
+		this.sheenColorTextureInfo.getChild()
+			.copy(resolve(other.sheenColorTextureInfo.getChild()), resolve);
+
+		this.setSheenRoughnessTexture(
+			other.sheenRoughnessTexture
+				? resolve(other.sheenRoughnessTexture.getChild())
+				: null
+		);
+		this.sheenRoughnessTextureInfo.getChild()
+			.copy(resolve(other.sheenRoughnessTextureInfo.getChild()), resolve);
 
 		return this;
 	}

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -22,11 +22,13 @@ export class Specular extends ExtensionProperty {
 
 		this._specularFactor = other._specularFactor;
 
-		if (other.specularTexture) {
-			this.setSpecularTexture(resolve(other.specularTexture.getChild()));
-			this.getSpecularTextureInfo()
-				.copy(resolve(other.specularTextureInfo.getChild()), resolve);
-		}
+		this.setSpecularTexture(
+			other.specularTexture
+				? resolve(other.specularTexture.getChild())
+				: null
+		);
+		this.specularTextureInfo.getChild()
+			.copy(resolve(other.specularTextureInfo.getChild()), resolve);
 
 		return this;
 	}

--- a/packages/extensions/src/khr-materials-transmission/transmission.ts
+++ b/packages/extensions/src/khr-materials-transmission/transmission.ts
@@ -21,11 +21,13 @@ export class Transmission extends ExtensionProperty {
 
 		this._transmissionFactor = other._transmissionFactor;
 
-		if (other.transmissionTexture) {
-			this.setTransmissionTexture(resolve(other.transmissionTexture.getChild()));
-			this.getTransmissionTextureInfo()
-				.copy(resolve(other.transmissionTextureInfo.getChild()), resolve);
-		}
+		this.setTransmissionTexture(
+			other.transmissionTexture
+				? resolve(other.transmissionTexture.getChild())
+				: null
+		);
+		this.transmissionTextureInfo.getChild()
+			.copy(resolve(other.transmissionTextureInfo.getChild()), resolve);
 
 		return this;
 	}

--- a/packages/extensions/src/khr-materials-variants/mapping.ts
+++ b/packages/extensions/src/khr-materials-variants/mapping.ts
@@ -15,9 +15,7 @@ export class Mapping extends ExtensionProperty {
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		super.copy(other, resolve);
 
-		if (other.material) {
-			this.setMaterial(resolve(other.material.getChild()));
-		}
+		this.setMaterial(other.material ? resolve(other.material.getChild()) : null);
 
 		this.clearGraphChildList(this.variants);
 		other.variants.forEach((link) => this.addVariant(resolve(link.getChild())));

--- a/packages/extensions/src/khr-materials-volume/volume.ts
+++ b/packages/extensions/src/khr-materials-volume/volume.ts
@@ -25,11 +25,13 @@ export class Volume extends ExtensionProperty {
 		this._attenuationDistance = other._attenuationDistance;
 		this._attenuationColor = [...other._attenuationColor] as vec3;
 
-		if (other.thicknessTexture) {
-			this.setThicknessTexture(resolve(other.thicknessTexture.getChild()));
-			this.getThicknessTextureInfo()
-				.copy(resolve(other.thicknessTextureInfo.getChild()), resolve);
-		}
+		this.setThicknessTexture(
+			other.thicknessTexture
+				? resolve(other.thicknessTexture.getChild())
+				: null
+		);
+		this.thicknessTextureInfo.getChild()
+			.copy(resolve(other.thicknessTextureInfo.getChild()), resolve);
 
 		return this;
 	}


### PR DESCRIPTION
Fixes #237.