### PR TITLE
Allow transform stages to detect later stages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
+packages/functions/src/**
+packages/cli/src/**
 **/dist
 **/in
 **/out

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,6 +1,6 @@
 /** @module core */
 
-export { Document, Transform } from './document';
+export { Document, Transform, TransformContext } from './document';
 export { JSONDocument } from './json-document';
 export { Extension } from './extension';
 export {

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -22,7 +22,11 @@ import {
 } from './properties';
 import { Logger } from './utils';
 
-export type Transform = (doc: Document) => void;
+export interface TransformContext {
+	stack: string[];
+}
+
+export type Transform = (doc: Document, context?: TransformContext) => void;
 
 /**
  * # Document
@@ -190,8 +194,9 @@ export class Document {
 	 * @param transforms List of synchronous transformation functions to apply.
 	 */
 	public async transform(...transforms: Transform[]): Promise<this> {
+		const stack = transforms.map((fn) => fn.name);
 		for (const transform of transforms) {
-			await transform(this);
+			await transform(this, { stack });
 		}
 		return this;
 	}

--- a/packages/functions/src/center.ts
+++ b/packages/functions/src/center.ts
@@ -1,5 +1,6 @@
 import { Document, Transform, vec3 } from '@gltf-transform/core';
 import { bounds } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'center';
 
@@ -24,7 +25,7 @@ const CENTER_DEFAULTS: Required<CenterOptions> = {pivot: 'center'};
 export function center (_options: CenterOptions = CENTER_DEFAULTS): Transform {
 	const options = {...CENTER_DEFAULTS, ..._options} as Required<CenterOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
 		const isAnimated = root.listAnimations().length > 0 || root.listSkins().length > 0;
@@ -69,6 +70,6 @@ export function center (_options: CenterOptions = CENTER_DEFAULTS): Transform {
 		});
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 
-}
+};

--- a/packages/functions/src/colorspace.ts
+++ b/packages/functions/src/colorspace.ts
@@ -1,4 +1,5 @@
 import { Accessor, Document, Primitive, Transform, vec3 } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'colorspace';
 
@@ -15,7 +16,7 @@ export interface ColorspaceOptions {
  */
 export function colorspace (options: ColorspaceOptions): Transform {
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 
 		const logger = doc.getLogger();
 
@@ -67,6 +68,6 @@ export function colorspace (options: ColorspaceOptions): Transform {
 
 		logger.debug(`${NAME}: Complete.`);
 
-	};
+	});
 
-}
+};

--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -1,4 +1,5 @@
 import { Accessor, BufferUtils, Document, Logger, Material, Mesh, Primitive, PrimitiveTarget, PropertyType, Root, Texture, Transform } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'dedup';
 
@@ -42,7 +43,7 @@ export const dedup = function (_options: DedupOptions = DEDUP_DEFAULTS): Transfo
 		}
 	}
 
-	return (doc: Document): void =>  {
+	return createTransform(NAME, (doc: Document): void =>  {
 		const logger = doc.getLogger();
 
 		if (propertyTypes.has(PropertyType.ACCESSOR)) dedupAccessors(logger, doc);
@@ -51,7 +52,7 @@ export const dedup = function (_options: DedupOptions = DEDUP_DEFAULTS): Transfo
 		if (propertyTypes.has(PropertyType.MATERIAL)) dedupMaterials(logger, doc);
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 
 };
 

--- a/packages/functions/src/instance.ts
+++ b/packages/functions/src/instance.ts
@@ -1,5 +1,6 @@
 import { Document, Logger, MathUtils, Mesh, Node, Transform, vec3, vec4 } from '@gltf-transform/core';
 import { InstancedMesh, MeshGPUInstancing } from '@gltf-transform/extensions';
+import { createTransform } from './utils';
 
 const NAME = 'instance';
 
@@ -16,7 +17,7 @@ export function instance (_options: InstanceOptions = INSTANCE_DEFAULTS): Transf
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const options = {...INSTANCE_DEFAULTS, ..._options} as Required<InstanceOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
 		const batchExtension = doc.createExtension(MeshGPUInstancing);
@@ -97,7 +98,7 @@ export function instance (_options: InstanceOptions = INSTANCE_DEFAULTS): Transf
 		}
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 
 }
 

--- a/packages/functions/src/metal-rough.ts
+++ b/packages/functions/src/metal-rough.ts
@@ -1,6 +1,6 @@
 import { Document, Texture, Transform } from '@gltf-transform/core';
 import { MaterialsIOR, MaterialsPBRSpecularGlossiness, MaterialsSpecular, PBRSpecularGlossiness } from '@gltf-transform/extensions';
