### PR TITLE
Align images to 8-byte boundaries

### DIFF
--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -349,9 +349,9 @@ export class GLTFWriter {
 					bufferByteLength += context.imageBufferViews[i].byteLength;
 					buffers.push(context.imageBufferViews[i]);
 
-					if (bufferByteLength % 4) {
+					if (bufferByteLength % 8) {
 						// See: https://github.com/KhronosGroup/glTF/issues/1935
-						const imagePadding = 4 - (bufferByteLength % 4);
+						const imagePadding = 8 - (bufferByteLength % 8);
 						bufferByteLength += imagePadding;
 						buffers.push(new ArrayBuffer(imagePadding));
 					}

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -112,7 +112,7 @@ test('@gltf-transform/core::texture | extras', t => {
 });
 
 test('@gltf-transform/core::texture | padding', t => {
-	// Ensure that buffer views are padded to 4-byte boundaries. See:
+	// Ensure that buffer views are padded to 8-byte boundaries. See:
 	// https://github.com/KhronosGroup/glTF/issues/1935
 
 	const doc = new Document();
@@ -130,11 +130,11 @@ test('@gltf-transform/core::texture | padding', t => {
 	], 'images');
 	t.deepEqual(jsonDoc.json.bufferViews, [
 		{buffer: 0, byteOffset: 0, byteLength: 17},
-		{buffer: 0, byteOffset: 20, byteLength: 21},
-		{buffer: 0, byteOffset: 44, byteLength: 20},
+		{buffer: 0, byteOffset: 24, byteLength: 21},
+		{buffer: 0, byteOffset: 48, byteLength: 20},
 	], 'bufferViews');
 	t.deepEqual(jsonDoc.json.buffers, [
-		{byteLength: 64}
+		{byteLength: 72}
 	], 'buffers');
 	t.end();
 });

--- a/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
+++ b/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
@@ -20,10 +20,8 @@ class KTX2ImageUtils implements ImageUtilsFormat {
 			return (dfd.samples.length === 2 && (dfd.samples[1].channelID & 0xF) === 15) ? 4 : 3;
 		} else if (dfd.colorModel === KTX2Model.UASTC) {
 			return (dfd.samples[0].channelID & 0xF) === 3 ? 4 : 3;
-		} else {
-			throw new Error(`Unexpected KTX2 colorModel, "${dfd.colorModel}".`);
 		}
-		return 4;
+		throw new Error(`Unexpected KTX2 colorModel, "${dfd.colorModel}".`);
 	}
 	getGPUByteLength (buffer: ArrayBuffer): number {
 		const container = readKTX(new Uint8Array(buffer));


### PR DESCRIPTION
Fixes #372. See https://github.com/KhronosGroup/glTF/issues/1935#issuecomment-932758769.