### PR TITLE
Support writing custom generator string

### DIFF
--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -48,8 +48,6 @@ export class GLTFReader {
 
 		if (assetDef.copyright) asset.copyright = assetDef.copyright;
 		if (assetDef.extras) asset.extras = assetDef.extras;
-		if (assetDef.generator) asset.generator = assetDef.generator;
-		if (assetDef.minVersion) asset.minVersion = assetDef.minVersion;
 
 		if (json.extras !== undefined) {
 			doc.getRoot().setExtras({...json.extras});

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -23,7 +23,7 @@ export class GLTFWriter {
 
 		const root = doc.getRoot();
 		const json = {
-			asset: {...root.getAsset(), generator: `glTF-Transform ${VERSION}`},
+			asset: {generator: `glTF-Transform ${VERSION}`, ...root.getAsset()},
 			extras: {...root.getExtras()},
 		} as GLTF.IGLTF;
 		const jsonDoc = {json, resources: {}} as JSONDocument;

--- a/packages/core/test/properties/root.test.ts
+++ b/packages/core/test/properties/root.test.ts
@@ -1,7 +1,7 @@
 require('source-map-support').install();
 
 import test from 'tape';
-import { Document, NodeIO, Root } from '../../';
+import { Document, JSONDocument, NodeIO, Root } from '../../';
 
 test('@gltf-transform/core::root', t => {
 	const doc = new Document();
@@ -98,5 +98,27 @@ test('@gltf-transform/core::root | extras', t => {
 	t.deepEquals(jsonDocExtras.json.extras, {custom: 'value'}, 'write extras');
 	t.deepEquals(rtDocNoExtras.getRoot().getExtras(), {}, 'round trip no extras');
 	t.deepEquals(rtDocExtras.getRoot().getExtras(), {custom: 'value'}, 'round trip extras');
+	t.end();
+});
+
+test('@gltf-transform/core::root | asset', t => {
+	const doc = new Document();
+	const root = doc.getRoot();
+	const io = new NodeIO();
+
+	let jsonDoc: JSONDocument;
+	let generator: string;
+
+	jsonDoc = io.writeJSON(doc);
+	generator = jsonDoc.json.asset.generator;
+	t.match(generator, /^glTF-Transform.*/i, 'write default generator');
+
+	root.getAsset().generator = 'Custom Tool v123';
+	jsonDoc = io.writeJSON(doc);
+	generator = jsonDoc.json.asset.generator;
+	t.match(generator, /^Custom Tool.*/i, 'write custom generator');
+
+	generator = io.readJSON(jsonDoc).getRoot().getAsset().generator;
+	t.match(generator, /^glTF-Transform.*/i, 'read default generator');
 	t.end();
 });


### PR DESCRIPTION
Fixes #385.

Changes:

- When reading an existing glTF file, the `asset.generator` string is not passed into the Document.
- When writing a Document, I/O classes will include user-provided `asset.generator` string if given, or `glTF-Transform $VERSION` if not.

While certain parts of the project need to see the original generator string, they already do this by accessing un-processed JSON rather than the resulting Document.