### PR TITLE
Parallel texture compression, and recover if texture compression fails

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
     "minimatch": "^5.0.0",
     "node-fetch": "^2.6.6",
     "node-gzip": "^1.1.2",
+    "p-limit": "^3.1.0",
     "semver": "^7.3.5",
     "spdx-correct": "^3.1.1",
     "tmp": "^0.2.1"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -806,6 +806,11 @@ normal maps and ETC1S for other textures, for example.`.trim()),
 		+ ' faster, less noisy output, but lower quality per output bit).',
 		{validator: program.BOOLEAN}
 	)
+	.option(
+		'--jobs <num_jobs>',
+		'Spawns up to num_jobs instances of toktx',
+		{validator: program.NUMBER, default: ETC1S_DEFAULTS.jobs}
+	)
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)
 			.transform(toktx({mode: Mode.ETC1S, ...options}))
@@ -920,6 +925,11 @@ for textures where the quality is sufficient.`.trim()),
 		+ '\n21    | 67 MB       |'
 		+ '\n22    | 134 MB      |',
 		{validator: program.NUMBER, default: UASTC_DEFAULTS.zstd}
+	)
+	.option(
+		'--jobs <num_jobs>',
+		'Spawns up to num_jobs instances of toktx',
+		{validator: program.NUMBER, default: UASTC_DEFAULTS.jobs}
 	)
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -171,18 +171,17 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 
 				if (status !== 0) {
 					logger.error(`• Texture compression failed:\n\n${stderr.toString()}`);
-					throw new Error('Texture compression failed');
+				} else {
+					// PACK: Replace image data in the glTF asset.
+
+					texture.setImage(await fs.readFile(outPath)).setMimeType('image/ktx2');
+
+					if (texture.getURI()) {
+						texture.setURI(FileUtils.basename(texture.getURI()) + '.ktx2');
+					}
+
+					numCompressed++;
 				}
-
-				// PACK: Replace image data in the glTF asset.
-
-				texture.setImage(await fs.readFile(outPath)).setMimeType('image/ktx2');
-
-				if (texture.getURI()) {
-					texture.setURI(FileUtils.basename(texture.getURI()) + '.ktx2');
-				}
-
-				numCompressed++;
 
 				const outBytes = texture.getImage()!.byteLength;
 				logger.debug(`• ${formatBytes(inBytes)} → ${formatBytes(outBytes)} bytes.`);

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { spawnSync: _spawnSync } = require('child_process');
+const { spawn: _spawn } = require('child_process');
 
-import { sync as _commandExistsSync } from 'command-exists';
+import _commandExists from 'command-exists';
 import { Document, PropertyType, Texture } from '@gltf-transform/core';
 
 // Constants.
@@ -16,15 +16,15 @@ export const XMPContext: Record<string, string> = {
 
 // Mock for tests.
 
-export let spawnSync = _spawnSync;
-export let commandExistsSync = _commandExistsSync;
+export let spawn = _spawn;
+export let commandExists = _commandExists;
 
-export function mockSpawnSync(_spawnSync: unknown): void {
-	spawnSync = _spawnSync;
+export function mockSpawn(_spawn: unknown): void {
+	spawn = _spawn;
 }
 
-export function mockCommandExistsSync(_commandExistsSync: (n: string) => boolean): void {
-	commandExistsSync = _commandExistsSync;
+export function mockCommandExists(_commandExists: (n: string) => Promise<boolean>): void {
+	commandExists = _commandExists as any;
 }
 
 // Formatting.

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -1,10 +1,10 @@
 require('source-map-support').install();
 
-import fs from 'fs';
+import fs from 'fs/promises';
 import test from 'tape';
 import { Document, Logger, TextureChannel, vec2 } from '@gltf-transform/core';
 import { MaterialsClearcoat } from '@gltf-transform/extensions';
-import { Mode, mockCommandExistsSync, mockSpawnSync, toktx } from '../';
+import { Mode, mockCommandExists, mockSpawn, toktx } from '../';
 
 const { R, G } = TextureChannel;
 
@@ -61,16 +61,16 @@ async function getParams(options: Record<string, unknown>, size: vec2, channels 
 	}
 
 	let actualParams: string[];
-	mockSpawnSync((_, params: string[]) => {
+	mockSpawn(async (_, params: string[]) => {
 		// Mock `toktx` version check.
 		if (params.join() === '--version') return { status: 0, stdout: 'v4.0.0' };
 
 		// Mock `toktx` compression.
 		actualParams = params;
-		fs.writeFileSync(params[params.length - 2], new Uint8Array(8));
+		await fs.writeFile(params[params.length - 2], new Uint8Array(8));
 		return { status: 0 };
 	});
-	mockCommandExistsSync(() => true);
+	mockCommandExists(() => Promise.resolve(true));
 
 	await doc.transform(toktx(options));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6697,6 +6697,13 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -9460,3 +9467,8 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==


### PR DESCRIPTION
Parallelize compression (~4x faster for some models with many textures)

Uses p-limit for a concurrency pool
Read files async when doing texture compression.
Make the number of concurrent toktx jobs a command-line argument.
If a texture in a model fails to compress, don’t bail.