### PR TITLE
Don't try and compress unsupported image formats

### DIFF
--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -120,10 +120,13 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 					|| `${textureIndex + 1}/${doc.getRoot().listTextures().length}`;
 				logger.debug(`Texture ${textureLabel} (${slots.join(', ')})`);
 
-				// FILTER: Exclude textures that don't match the 'slots' glob, or are already KTX.
+				// FILTER: Exclude textures that don't match the 'slots' glob, are not supported, or are already KTX
 
 				if (texture.getMimeType() === 'image/ktx2') {
 					logger.debug('• Skipping, already KTX.');
+					return;
+				} else if (texture.getMimeType() !== 'image/png' && texture.getMimeType() !== 'image/jpeg') {
+					logger.warn(`• Skipping, unsupported texture type "${texture.getMimeType()}".`);
 					return;
 				} else if (options.slots !== '*'
 						&& !slots.find((slot) => minimatch(slot, options.slots, {nocase: true}))) {


### PR DESCRIPTION
The `toktx` tool errors out if you try and compress anything but PNG and JPEG images. Although nothing else is allowed by the core GLTF spec it is common for third-party extensions to include other things, for instance _image/vnd.radiance_ for HDR lightmaps or environments. Downgrading this to a warning at least allows the image to remain unchanged in the output file.

This could also be addressed using the `slots` property, but it's a bit of a blunt tool and hard to use when you want to target specific image types.