### PR TITLE
Avoid meshopt compression on unquantized UVs

### DIFF
--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -132,13 +132,7 @@ export function getMeshoptMode(accessor: Accessor, usage: string): MeshoptMode {
 }
 
 export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: MeshoptFilter; bits?: number } {
-	const semantics = doc
-		.getGraph()
-		.listParentLinks(accessor)
-		.map((link) => link.getName())
-		.filter((name) => name !== 'accessor');
-
-	for (const semantic of semantics) {
+	for (const semantic of getSemantics(accessor, doc)) {
 		// Indices.
 		if (semantic === 'indices') return { filter: MeshoptFilter.NONE };
 
@@ -170,6 +164,14 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 	}
 
 	return { filter: MeshoptFilter.NONE };
+}
+
+export function getSemantics(accessor: Accessor, doc: Document): string[] {
+	return doc
+		.getGraph()
+		.listParentLinks(accessor)
+		.map((link) => link.getName())
+		.filter((name) => name !== 'accessor');
 }
 
 export function getTargetPath(accessor: Accessor): GLTF.AnimationChannelTargetPath | null {

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -132,7 +132,7 @@ export function getMeshoptMode(accessor: Accessor, usage: string): MeshoptMode {
 }
 
 export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: MeshoptFilter; bits?: number } {
-	for (const semantic of getSemantics(accessor, doc)) {
+	for (const semantic of listSemantics(accessor, doc)) {
 		// Indices.
 		if (semantic === 'indices') return { filter: MeshoptFilter.NONE };
 
@@ -166,7 +166,7 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 	return { filter: MeshoptFilter.NONE };
 }
 
-export function getSemantics(accessor: Accessor, doc: Document): string[] {
+export function listSemantics(accessor: Accessor, doc: Document): string[] {
 	return doc
 		.getGraph()
 		.listParentLinks(accessor)

--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -1,7 +1,7 @@
 import { Accessor, Buffer, BufferUtils, Extension, GLB_BUFFER, GLTF, PropertyType, ReaderContext, WriterContext } from '@gltf-transform/core';
 import { EncoderMethod, MeshoptBufferViewExtension, MeshoptFilter } from './constants';
 import { EXT_MESHOPT_COMPRESSION } from '../constants';
-import { getMeshoptFilter, getMeshoptMode, getTargetPath, prepareAccessor } from './encoder';
+import { getMeshoptFilter, getMeshoptMode, getSemantics, getTargetPath, prepareAccessor } from './encoder';
 import { isFallbackBuffer } from './decoder';
 import type { MeshoptEncoder, MeshoptDecoder } from 'meshoptimizer';
 
@@ -276,6 +276,10 @@ export class MeshoptCompression extends Extension {
 			// See: https://github.com/donmccurdy/glTF-Transform/pull/323#issuecomment-898791251
 			// Example: https://skfb.ly/6qAD8
 			if (getTargetPath(accessor) === 'weights') continue;
+
+			// See: https://github.com/donmccurdy/glTF-Transform/issues/414
+			const isTexcoord = getSemantics(accessor, this.doc).some((semantic) => semantic.startsWith('TEXCOORD_'));
+			if (isTexcoord && accessor.getComponentSize() > 2) continue;
 
 			const usage = context.getAccessorUsage(accessor);
 			const mode = getMeshoptMode(accessor, usage);


### PR DESCRIPTION
Intended to work around #414, but doesn't seem to be working yet.