-import { rewriteTexture } from './utils';
+import { createTransform, rewriteTexture } from './utils';
 
 const NAME = 'metalRough';
 
@@ -21,7 +21,7 @@ export function metalRough (_options: MetalRoughOptions = METALROUGH_DEFAULTS): 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const options = {...METALROUGH_DEFAULTS, ..._options} as Required<MetalRoughOptions>;
 
-	return async (doc: Document): Promise<void> => {
+	return createTransform(NAME, async (doc: Document): Promise<void> => {
 
 		const logger = doc.getLogger();
 
@@ -117,6 +117,6 @@ export function metalRough (_options: MetalRoughOptions = METALROUGH_DEFAULTS): 
 
 		logger.debug(`${NAME}: Complete.`);
 
-	};
+	});
 
 }

--- a/packages/functions/src/partition.ts
+++ b/packages/functions/src/partition.ts
@@ -1,5 +1,6 @@
 import { Document, Logger, PropertyType, Transform } from '@gltf-transform/core';
 import { prune } from './prune';
+import { createTransform } from './utils';
 
 const NAME = 'partition';
 
@@ -32,7 +33,7 @@ const partition = (_options: PartitionOptions = PARTITION_DEFAULTS): Transform =
 
 	const options = {...PARTITION_DEFAULTS, ..._options} as Required<PartitionOptions>;
 
-	return async (doc: Document): Promise<void> => {
+	return createTransform(NAME, async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
 
 		if (options.meshes !== false) partitionMeshes(doc, logger, options);
@@ -45,7 +46,7 @@ const partition = (_options: PartitionOptions = PARTITION_DEFAULTS): Transform =
 		await doc.transform(prune({propertyTypes: [PropertyType.BUFFER]}));
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 
 };
 

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -1,4 +1,5 @@
 import { AnimationChannel, Document, Graph, Property, PropertyType, Root, Transform } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'prune';
 
@@ -44,7 +45,7 @@ export const prune = function (_options: PruneOptions = PRUNE_DEFAULTS): Transfo
 	const options = {...PRUNE_DEFAULTS, ..._options} as Required<PruneOptions>;
 	const propertyTypes = options.propertyTypes;
 
-	return (doc: Document): void =>  {
+	return createTransform(NAME, (doc: Document): void =>  {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
 		const graph = doc.getGraph();
@@ -139,6 +140,6 @@ export const prune = function (_options: PruneOptions = PRUNE_DEFAULTS): Transfo
 			disposed[prop.propertyType]++;
 		}
 
-	};
+	});
 
 };

