### PR TITLE
Add node and scene preread hooks

### DIFF
--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -351,6 +351,11 @@ export class GLTFReader {
 		/** Nodes. */
 
 		const nodeDefs = json.nodes || [];
+
+		doc.getRoot().listExtensionsUsed()
+			.filter((extension) => extension.prereadTypes.includes(PropertyType.NODE))
+			.forEach((extension) => extension.preread(context, PropertyType.NODE));
+
 		context.nodes = nodeDefs.map((nodeDef) => {
 			const node = doc.createNode(nodeDef.name);
 
@@ -468,6 +473,11 @@ export class GLTFReader {
 		/** Scenes. */
 
 		const sceneDefs = json.scenes || [];
+
+		doc.getRoot().listExtensionsUsed()
+			.filter((extension) => extension.prereadTypes.includes(PropertyType.SCENE))
+			.forEach((extension) => extension.preread(context, PropertyType.SCENE));
+
 		context.scenes = sceneDefs.map((sceneDef) => {
 			const scene = doc.createScene(sceneDef.name);
 


### PR DESCRIPTION
These preread hooks are necessary for the `MOZ_hubs_components` extension. The component doesn't have a stable schema, so I'd like to migrate from older versions to a singular up to date version by modifying the json in the preread hook.