### PR TITLE
Corrected multi-byte units in format function

### DIFF
--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -26,7 +26,7 @@ export function formatLong(x: number): string {
 export function formatBytes(bytes: number, decimals = 2): string {
 	if (bytes === 0) return '0 Bytes';
 
-	const k = 1024;
+	const k = 1000;
 	const dm = decimals < 0 ? 0 : decimals;
 	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 

--- a/packages/cli/test/util.test.ts
+++ b/packages/cli/test/util.test.ts
@@ -15,7 +15,7 @@ chocolate cake. Liquorice jelly-o pie jujubes fruitcake chocolate bar jelly-o
 tart. Marshmallow icing tart tootsie roll brownie dragée.`.trim();
 
 test('@gltf-transform/cli::util', t => {
-	t.equals(formatBytes(1024), '1 KB', 'formatBytes');
+	t.equals(formatBytes(1000), '1 KB', 'formatBytes');
 	t.equals(formatHeader('Hello'), HEADER, 'formatHeader');
 	t.equals(formatParagraph(TEXT), PARAGRAPH, 'formatParagraph');
 	t.end();


### PR DESCRIPTION
SI units for multi-byte data require base-10 convention, not the base-2 convention, which should use the alternative prefixes such as kibi.

Ref: https://en.wikipedia.org/wiki/Kilobyte