### PR TITLE
Add reorder function.

### DIFF
--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -48,6 +48,7 @@ export * from './partition';
 export * from './prune';
 export * from './quantize';
 export * from './resample';
+export * from './reorder';
 export * from './sequence';
 export * from './tangents';
 export * from './texture-resize';

--- a/packages/functions/src/reorder.ts
+++ b/packages/functions/src/reorder.ts
@@ -1,0 +1,153 @@
+import { Accessor, Document, GLTF, Primitive, PropertyType, Transform } from '@gltf-transform/core';
+import { prune } from './prune';
+import { SetMap } from './utils';
+import type { MeshoptEncoder } from 'meshoptimizer';
+
+const NAME = 'reorder';
+
+/** Options for the {@link reorder} function. */
+export interface ReorderOptions {
+	/** MeshoptEncoder instance. */
+	encoder?: typeof MeshoptEncoder,
+	/**
+	 * Whether the order should be optimal for transmission size (recommended for Web)
+	 * or for GPU rendering performance. Default is 'size'.
+	 */
+	target?: 'size' | 'performance',
+}
+
+const REORDER_DEFAULTS: Required<Omit<ReorderOptions, 'encoder'>> = {
+	target: 'size',
+};
+
+interface LayoutPlan {
+	indicesToMode: Map<Accessor, GLTF.MeshPrimitiveMode>;
+	indicesToAttributes: SetMap<Accessor, Accessor>;
+	attributesToPrimitives: SetMap<Accessor, Primitive>;
+}
+
+/**
+ * Optimizes {@link Mesh} {@link Primitive Primitives} for locality of reference. Choose whether
+ * the order should be optimal for transmission size (recommended for Web) or for GPU rendering
+ * performance. Requires a MeshoptEncoder instance from the Meshoptimizer library.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { MeshoptEncoder } from 'path/to/meshopt_encoder.module.js';
+ * import { reorder } from '@gltf-transform/functions';
+ *
+ * await document.transform(
+ * 	reorder({encoder: MeshoptEncoder})
+ * );
+ * ```
+ */
+export function reorder (_options: ReorderOptions = REORDER_DEFAULTS): Transform {
+	const options = {...REORDER_DEFAULTS, ..._options} as Required<ReorderOptions>;
+	const encoder = options.encoder;
+
+	return async (doc: Document): Promise<void> => {
+		const logger = doc.getLogger();
+
+		await encoder.ready;
+
+		const plan = preprocessPrimitives(doc);
+
+		for (const indices of plan.indicesToAttributes.keys()) {
+			let indicesArray = indices.getArray()!;
+			if (!(indicesArray instanceof Uint32Array)) {
+				indicesArray = new Uint32Array(indicesArray);
+			}
+
+			// Compute optimal order.
+			const [remap, unique] = encoder.reorderMesh(
+				indicesArray,
+				plan.indicesToMode.get(indices) === Primitive.Mode.TRIANGLES,
+				options.target === 'size'
+			);
+
+			indices.setArray(unique <= 65534 ? new Uint16Array( indicesArray ) : indicesArray);
+
+			// Update affected primitives.
+			for (const srcAttribute of plan.indicesToAttributes.get(indices)) {
+				const dstAttribute = srcAttribute.clone();
+				remapAttribute(dstAttribute, remap, unique);
+				for (const prim of plan.attributesToPrimitives.get(srcAttribute)) {
+					if (prim.getIndices() === indices) {
+						prim.swap(srcAttribute, dstAttribute);
+						for (const target of prim.listTargets()) {
+							target.swap(srcAttribute, dstAttribute);
+						}
+					}
+				}
+			}
+		}
+
+		// Clean up any attributes left unused by earlier cloning.
+		await doc.transform(prune({propertyTypes: [PropertyType.ACCESSOR]}));
+
+		if (!plan.indicesToAttributes.size) {
+			logger.warn(`${NAME}: No qualifying primitives found; may need to weld first.`);
+		} else {
+			logger.debug(`${NAME}: Complete.`);
+		}
+	};
+}
+
+function remapAttribute(attribute: Accessor, remap: Uint32Array, dstCount: number) {
+	const elementSize = attribute.getElementSize();
+	const srcCount = attribute.getCount();
+	const srcArray = attribute.getArray()!;
+	const dstArray = srcArray.slice(0, dstCount * elementSize);
+
+	for (let i = 0; i < srcCount; i++) {
+		for (let j = 0; j < elementSize; j++) {
+			dstArray[remap[i] * elementSize + j] = srcArray[i * elementSize + j];
+		}
+	}
+
+	attribute.setArray(dstArray);
+}
+
+/**
+ * Constructs a plan for creating optimal vertex cache order, based on unique
+ * index:attribute[] groups. Where different indices are used with the same
+ * attributes, we'll end up splitting the primitives to not share attributes,
+ * which appears to be consistent with the Meshopt implementation.
+ */
+function preprocessPrimitives(doc: Document): LayoutPlan {
+	const indicesToAttributes = new SetMap<Accessor, Accessor>();
+	const indicesToMode = new Map<Accessor, GLTF.MeshPrimitiveMode>();
+	const attributesToPrimitives = new SetMap<Accessor, Primitive>();
+
+	for (const mesh of doc.getRoot().listMeshes()) {
+		for (const prim of mesh.listPrimitives()) {
+			const indices = prim.getIndices();
+			if (!indices) continue;
+
+			indicesToMode.set(indices, prim.getMode());
+
+			for (const attribute of listAttributes(prim)) {
+				indicesToAttributes.add(indices, attribute);
+				attributesToPrimitives.add(attribute, prim);
+			}
+		}
+	}
+
+	return {indicesToAttributes, indicesToMode, attributesToPrimitives};
+}
+
+function listAttributes(prim: Primitive): Accessor[] {
+	const accessors: Accessor[] = [];
+
+	for (const attribute of prim.listAttributes()) {
+		accessors.push(attribute);
+	}
+	for (const target of prim.listTargets()) {
+		for (const attribute of target.listAttributes()) {
+			accessors.push(attribute);
+		}
+	}
+
+	return Array.from(new Set(accessors));
+}

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -52,3 +52,28 @@ export function getGLPrimitiveCount(prim: Primitive): number {
 			throw new Error('Unexpected mode: ' + prim.getMode());
 	}
 }