--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -21,6 +21,7 @@ import { fromRotationTranslationScale, fromScaling, invert, multiply as multiply
 import { max, min, scale, transformMat4 } from 'gl-matrix/vec3';
 import { MeshQuantization } from '@gltf-transform/extensions';
 import { prune } from './prune';
+import { createTransform } from './utils';
 
 const NAME = 'quantize';
 
@@ -80,7 +81,7 @@ export const QUANTIZE_DEFAULTS: Required<QuantizeOptions> = {
 const quantize = (_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transform => {
 	const options = { ...QUANTIZE_DEFAULTS, ..._options } as Required<QuantizeOptions>;
 
-	return async (doc: Document): Promise<void> => {
+	return createTransform(NAME, async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
 
@@ -116,7 +117,7 @@ const quantize = (_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transform => {
 		);
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 };
 
 function quantizePrimitive(

--- a/packages/functions/src/reorder.ts
+++ b/packages/functions/src/reorder.ts
@@ -1,6 +1,6 @@
 import { Accessor, Document, GLTF, Primitive, PropertyType, Transform } from '@gltf-transform/core';
 import { prune } from './prune';
-import { SetMap } from './utils';
+import { createTransform, SetMap } from './utils';
 import type { MeshoptEncoder } from 'meshoptimizer';
 
 const NAME = 'reorder';
@@ -46,7 +46,7 @@ export function reorder (_options: ReorderOptions = REORDER_DEFAULTS): Transform
 	const options = {...REORDER_DEFAULTS, ..._options} as Required<ReorderOptions>;
 	const encoder = options.encoder;
 
-	return async (doc: Document): Promise<void> => {
+	return createTransform(NAME, async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
 
 		await encoder.ready;
@@ -95,7 +95,7 @@ export function reorder (_options: ReorderOptions = REORDER_DEFAULTS): Transform
 		} else {
 			logger.debug(`${NAME}: Complete.`);
 		}
-	};
+	});
 }
 
 function remapAttribute(attribute: Accessor, remap: Uint32Array, dstCount: number) {

--- a/packages/functions/src/resample.ts
+++ b/packages/functions/src/resample.ts
@@ -1,4 +1,5 @@
-import { Accessor, AnimationSampler, Document, Root, Transform } from '@gltf-transform/core';
+import { Accessor, AnimationSampler, Document, Root, Transform, TransformContext } from '@gltf-transform/core';
+import { createTransform, isTransformPending } from './utils';
 
 const NAME = 'resample';
 
@@ -17,7 +18,7 @@ export const resample = (_options: ResampleOptions = RESAMPLE_DEFAULTS): Transfo
 
 	const options = {...RESAMPLE_DEFAULTS, ..._options} as Required<ResampleOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document, context?: TransformContext): void => {
 		const accessorsVisited = new Set<Accessor>();
 		const accessorsCountPrev = doc.getRoot().listAccessors().length;
 		const logger = doc.getLogger();
@@ -52,7 +53,7 @@ export const resample = (_options: ResampleOptions = RESAMPLE_DEFAULTS): Transfo
 			if (!used) accessor.dispose();
 		}
 
-		if (doc.getRoot().listAccessors().length > accessorsCountPrev) {
+		if (doc.getRoot().listAccessors().length > accessorsCountPrev && !isTransformPending(context, NAME, 'dedup')) {
 			logger.warn(
 				`${NAME}: Resampling required copying accessors, some of which may be duplicates.`
 				+ ' Consider using "dedup" to consolidate any duplicates.'
@@ -64,7 +65,7 @@ export const resample = (_options: ResampleOptions = RESAMPLE_DEFAULTS): Transfo
 		}
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 
 };
 

--- a/packages/functions/src/sequence.ts
+++ b/packages/functions/src/sequence.ts
@@ -1,4 +1,5 @@
 import { Accessor, AnimationChannel, AnimationSampler, Document, Transform } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'sequence';
 
@@ -26,7 +27,7 @@ const SEQUENCE_DEFAULTS: Required<SequenceOptions> = {
 export function sequence (_options: SequenceOptions = SEQUENCE_DEFAULTS): Transform {
 	const options = {...SEQUENCE_DEFAULTS, ..._options} as Required<SequenceOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
@@ -80,6 +81,6 @@ export function sequence (_options: SequenceOptions = SEQUENCE_DEFAULTS): Transf
 
 		logger.debug(`${NAME}: Complete.`);
 
-	};
+	});
 
 }

--- a/packages/functions/src/tangents.ts
+++ b/packages/functions/src/tangents.ts
@@ -1,4 +1,5 @@
 import { Accessor, Document, Logger, Primitive, Transform, TypedArray, uuid } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'tangents';
 
@@ -42,7 +43,7 @@ export function tangents (_options: TangentsOptions = TANGENTS_DEFAULTS): Transf
 
 	const options = {...TANGENTS_DEFAULTS, ..._options} as Required<TangentsOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 		const logger = doc.getLogger();
 		const attributeIDs = new Map<TypedArray, string>();
 		const tangentCache = new Map<string, Accessor>();
@@ -117,7 +118,7 @@ export function tangents (_options: TangentsOptions = TANGENTS_DEFAULTS): Transf
 		} else {
 			logger.debug(`${NAME}: Complete.`);
 		}
-	};
+	});
 }
 
 function getNormalTexcoord(prim: Primitive): string {

--- a/packages/functions/src/texture-resize.ts
+++ b/packages/functions/src/texture-resize.ts
@@ -2,6 +2,7 @@ import ndarray from 'ndarray';
 import { lanczos2, lanczos3 } from 'ndarray-lanczos';
 import { getPixels, savePixels } from 'ndarray-pixels';
 import { Document, Transform, vec2 } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'textureResize';
 
@@ -40,7 +41,7 @@ export const TEXTURE_RESIZE_DEFAULTS: TextureResizeOptions = {
 export function textureResize(_options: TextureResizeOptions = TEXTURE_RESIZE_DEFAULTS): Transform {
 	const options = {...TEXTURE_RESIZE_DEFAULTS, ..._options} as Required<TextureResizeOptions>;
 
-	return async (doc: Document): Promise<void> => {
+	return createTransform(NAME, async (doc: Document): Promise<void> => {
 
 		const logger = doc.getLogger();
 
@@ -105,6 +106,6 @@ export function textureResize(_options: TextureResizeOptions = TEXTURE_RESIZE_DE
 
 		logger.debug(`${NAME}: Complete.`);
 
-	};
+	});
 
 }

--- a/packages/functions/src/unweld.ts
+++ b/packages/functions/src/unweld.ts
@@ -1,4 +1,5 @@
 import { Accessor, Document, Logger, Transform, TypedArray } from '@gltf-transform/core';
+import { createTransform } from './utils';
 
 const NAME = 'unweld';
 
@@ -19,7 +20,7 @@ export function unweld (_options: UnweldOptions = UNWELD_DEFAULTS): Transform {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const options = {...UNWELD_DEFAULTS, ..._options} as Required<UnweldOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 
 		const logger = doc.getLogger();
 		const visited = new Map<Accessor, Map<Accessor, Accessor>>();
@@ -60,7 +61,7 @@ export function unweld (_options: UnweldOptions = UNWELD_DEFAULTS): Transform {
 		}
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 }
 
 function unweldAttribute(

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -1,6 +1,23 @@
 import { NdArray } from 'ndarray';
 import { getPixels, savePixels } from 'ndarray-pixels';
-import { Primitive, Texture } from '@gltf-transform/core';
+import { Primitive, Texture, Transform, TransformContext } from '@gltf-transform/core';
+
+/**
+ * Prepares a function used in an {@link Document.transform} pipeline. Use of this wrapper is
+ * optional, and plain functions may be used in transform pipelines just as well. The wrapper is
+ * used internally so earlier pipeline stages can detect and optimize based on later stages.
+ */
+export function createTransform(name: string, fn: Transform): Transform {
+	Object.defineProperty(fn, 'name', { value: name });
+	return fn;
+}
+
+export function isTransformPending(context: TransformContext | undefined, initial: string, pending: string): boolean {
+	if (!context) return false;
+	const initialIndex = context.stack.lastIndexOf(initial);
+	const pendingIndex = context.stack.lastIndexOf(pending);
+	return initialIndex < pendingIndex;
+}
 
 /** Maps pixels from source to target textures, with a per-pixel callback. */
 export async function rewriteTexture(

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -1,5 +1,5 @@
 import { Accessor, Document, Primitive, PrimitiveTarget, Transform, TypedArray } from '@gltf-transform/core';
-import { getGLPrimitiveCount } from './utils';
+import { getGLPrimitiveCount, createTransform } from './utils';
 
 const NAME = 'weld';
 
@@ -17,7 +17,7 @@ const WELD_DEFAULTS: Required<WeldOptions> = {tolerance: 1e-4};
 export function weld (_options: WeldOptions = WELD_DEFAULTS): Transform {
 	const options = {...WELD_DEFAULTS, ..._options} as Required<WeldOptions>;
 
-	return (doc: Document): void => {
+	return createTransform(NAME, (doc: Document): void => {
 		const logger = doc.getLogger();
 
 		for (const mesh of doc.getRoot().listMeshes()) {
@@ -31,7 +31,7 @@ export function weld (_options: WeldOptions = WELD_DEFAULTS): Transform {
 		}
 
 		logger.debug(`${NAME}: Complete.`);
-	};
+	});
 }
 
 /**  In-place weld, adds indices without changing number of vertices. */

--- a/packages/functions/test/utils.test.ts
+++ b/packages/functions/test/utils.test.ts
@@ -43,12 +43,12 @@ test('@gltf-transform/functions::utils | getGLPrimitiveCount', async (t) => {
 
 test('@gltf-transform/functions::utils | transform pipeline', async (t) => {
 	const doc = new Document();
-	const first = createTransform('first', (doc: Document, context?: TransformContext) => {
+	const first = createTransform('first', (_: Document, context?: TransformContext) => {
 		if (!isTransformPending(context, 'first', 'second')) {
 			throw new Error('Out of order!');
 		}
 	});
-	const second: Transform = (doc: Document, context?: TransformContext) => {};
+	const second: Transform = (_: Document) => undefined;
 
 	t.ok(doc.transform(first, second), '[a, b] OK');
 


### PR DESCRIPTION
- Fixes #399

Sets `.name` on functions used in `document.transform(...)`. This is optional; user-defined functions can omit the name for simplicity. Allows us to avoid needless warnings like in #399, and potentially to optimize out additional steps in some transforms when we can detect they'll happen later.

