### PR TITLE
Support EXT_meshopt_compression encoding

### DIFF
--- a/packages/extensions/src/ext-mesh-gpu-instancing/mesh-gpu-instancing.ts
+++ b/packages/extensions/src/ext-mesh-gpu-instancing/mesh-gpu-instancing.ts
@@ -4,7 +4,7 @@ import { InstancedMesh } from './instanced-mesh';
 
 const NAME = EXT_MESH_GPU_INSTANCING;
 
-// See BufferViewUsage in `writer.ts`.
+// See BufferViewUsage in `writer-context.ts`.
 const INSTANCE_ATTRIBUTE = 'INSTANCE_ATTRIBUTE';
 
 interface InstancedMeshDef {
@@ -119,7 +119,7 @@ export class MeshGPUInstancing extends Extension {
 		context.accessorUsageGroupedByParent.add(INSTANCE_ATTRIBUTE);
 		for (const prop of this.properties) {
 			for (const attribute of (prop as InstancedMesh).listAttributes()) {
-				context.setAccessorUsage(attribute, INSTANCE_ATTRIBUTE);
+				context.addAccessorToUsageGroup(attribute, INSTANCE_ATTRIBUTE);
 			}
 		}
 		return this;

--- a/packages/extensions/src/ext-meshopt-compression/constants.ts
+++ b/packages/extensions/src/ext-meshopt-compression/constants.ts
@@ -1,0 +1,31 @@
+export enum EncoderMethod {
+	QUANTIZE = 'quantize',
+	FILTER = 'filter',
+}
+
+export interface MeshoptBufferExtension {
+	fallback?: boolean;
+}
+
+export enum MeshoptMode {
+	ATTRIBUTES = 'ATTRIBUTES',
+	TRIANGLES = 'TRIANGLES',
+	INDICES = 'INDICES',
+}
+
+export enum MeshoptFilter {
+	NONE = 'NONE',
+	OCTAHEDRAL = 'OCTAHEDRAL',
+	QUATERNION = 'QUATERNION',
+	EXPONENTIAL = 'EXPONENTIAL',
+}
+
+export interface MeshoptBufferViewExtension {
+	buffer: number;
+	byteOffset: number;
+	byteLength: number;
+	byteStride: number;
+	count: number;
+	mode: MeshoptMode;
+	filter?: MeshoptFilter;
+}

--- a/packages/extensions/src/ext-meshopt-compression/decoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/decoder.ts
@@ -1,0 +1,17 @@
+import { EXT_MESHOPT_COMPRESSION } from '../constants';
+import { GLTF } from '@gltf-transform/core';
+import { MeshoptBufferExtension } from './constants';
+
+/**
+ * Returns true for a fallback buffer, else false.
+ *
+ *   - All references to the fallback buffer must come from bufferViews that
+ *     have a EXT_meshopt_compression extension specified.
+ *   - No references to the fallback buffer may come from
+ *     EXT_meshopt_compression extension JSON.
+ */
+export function isFallbackBuffer(bufferDef: GLTF.IBuffer): boolean {
+	if (!bufferDef.extensions || !bufferDef.extensions[EXT_MESHOPT_COMPRESSION]) return false;
+	const fallbackDef = bufferDef.extensions[EXT_MESHOPT_COMPRESSION] as MeshoptBufferExtension;
+	return !!fallbackDef.fallback;
+}

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -1,0 +1,105 @@
+import { MeshoptFilter, MeshoptMode } from './constants';
+import { Accessor, AnimationChannel, AnimationSampler, AttributeLink, BufferUtils, Document, GLTF, Primitive, TypedArray, TypedArrayConstructor, WriterContext } from '@gltf-transform/core';
+import type { MeshoptEncoder } from 'meshoptimizer';
+
+/** Pre-processes array with required filters or padding. */
+export function prepareArray(
+	accessor: Accessor,
+	encoder: typeof MeshoptEncoder,
+	mode: MeshoptMode,
+	filter: MeshoptFilter
+): ({array: TypedArray, byteStride: number}) {
+	let array = accessor.getArray()!;
+	let byteStride = array.byteLength / accessor.getCount();
+
+	if (mode === MeshoptMode.ATTRIBUTES && filter !== MeshoptFilter.NONE) {
+		if (filter === MeshoptFilter.EXPONENTIAL) {
+			byteStride = accessor.getElementSize() * 4;
+			array = encoder.encodeFilterExp(
+				new Float32Array(array), accessor.getCount(), byteStride, 12
+			);
+		} else if (filter === MeshoptFilter.OCTAHEDRAL) {
+			// TODO(filter): Add .w component to normals?
+			byteStride = 8;
+			array = encoder.encodeFilterOct(
+				new Float32Array(array), accessor.getCount(), byteStride, 8
+			);
+		} else if (filter === MeshoptFilter.QUATERNION) {
+			byteStride = 8;
+			array = encoder.encodeFilterQuat(
+				new Float32Array(array), accessor.getCount(), byteStride, 16
+			);
+		}
+	} else if (mode === MeshoptMode.ATTRIBUTES && byteStride % 4) {
+		array = padArrayElements(array, accessor.getElementSize());
+		byteStride = array.byteLength / accessor.getCount();
+	}
+
+	return {array, byteStride};
+}
+
+/** Pads array to 4 byte alignment, required for Meshopt ATTRIBUTE buffer views. */
+export function padArrayElements<T extends TypedArray>(srcArray: T, elementSize: number): T {
+	const byteStride = BufferUtils.padNumber(srcArray.BYTES_PER_ELEMENT * elementSize);
+	const elementStride = byteStride / srcArray.BYTES_PER_ELEMENT;
+	const elementCount = srcArray.length / elementSize;
+
+	const dstArray =
+		new (srcArray.constructor as TypedArrayConstructor)(elementCount * elementStride) as T;
+
+	for (let i = 0; i * elementSize < srcArray.length; i++) {
+		for (let j = 0; j < elementSize; j++) {
+			dstArray[i * elementStride + j] = srcArray[i * elementSize + j];
+		}
+	}
+
+	return dstArray;
+}
+
+export function getMeshoptMode(accessor: Accessor, usage: string): MeshoptMode {
+	if (usage === WriterContext.BufferViewUsage.ELEMENT_ARRAY_BUFFER) {
+		const isTriangles = accessor.listParents()
+			.some((parent) => {
+				return parent instanceof Primitive && parent.getMode() === Primitive.Mode.TRIANGLES;
+			});
+		return isTriangles ? MeshoptMode.TRIANGLES : MeshoptMode.INDICES;
+	}
+
+	return MeshoptMode.ATTRIBUTES;
+}
+
+export function getMeshoptFilter(accessor: Accessor, doc: Document): MeshoptFilter {
+	const semantics = doc.getGraph().listParentLinks(accessor)
+		.map((link) => (link as AttributeLink).getName())
+		.filter((name) => name !== 'accessor');
+	for (const semantic of semantics) {
+		// TODO(filter): Need to pad the normals with a .w component, I think?
+		if (semantic === 'NORMAL') return MeshoptFilter.NONE;
+		if (semantic === 'TANGENT') return MeshoptFilter.OCTAHEDRAL;
+		if (semantic.startsWith('JOINTS_')) return MeshoptFilter.NONE;
+		if (semantic.startsWith('WEIGHTS_')) return MeshoptFilter.NONE;
+		if (semantic === 'output') {
+			const targetPath = getTargetPath(accessor);
+			if (targetPath === 'rotation') return MeshoptFilter.NONE;
+			if (targetPath === 'translation') return MeshoptFilter.EXPONENTIAL;
+			if (targetPath === 'scale') return MeshoptFilter.EXPONENTIAL;
+			return MeshoptFilter.NONE;
+		}
+		// TODO(filter): Exponential? Index sequence?
+		if (semantic === 'input') return MeshoptFilter.NONE;
+		if (semantic === 'inverseBindMatrices') return MeshoptFilter.NONE;
+	}
+
+	return MeshoptFilter.EXPONENTIAL;
+}
+
+export function getTargetPath(accessor: Accessor): GLTF.AnimationChannelTargetPath | null {
+	for (const sampler of accessor.listParents()) {
+		if (!(sampler instanceof AnimationSampler)) continue;
+		for (const channel of sampler.listParents()) {
+			if (!(channel instanceof AnimationChannel)) continue;
+			return channel.getTargetPath();
+		}
+	}
+	return null;
+}

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -5,7 +5,7 @@ import test from 'tape';
 import { NodeIO } from '@gltf-transform/core';
 import { bounds } from '@gltf-transform/functions';
 import { MeshoptCompression, MeshQuantization } from '../';
-import { MeshoptDecoder } from 'meshoptimizer';
+import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
 
 test('@gltf-transform/extensions::draco-mesh-compression | decoding', async t => {
 	await MeshoptDecoder.ready;
@@ -18,5 +18,30 @@ test('@gltf-transform/extensions::draco-mesh-compression | decoding', async t =>
 	const bbox = bounds(doc.getRoot().listScenes()[0]);
 	t.deepEquals(bbox.min.map(v => +v.toFixed(3)), [-0.5, -0.5, -0.5], 'decompress (min)');
 	t.deepEquals(bbox.max.map(v => +v.toFixed(3)), [0.5, 0.5, 0.5], 'decompress (max)');
+	t.end();
+});
+
+test('@gltf-transform/extensions::draco-mesh-compression | encoding', async t => {
+	await Promise.all([MeshoptDecoder.ready, MeshoptEncoder.ready]);
+
+	const io = new NodeIO()
+		.registerExtensions([MeshoptCompression, MeshQuantization])
+		.registerDependencies({
+			'meshopt.decoder': MeshoptDecoder,
+			'meshopt.encoder': MeshoptEncoder,
+		});
+
+	const doc = io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
+	const glb = io.writeBinary(doc);
+	const rtDoc = io.readBinary(glb);
+
+	const extensionsRequired = rtDoc.getRoot()
+		.listExtensionsRequired()
+		.map((ext) => ext.extensionName);
+	const bbox = bounds(doc.getRoot().listScenes()[0]);
+
+	t.ok(extensionsRequired.includes('EXT_meshopt_compression'), 'retains EXT_meshopt_compression');
+	t.deepEquals(bbox.min.map(v => +v.toFixed(3)), [-0.5, -0.5, -0.5], 'round trip (min)');
+	t.deepEquals(bbox.max.map(v => +v.toFixed(3)), [0.5, 0.5, 0.5], 'round trip (max)');
 	t.end();
 });


### PR DESCRIPTION
Remaining: 

- [x] ~~Resolve various issues (normals, morph targets) on `-c` output~~
- [x] ~~Refactor into 'encoder.ts' and 'decoder.ts' files~~
- [x] ~~Unit tests~~
- [x] ~~Documentation~~
- [x] ~~Clean up duplicated buffer view target code~~
- [x] ~~Misc TODO items~~
- [ ] Fully implement `-cc` (filters)