+
+export class SetMap<K, V> {
+	private _map = new Map<K, Set<V>>();
+	public get size(): number {
+		return this._map.size;
+	}
+	public has(k: K): boolean {
+		return this._map.has(k);
+	}
+	public add(k: K, v: V): this {
+		let entry = this._map.get(k);
+		if (!entry) {
+			entry = new Set();
+			this._map.set(k, entry);
+		}
+		entry.add(v);
+		return this;
+	}
+	public get(k: K): Set<V> {
+		return this._map.get(k) || new Set();
+	}
+	public keys(): Iterable<K> {
+		return this._map.keys();
+	}
+}

--- a/packages/functions/test/reorder.test.ts
+++ b/packages/functions/test/reorder.test.ts
@@ -1,0 +1,124 @@
+require('source-map-support').install();
+
+import test from 'tape';
+import { Accessor, Document, GLTF, Logger, Primitive } from '@gltf-transform/core';
+import { reorder } from '../';
+import { MeshoptEncoder } from 'meshoptimizer';
+
+// TODO cases:
+// - [x] no indices, no effect
+// - [x] same attributes, many indices
+// - [ ] same indices, many attributes
+// - [ ] morph targets
+
+const CUBE_INDICES = new Uint32Array([
+	4, 2, 5,
+	3, 1, 4,
+	0, 1, 3,
+	1, 2, 4,
+]);
+
+const CUBE_INDICES_EXPECTED = new Uint32Array([
+	0, 1, 2,
+	3, 1, 0,
+	4, 3, 0,
+	5, 3, 4,
+]);
+
+const CUBE_POSITIONS = new Float32Array([
+	0.00, 0.00, 1.00,
+	0.00, 0.00, -1.00,
+	0.00, 1.00, 0.00,
+	0.00, -1.00, 0.00,
+	1.00, 0.00, 0.00,
+	-1.00, 0.00, 0.00,
+]);
+
+const CUBE_POSITIONS_EXPECTED = new Float32Array(CUBE_POSITIONS.length);
+const REMAP = [5, 3, 1, 4, 0, 2];
+for (let i = 0; i < CUBE_POSITIONS.length; i++) {
+	CUBE_POSITIONS_EXPECTED[REMAP[i] * 3 + 0] = CUBE_POSITIONS[i * 3 + 0];
+	CUBE_POSITIONS_EXPECTED[REMAP[i] * 3 + 1] = CUBE_POSITIONS[i * 3 + 1];
+	CUBE_POSITIONS_EXPECTED[REMAP[i] * 3 + 2] = CUBE_POSITIONS[i * 3 + 2];
+}
+
+const logger = new Logger(Logger.Verbosity.SILENT);
+
+test('@gltf-transform/functions::reorder | no indices', async t => {
+	// Without indices, don't reorder. Need a lossy weld first.
+	const doc = new Document().setLogger(logger);
+	const root = doc.getRoot();
+	const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+	const prim1 = root.listMeshes()[0].listPrimitives()[0];
+
+	await doc.transform(reorder({encoder: MeshoptEncoder}));
+
+	t.ok(
+		prim1.getIndices() === null
+		&& prim1.getAttribute('POSITION') === position1,
+		'primitive unchanged'
+	);
+	t.ok(!position1.isDisposed(), 'positions not disposed');
+	t.deepEquals(position1.getArray(), CUBE_POSITIONS, 'positions unchanged');
+	t.end();
+});
+
+test('@gltf-transform/functions::reorder | shared indices', async t => {
+	// With shared indices and unshared attributes, indices should be cloned.
+	const doc = new Document().setLogger(logger);
+	const root = doc.getRoot();
+	const indices = doc.createAccessor()
+		.setType('SCALAR')
+		.setArray(CUBE_INDICES);
+	const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+	const position2 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+	const prim1 = root.listMeshes()[0].listPrimitives()[0].setIndices(indices);
+	const prim2 = root.listMeshes()[1].listPrimitives()[0].setIndices(indices);
+
+	await doc.transform(reorder({encoder: MeshoptEncoder}));
+
+	t.ok(indices !== prim1.getIndices(), 'indices #1 cloned');
+	t.ok(indices !== prim2.getIndices(), 'indices #2 cloned');
+	t.ok(prim1.getIndices() === prim2.getIndices(), 'indices shared');
+	t.ok(
+		prim1.getAttribute('POSITION') !== prim2.getAttribute('POSITION'),
+		'positions remain unshared'
+	);
+	t.ok(indices.isDisposed(), 'original indices disposed');
+	t.ok(position1.isDisposed(), 'original positions #1 disposed');
+	t.ok(position2.isDisposed(), 'original positions #2 disposed');
+	t.deepEquals(
+		Array.from(prim1.getIndices().getArray()),
+		Array.from(CUBE_INDICES_EXPECTED),
+		'indices reordered'
+	);
+	t.deepEquals(
+		Array.from(prim1.getAttribute('POSITION').getArray()),
+		Array.from(CUBE_POSITIONS_EXPECTED),
+		'positions #1 reordered'
+	);
+	t.deepEquals(
+		Array.from(prim2.getAttribute('POSITION').getArray()),
+		Array.from(CUBE_POSITIONS_EXPECTED),
+		'positions #2 reordered'
+	);
+	t.end();
+});
+
+/* UTILITIES */
+
+/** Builds a new float32 attribute for given type and data. */
+function createFloatAttribute(
+		doc: Document,
+		semantic: string,
+		type: GLTF.AccessorType,
+		array: Float32Array): Accessor {
+	const attribute = doc.createAccessor()
+		.setType(type)
+		.setArray(array);
+	const prim = doc.createPrimitive()
+		.setAttribute(semantic, attribute)
+		.setMode(Primitive.Mode.TRIANGLES);
+	doc.createMesh().addPrimitive(prim);
+	return attribute;
+}


### PR DESCRIPTION
Implements a `reorder()` function, using Meshoptimizer for improving vertex locality and compression. Pre-processing step for Meshopt compression (#106).

Example:

```js
import { MeshoptEncoder } from './path/to/meshopt_encoder.module.js';
import { reorder, quantize } from '@gltf-transform/functions';

await document.transform(
  reorder({target: 'size', encoder: MeshoptEncoder}),
  quantize(),
  ...
);
```

Remaining:

- [x] Documentation
- [x] Clean up TS typings
- [x] Unit tests
