### PR TITLE
Writer updates to enable Meshopt support.

### DIFF
--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -16,6 +16,7 @@ type PropertyDef = GLTF.IScene | GLTF.INode | GLTF.IMaterial | GLTF.ISkin | GLTF
  */
 export class WriterContext {
 	public readonly accessorIndexMap = new Map<Accessor, number>();
+	public readonly bufferIndexMap = new Map<Buffer, number>();
 	public readonly cameraIndexMap = new Map<Camera, number>();
 	public readonly skinIndexMap = new Map<Skin, number>();
 	public readonly materialIndexMap = new Map<Material, number>();
@@ -37,6 +38,7 @@ export class WriterContext {
 
 	private readonly _accessorUsageMap = new Map<Accessor, string>();
 	public readonly accessorUsageGroupedByParent = new Set<string>(['ARRAY_BUFFER']);
+	public readonly accessorParents = new Map<Property, Set<Accessor>>();
 
 	constructor (
 		doc: Document,

--- a/packages/core/src/properties/primitive-target.ts
+++ b/packages/core/src/properties/primitive-target.ts
@@ -54,7 +54,7 @@ export class PrimitiveTarget extends Property {
 		if (!accessor) return this;
 
 		// Add next attribute.
-		const link = this.graph.linkAttribute(semantic.toLowerCase(), this, accessor);
+		const link = this.graph.linkAttribute(semantic, this, accessor);
 		link.semantic = semantic;
 		return this.addGraphChild(this.attributes, link);
 	}

--- a/packages/functions/src/partition.ts
+++ b/packages/functions/src/partition.ts
@@ -1,4 +1,5 @@
-import { Document, Logger, Transform } from '@gltf-transform/core';
+import { Document, Logger, PropertyType, Transform } from '@gltf-transform/core';
+import { prune } from './prune';
 
 const NAME = 'partition';
 
@@ -31,7 +32,7 @@ const partition = (_options: PartitionOptions = PARTITION_DEFAULTS): Transform =
 
 	const options = {...PARTITION_DEFAULTS, ..._options} as Required<PartitionOptions>;
 
-	return (doc: Document): void => {
+	return async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
 
 		if (options.meshes !== false) partitionMeshes(doc, logger, options);
@@ -40,6 +41,8 @@ const partition = (_options: PartitionOptions = PARTITION_DEFAULTS): Transform =
 		if (!options.meshes && !options.animations) {
 			logger.warn(`${NAME}: Select animations or meshes to create a partition.`);
 		}
+
+		await doc.transform(prune({propertyTypes: [PropertyType.BUFFER]}));
 
 		logger.debug(`${NAME}: Complete.`);
 	};


### PR DESCRIPTION
Splits writing accessors and buffer views into two passes, allowing Meshopt extension to use appropriate prewrite hooks.