### PR TITLE
CI: Add Node.js v16 to version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest # Better `headless-gl` support on macOS.
     strategy:
       matrix:
-        node-version: [12.x, 14.x] # Latest prebuilt binaries for `headless-gl`
+        node-version: [12.x, 14.x, 16.x] # Latest prebuilt binaries for `headless-gl`
     env:
       CI: true
     steps:


### PR DESCRIPTION
See https://github.com/donmccurdy/glTF-Transform/issues/376.