### PR TITLE
No invalid output when missing buffer

### DIFF
--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -259,9 +259,16 @@ export class GLTFWriter {
 
 		/* Buffers, buffer views. */
 
-		doc.getRoot().listExtensionsUsed()
+		root.listExtensionsUsed()
 			.filter((extension) => extension.prewriteTypes.includes(PropertyType.BUFFER))
 			.forEach((extension) => extension.prewrite(context, PropertyType.BUFFER));
+
+		const hasBinaryResources = root.listAccessors().length > 0
+			|| root.listTextures().length > 0
+			|| context.otherBufferViews.size > 0;
+		if (hasBinaryResources && root.listBuffers().length === 0) {
+			throw new Error('Buffer required for Document resources, but none was found.');
+		}
 
 		json.buffers = [];
 		root.listBuffers().forEach((buffer, index) => {

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -31,3 +31,37 @@ test('@gltf-transform/core::io | glb without buffer', t => {
 	);
 	t.end();
 });
+
+test('@gltf-transform/core::io | glb with texture-only buffer', t => {
+	const doc = new Document();
+	const texA = doc.createTexture('TexA').setImage(new ArrayBuffer(1)).setMimeType('image/png');
+	const texB = doc.createTexture('TexB').setImage(new ArrayBuffer(2)).setMimeType('image/png');
+	doc.createMaterial('MaterialA').setBaseColorTexture(texA);
+	doc.createMaterial('MaterialB').setBaseColorTexture(texB);
+
+	const io = new NodeIO();
+
+	t.throws(() => io.writeJSON(doc, {format: Format.GLB}), 'no writeJSON without buffer');
+	t.throws(() => io.writeBinary(doc), 'no writeBinary without buffer');
+
+	doc.createBuffer();
+
+	const json = io.writeJSON(doc, {format: Format.GLB});
+	const binary = io.writeBinary(doc);
+
+	t.ok(json, 'writes json');
+	t.ok(binary, 'writes binary');
+	t.equals(Object.values(json.resources).length, 1, 'writes 1 buffer');
+	t.ok(io.readJSON(json), 'reads json');
+	t.ok(io.readBinary(binary), 'reads binary');
+
+	const rtTextures = io.readBinary(binary).getRoot()
+		.listMaterials()
+		.map((n) => n.getBaseColorTexture());
+
+	t.equals(rtTextures[0].getName(), 'TexA', 'reads texture 1');
+	t.equals(rtTextures[1].getName(), 'TexB', 'reads texture 1');
+	t.deepEquals(rtTextures[0].getImage(), new ArrayBuffer(1), 'reads texture 1 data');
+	t.deepEquals(rtTextures[1].getImage(), new ArrayBuffer(2), 'reads texture 2 data');
+	t.end();
+});

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -49,6 +49,7 @@ test('@gltf-transform/core::texture | read', t => {
 
 test('@gltf-transform/core::texture | write', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const image1 = new ArrayBuffer(1);
 	const image2 = new ArrayBuffer(2);
 	const texture1 = doc.createTexture('tex1')
@@ -96,6 +97,7 @@ test('@gltf-transform/core::texture | copy', t => {
 test('@gltf-transform/core::texture | extras', t => {
 	const io = new NodeIO();
 	const doc = new Document();
+	doc.createBuffer();
 	doc.createTexture('A')
 		.setExtras({foo: 1, bar: 2})
 		.setImage(new ArrayBuffer(10))

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -29,6 +29,7 @@ test('@gltf-transform/extensions::materials-clearcoat | factors', t => {
 
 test('@gltf-transform/extensions::materials-clearcoat | textures', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
 	const clearcoat = clearcoatExtension.createClearcoat()
 		.setClearcoatFactor(0.9)

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -8,6 +8,7 @@ const WRITER_OPTIONS = {basename: 'extensionTest'};
 
 test('@gltf-transform/extensions::materials-pbr-specular-glossiness', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
 	const specGloss = specGlossExtension.createPBRSpecularGlossiness()
 		.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -8,6 +8,7 @@ const WRITER_OPTIONS = {basename: 'extensionTest'};
 
 test('@gltf-transform/extensions::materials-sheen', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const sheenExtension = doc.createExtension(MaterialsSheen);
 	const sheen = sheenExtension.createSheen()
 		.setSheenColorFactor([0.9, 0.5, .8])

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -8,6 +8,7 @@ const WRITER_OPTIONS = {basename: 'extensionTest'};
 
 test('@gltf-transform/extensions::materials-specular', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const specularExtension = doc.createExtension(MaterialsSpecular);
 	const specular = specularExtension.createSpecular()
 		.setSpecularFactor(0.9)

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -8,6 +8,7 @@ const WRITER_OPTIONS = {basename: 'extensionTest'};
 
 test('@gltf-transform/extensions::materials-transmission', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const transmissionExtension = doc.createExtension(MaterialsTransmission);
 	const transmission = transmissionExtension.createTransmission()
 		.setTransmissionFactor(0.9)

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -8,6 +8,7 @@ const WRITER_OPTIONS = {basename: 'extensionTest'};
 
 test('@gltf-transform/extensions::materials-volume', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const volumeExtension = doc.createExtension(MaterialsVolume);
 	const volume = volumeExtension.createVolume()
 		.setThicknessFactor(0.9)

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -10,6 +10,7 @@ const io = new NodeIO().registerExtensions([TextureBasisu]);
 
 test('@gltf-transform/extensions::texture-basisu', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const basisuExtension = doc.createExtension(TextureBasisu);
 	const tex1 = doc.createTexture('BasisTexture')
 		.setMimeType('image/ktx2')

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -10,6 +10,7 @@ const io = new NodeIO().registerExtensions([TextureTransform]);
 
 test('@gltf-transform/extensions::texture-transform', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const transformExtension = doc.createExtension(TextureTransform);
 	const tex1 = doc.createTexture()
 		.setMimeType('image/png')
@@ -123,6 +124,7 @@ test('@gltf-transform/extensions::texture-transform | clone', t => {
 
 test('@gltf-transform/extensions::texture-transform | i/o', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const transformExtension = doc.createExtension(TextureTransform);
 	const tex1 = doc.createTexture();
 

--- a/packages/extensions/test/texture-webp.test.ts
+++ b/packages/extensions/test/texture-webp.test.ts
@@ -10,6 +10,7 @@ const io = new NodeIO().registerExtensions([TextureWebP]);
 
 test('@gltf-transform/extensions::texture-webp', t => {
 	const doc = new Document();
+	doc.createBuffer();
 	const webpExtension = doc.createExtension(TextureWebP);
 	const tex1 = doc.createTexture('WebPTexture')
 		.setMimeType('image/webp')


### PR DESCRIPTION
Context: https://github.com/donmccurdy/glTF-Transform/issues/353

Just adds a failing test for now. Should either create the buffer properly (but the library usually avoids modifying a Document during export... 🤔 ) or throw a clear error when a required Buffer is missing.