### PR TITLE
Support for latest KTX Software build, fix build dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "csv-stringify": "^5.6.2",
     "draco3dgltf": "^1.4.1",
     "gl": "^4.9.0",
-    "gltf-validator": "^2.0.0-dev.3.2",
+    "gltf-validator": "^2.0.0-dev.3.3",
     "ktx-parse": "^0.2.1",
     "markdown-table": "^2.0.0",
     "mikktspace": "^0.2.0",
@@ -47,5 +47,8 @@
     "package.json",
     "package-lock.json"
   ],
-  "gitHead": "9f80b1a7b25076e9b6d1dd5c4702daa3ce1b67ae"
+  "gitHead": "9f80b1a7b25076e9b6d1dd5c4702daa3ce1b67ae",
+  "devDependencies": {
+    "microbundle": "^0.13.0"
+  }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-import fs from 'fs';
-import minimatch from 'minimatch';
+import * as fs from 'fs';
+import * as minimatch from 'minimatch';
 import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
 import { Logger, NodeIO, PropertyType, VertexLayout } from '@gltf-transform/core';

--- a/packages/cli/src/inspect.ts
+++ b/packages/cli/src/inspect.ts
@@ -1,9 +1,12 @@
-import CLITable from 'cli-table3';
-import stringify from 'csv-stringify';
-import mdTable from 'markdown-table';
+import * as CLITable from 'cli-table3';
+import * as stringify_ from 'csv-stringify';
+import * as mdTable_ from 'markdown-table';
 import { JSONDocument, Logger, NodeIO, WebIO } from '@gltf-transform/core';
 import { InspectAnimationReport, InspectMaterialReport, InspectMeshReport, InspectPropertyReport, InspectSceneReport, InspectTextureReport, inspect as inspectDoc } from '@gltf-transform/lib';
 import { formatBytes, formatHeader, formatLong, formatParagraph } from './util';
+
+const stringify = stringify_;
+const mdTable = mdTable_;
 
 export enum InspectFormat {
 	PRETTY = 'pretty',

--- a/packages/cli/src/transforms/merge.ts
+++ b/packages/cli/src/transforms/merge.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import * as fs from 'fs';
 import { BufferUtils, Document, FileUtils, ImageUtils, NodeIO, Transform } from '@gltf-transform/core';
 
 const NAME = 'merge';

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -10,7 +10,7 @@ import { commandExistsSync, formatBytes, getTextureChannels, getTextureSlots, sp
 
 tmp.setGracefulCleanup();
 
-const KTX_SOFTWARE_VERSION_MIN = '4.0.0-rc1';
+const KTX_SOFTWARE_VERSION_MIN = '4.0.0-1';
 
 const { R, G } = TextureChannel;
 

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -1,7 +1,7 @@
-import fs from 'fs';
-import path from 'path';
-import CLITable from 'cli-table3';
-import validator from 'gltf-validator';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as CLITable from 'cli-table3';
+import * as validator from 'gltf-validator';
 import { Logger } from '@gltf-transform/core';
 import { formatHeader } from './util';
 


### PR DESCRIPTION
- Fix build dependencies
- Prevent error with latest KTX Software build `error: Requires KTX-Software >= 4.0.0, found v4.0.0-5-gca6f6e7d.`