### PR TITLE
Support quantizationVolume=scene for Draco

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -433,6 +433,10 @@ Requires KHR_mesh_quantization support.`.trim())
 		validator: program.ARRAY,
 		default: QUANTIZE_DEFAULTS.excludeAttributes,
 	})
+	.option('--quantization-volume <volume>', 'Bounds for quantization grid.', {
+		validator: ['mesh', 'scene'],
+		default: QUANTIZE_DEFAULTS.quantizationVolume,
+	})
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)
 			.transform(quantize(options))

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -374,6 +374,10 @@ given --decodeSpeed.`.trim())
 		validator: program.NUMBER,
 		default: DRACO_DEFAULTS.quantizeGeneric,
 	})
+	.option('--quantization-volume <volume>', 'Bounds for quantization grid.', {
+		validator: ['mesh', 'scene'],
+		default: DRACO_DEFAULTS.quantizationVolume,
+	})
 	.action(({args, options, logger}) =>
 		// Include a lossless weld — Draco requires indices.
 		Session.create(io, logger, args.input, args.output)

--- a/packages/cli/src/transforms/draco.ts
+++ b/packages/cli/src/transforms/draco.ts
@@ -10,6 +10,7 @@ export interface DracoCLIOptions {
 	quantizeColor?: number;
 	quantizeTexcoord?: number;
 	quantizeGeneric?: number;
+	quantizationVolume?: 'mesh' | 'scene';
 }
 
 export const DRACO_DEFAULTS: DracoCLIOptions = {
@@ -21,10 +22,11 @@ export const DRACO_DEFAULTS: DracoCLIOptions = {
 	quantizeColor: 8,
 	quantizeTexcoord: 12,
 	quantizeGeneric: 12,
+	quantizationVolume: 'mesh',
 };
 
-export const draco = (options: DracoCLIOptions): Transform => {
-	options = {...DRACO_DEFAULTS, ...options};
+export const draco = (_options: DracoCLIOptions): Transform => {
+	const options = {...DRACO_DEFAULTS, ..._options} as Required<DracoCLIOptions>;
 	return (doc: Document): void => {
 		doc.createExtension(DracoMeshCompression)
 			.setRequired(true)
@@ -35,12 +37,13 @@ export const draco = (options: DracoCLIOptions): Transform => {
 				encodeSpeed: options.encodeSpeed,
 				decodeSpeed: options.decodeSpeed,
 				quantizationBits: {
-					'POSITION': options.quantizePosition!,
-					'NORMAL': options.quantizeNormal!,
-					'COLOR': options.quantizeColor!,
-					'TEX_COORD': options.quantizeTexcoord!,
-					'GENERIC': options.quantizeGeneric!,
-				}
+					'POSITION': options.quantizePosition,
+					'NORMAL': options.quantizeNormal,
+					'COLOR': options.quantizeColor,
+					'TEX_COORD': options.quantizeTexcoord,
+					'GENERIC': options.quantizeGeneric,
+				},
+				quantizationVolume: options.quantizationVolume
 			});
 	};
 };

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -65,6 +65,9 @@ export type mat4 = [
 ];
 
 /** @hidden */
+export type bbox = {min: vec3, max: vec3};
+
+/** @hidden */
 export const GLB_BUFFER = '@glb.bin';
 
 /**

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -7,5 +7,5 @@ export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera
 export { Graph, GraphChild, GraphChildList, Link } from './graph/';
 export { PlatformIO, NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
 export { BufferUtils, ColorUtils, FileUtils, ImageUtils, ImageUtilsFormat, Logger, MathUtils, bounds, uuid } from './utils/';
-export { TypedArray, TypedArrayConstructor, PropertyType, Format, TextureChannel, VertexLayout, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';
+export { TypedArray, TypedArrayConstructor, PropertyType, Format, TextureChannel, VertexLayout, vec2, vec3, vec4, mat3, mat4, bbox, GLB_BUFFER } from './constants';
 export { GLTF } from './types/gltf';

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -6,6 +6,6 @@ export { Extension } from './extension';
 export { Accessor, Animation, AnimationChannel, AnimationSampler, Buffer, Camera, ExtensionProperty, Property, Material, Mesh, Node, Primitive, PrimitiveTarget, Root, Scene, Skin, Texture, TextureInfo, TextureLink, AttributeLink, IndexLink, COPY_IDENTITY } from './properties';
 export { Graph, GraphChild, GraphChildList, Link } from './graph/';
 export { PlatformIO, NodeIO, WebIO, ReaderContext, WriterContext } from './io/';
-export { BufferUtils, ColorUtils, FileUtils, ImageUtils, ImageUtilsFormat, Logger, MathUtils, uuid } from './utils/';
+export { BufferUtils, ColorUtils, FileUtils, ImageUtils, ImageUtilsFormat, Logger, MathUtils, bounds, uuid } from './utils/';
 export { TypedArray, TypedArrayConstructor, PropertyType, Format, TextureChannel, VertexLayout, vec2, vec3, vec4, mat3, mat4, GLB_BUFFER } from './constants';
 export { GLTF } from './types/gltf';

--- a/packages/core/src/utils/bounds.ts
+++ b/packages/core/src/utils/bounds.ts
@@ -1,6 +1,6 @@
 import { transformMat4 } from 'gl-matrix/vec3';
-import { mat4, vec3 } from '../constants';
-import { Mesh, Node, Scene } from '../properties';
+import { PropertyType, bbox, mat4, vec3 } from '../constants';
+import type { Mesh, Node, Scene } from '../properties';
 
 /**
  * Computes bounding box (AABB) in world space for the given {@link Node} or {@link Scene}.
@@ -11,9 +11,9 @@ import { Mesh, Node, Scene } from '../properties';
  * const {min, max} = bounds(scene);
  * ```
  */
-export function bounds (node: Node | Scene): {min: vec3; max: vec3} {
+export function bounds (node: Node | Scene): bbox {
 	const resultBounds = createBounds();
-	const parents = node instanceof Node ? [node] : node.listChildren();
+	const parents = node.propertyType === PropertyType.NODE ? [node] : node.listChildren();
 
 	for (const parent of parents) {
 		parent.traverse((node) => {
@@ -31,7 +31,7 @@ export function bounds (node: Node | Scene): {min: vec3; max: vec3} {
 }
 
 /** Computes mesh bounds in local space. */
-function getMeshBounds(mesh: Mesh, worldMatrix: mat4): {min: vec3; max: vec3} {
+function getMeshBounds(mesh: Mesh, worldMatrix: mat4): bbox {
 	const meshBounds = createBounds();
 
 	// We can't transform a local AABB into world space and still have a tight AABB in world space,
@@ -53,7 +53,7 @@ function getMeshBounds(mesh: Mesh, worldMatrix: mat4): {min: vec3; max: vec3} {
 }
 
 /** Expands bounds of target by given source. */
-function expandBounds(point: vec3, target: {min: vec3; max: vec3}): void {
+function expandBounds(point: vec3, target: bbox): void {
 	for (let i = 0; i < 3; i++) {
 		target.min[i] = Math.min(point[i], target.min[i]);
 		target.max[i] = Math.max(point[i], target.max[i]);
@@ -61,7 +61,7 @@ function expandBounds(point: vec3, target: {min: vec3; max: vec3}): void {
 }
 
 /** Creates new bounds with min=Infinity, max=-Infinity. */
-function createBounds(): {min: vec3; max: vec3} {
+function createBounds(): bbox {
 	return {
 		min: [Infinity, Infinity, Infinity] as vec3,
 		max: [-Infinity, -Infinity, -Infinity] as vec3,

--- a/packages/core/src/utils/bounds.ts
+++ b/packages/core/src/utils/bounds.ts
@@ -1,5 +1,6 @@
 import { transformMat4 } from 'gl-matrix/vec3';
-import { Mesh, Node, Scene, mat4, vec3 } from '@gltf-transform/core';
+import { mat4, vec3 } from '../constants';
+import { Mesh, Node, Scene } from '../properties';
 
 /**
  * Computes bounding box (AABB) in world space for the given {@link Node} or {@link Scene}.

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './bounds';
 export * from './buffer-utils';
 export * from './color-utils';
 export * from './file-utils';

--- a/packages/core/test/utils/bounds.test.ts
+++ b/packages/core/test/utils/bounds.test.ts
@@ -2,7 +2,7 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Accessor, Document } from '@gltf-transform/core';
-import { bounds } from '../';
+import { bounds } from '../../';
 
 test('@gltf-transform/functions::bounds', t => {
 

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -1,3 +1,4 @@
+import { bbox } from 'core/dist/constants';
 import { Accessor, Document, Extension, GLB_BUFFER, Primitive, PropertyType, ReaderContext, WriterContext, bounds, vec3 } from '@gltf-transform/core';
 import { KHR_DRACO_MESH_COMPRESSION } from '../constants';
 import { DRACO } from '../types/draco3d';
@@ -181,7 +182,7 @@ export class DracoMeshCompression extends Extension {
 		const primitiveHashMap = listDracoPrimitives(this.doc);
 		const primitiveEncodingMap = new Map<string, EncodedPrimitive>();
 
-		let quantizationVolume: {min: vec3, max: vec3} | 'mesh' = 'mesh';
+		let quantizationVolume: bbox | 'mesh' = 'mesh';
 		if (this._encoderOptions.quantizationVolume === 'scene') {
 			if (this.doc.getRoot().listScenes().length !== 1) {
 				logger.warn(`[${NAME}]: quantizationVolume=scene requires exactly 1 scene.`);

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -1,5 +1,5 @@
 import { bbox } from 'core/dist/constants';
-import { Accessor, Document, Extension, GLB_BUFFER, Primitive, PropertyType, ReaderContext, WriterContext, bounds, vec3 } from '@gltf-transform/core';
+import { Accessor, Document, Extension, GLB_BUFFER, Primitive, PropertyType, ReaderContext, WriterContext, bounds } from '@gltf-transform/core';
 import { KHR_DRACO_MESH_COMPRESSION } from '../constants';
 import { DRACO } from '../types/draco3d';
 import { decodeAttribute, decodeGeometry, decodeIndex, initDecoderModule } from './decoder';

--- a/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
@@ -1,4 +1,4 @@
-import { Accessor, GLTF, Primitive, TypedArray, vec3 } from '@gltf-transform/core';
+import { Accessor, GLTF, Primitive, TypedArray, bbox } from '@gltf-transform/core';
 import { DRACO } from '../types/draco3d';
 
 export let encoderModule: DRACO.EncoderModule;
@@ -36,7 +36,7 @@ export interface EncoderOptions {
 	encodeSpeed?: number;
 	method?: EncoderMethod;
 	quantizationBits?: {[key: string]: number};
-	quantizationVolume?: 'mesh' | 'scene' | {min: vec3, max: vec3};
+	quantizationVolume?: 'mesh' | 'scene' | bbox;
 }
 
 const DEFAULT_ENCODER_OPTIONS: EncoderOptions = {

--- a/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
@@ -1,4 +1,4 @@
-import { Accessor, GLTF, Primitive, TypedArray } from '@gltf-transform/core';
+import { Accessor, GLTF, Primitive, TypedArray, vec3 } from '@gltf-transform/core';
 import { DRACO } from '../types/draco3d';
 
 export let encoderModule: DRACO.EncoderModule;
@@ -36,6 +36,7 @@ export interface EncoderOptions {
 	encodeSpeed?: number;
 	method?: EncoderMethod;
 	quantizationBits?: {[key: string]: number};
+	quantizationVolume?: 'mesh' | 'scene' | {min: vec3, max: vec3};
 }
 
 const DEFAULT_ENCODER_OPTIONS: EncoderOptions = {
@@ -43,6 +44,7 @@ const DEFAULT_ENCODER_OPTIONS: EncoderOptions = {
 	encodeSpeed: 5,
 	method: EncoderMethod.EDGEBREAKER,
 	quantizationBits: DEFAULT_QUANTIZATION_BITS,
+	quantizationVolume: 'mesh',
 };
 
 export function initEncoderModule (_encoderModule: DRACO.EncoderModule): void {
@@ -81,10 +83,28 @@ export function encodeGeometry (prim: Primitive, _options: EncoderOptions = DEFA
 		if (attributeID === -1) throw new Error(`Error compressing "${semantic}" attribute.`);
 
 		attributeIDs[semantic] = attributeID;
-		encoder.SetAttributeQuantization(
-			encoderModule[attributeEnum],
-			options.quantizationBits[attributeEnum]
-		);
+		if (options.quantizationVolume === 'mesh' || semantic !== 'POSITION') {
+			encoder.SetAttributeQuantization(
+				encoderModule[attributeEnum],
+				options.quantizationBits[attributeEnum]
+			);
+		} else if (typeof options.quantizationVolume === 'object') {
+			const {quantizationVolume} = options;
+			const range = Math.max(
+				quantizationVolume.max[0] - quantizationVolume.min[0],
+				quantizationVolume.max[1] - quantizationVolume.min[1],
+				quantizationVolume.max[2] - quantizationVolume.min[2],
+			);
+			encoder.SetAttributeExplicitQuantization(
+				encoderModule[attributeEnum],
+				options.quantizationBits[attributeEnum],
+				attribute.getElementSize(),
+				quantizationVolume.min,
+				range
+			);
+		} else {
+			throw new Error('Invalid quantization volume state.');
+		}
 	}
 
 	const indices = prim.getIndices();

--- a/packages/extensions/src/types/draco3d.ts
+++ b/packages/extensions/src/types/draco3d.ts
@@ -156,6 +156,13 @@ export declare module DRACO {
 
 	interface Encoder {
 		SetAttributeQuantization(attribute: number, bits: number): void;
+		SetAttributeExplicitQuantization(
+			attribute: number,
+			bits: number,
+			itemSize: number,
+			origin: [number, number, number],
+			range: number
+		): void;
 		SetSpeedOptions(encodeSpeed: number, decodeSpeed: number): void;
 		SetEncodingMethod(method: number): void;
 		SetTrackEncodedProperties(track: boolean): void;

--- a/packages/functions/src/center.ts
+++ b/packages/functions/src/center.ts
@@ -1,5 +1,5 @@
 import { Document, Transform, vec3 } from '@gltf-transform/core';
-import { bounds } from './bounds';
+import { bounds } from '@gltf-transform/core';
 
 const NAME = 'center';
 

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -25,7 +25,6 @@
  * @module functions
  */
 
-export * from './bounds';
 export * from './center';
 export * from './colorspace';
 export * from './dedup';

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -25,6 +25,7 @@
  * @module functions
  */
 
+export { bounds } from '@gltf-transform/core'; // backwards compatibility, remove in v0.12
 export * from './center';
 export * from './colorspace';
 export * from './dedup';

--- a/packages/functions/src/inspect.ts
+++ b/packages/functions/src/inspect.ts
@@ -1,5 +1,4 @@
-import { Accessor, Document, ExtensionProperty, GLTF, ImageUtils, Texture, TypedArray } from '@gltf-transform/core';
-import { bounds } from './bounds';
+import { Accessor, Document, ExtensionProperty, GLTF, ImageUtils, Texture, TypedArray, bounds } from '@gltf-transform/core';
 import { getGLPrimitiveCount } from './utils';
 
 /** Inspects the contents of a glTF file and returns a JSON report. */


### PR DESCRIPTION
Fixes https://github.com/donmccurdy/glTF-Transform/issues/257.

Remaining:

- [x] Support same option for `quantize()`
- [x] Backwards compatibility, export `bounds()` from functions package