### PR TITLE
Write only registered extensions from I/O

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -68,9 +68,8 @@ const io = new WebIO().registerExtensions([MaterialsUnlit]);
 const doc = await io.readGLB('unlit.glb');
 ```
 
-Reading files requires registering the necessary Extensions, but writing files does not — the
-Extension objects are already attached to the Document itself. Some extensions may require
-installing dependencies:
+Reading or writing files requires registering the necessary Extensions with the I/O class. Some
+extensions may require installing dependencies:
 
 ```typescript
 import { NodeIO } from '@gltf-transform/core';

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -128,11 +128,8 @@ export class NodeIO extends PlatformIO {
 	/** @internal */
 	private _writeGLTF(uri: string, doc: Document): void {
 		this.lastWriteBytes = 0;
-		const { json, resources } = GLTFWriter.write(doc, {
+		const { json, resources } = this.writeJSON(doc, {
 			format: Format.GLTF,
-			logger: this._logger,
-			dependencies: this._dependencies,
-			vertexLayout: this._vertexLayout,
 			basename: FileUtils.basename(uri),
 		});
 		const { _fs: fs, _path: path } = this;

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -112,10 +112,15 @@ test('@gltf-transform/core::extension | i/o', (t) => {
 	let jsonDoc;
 	let resultDoc;
 
-	// Write.
+	// Write (unregistered).
+
+	jsonDoc = new NodeIO().writeJSON(doc, options);
+	t.deepEqual(jsonDoc.json.extensionsUsed, undefined, 'write extensionsUsed (unregistered)');
+
+	// Write (registered).
 
 	jsonDoc = io.writeJSON(doc, options);
-	t.deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)yar');
 	t.equal(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
 	t.equal(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
 

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -120,7 +120,7 @@ test('@gltf-transform/core::extension | i/o', (t) => {
 	// Write (registered).
 
 	jsonDoc = io.writeJSON(doc, options);
-	t.deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)yar');
+	t.deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)');
 	t.equal(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
 	t.equal(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
 

--- a/packages/extensions/test/lights-punctual.test.ts
+++ b/packages/extensions/test/lights-punctual.test.ts
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::lights-punctual', (t) => {
 
 	t.equal(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
@@ -100,7 +100,7 @@ test('@gltf-transform/extensions::lights-punctual | i/o', (t) => {
 
 	t.equal(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -45,7 +45,7 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_clearcoat'), clearcoat, 'clearcoat is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/materials-ior.test.ts
+++ b/packages/extensions/test/materials-ior.test.ts
@@ -18,7 +18,7 @@ test('@gltf-transform/extensions::materials-ior', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_ior'), ior, 'ior is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -21,7 +21,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), specGloss, 'specGloss is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsPBRSpecularGlossiness]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-sheen', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_sheen'), sheen, 'sheen is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -24,7 +24,7 @@ test('@gltf-transform/extensions::materials-specular', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_specular'), specular, 'specular is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-transmission', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_transmission'), transmission, 'transmission is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsTransmission]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/materials-unlit.test.ts
+++ b/packages/extensions/test/materials-unlit.test.ts
@@ -1,7 +1,7 @@
 require('source-map-support').install();
 
 import test from 'tape';
-import { Document, NodeIO } from '@gltf-transform/core';
+import { Document, Material, NodeIO } from '@gltf-transform/core';
 import { MaterialsUnlit } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
@@ -20,7 +20,7 @@ test('@gltf-transform/extensions::materials-unlit', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_unlit'), unlit, 'unlit is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -24,7 +24,7 @@ test('@gltf-transform/extensions::materials-volume', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_volume'), volume, 'volume is attached');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = new NodeIO().registerExtensions([MaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');

--- a/packages/extensions/test/mesh-quantization.test.ts
+++ b/packages/extensions/test/mesh-quantization.test.ts
@@ -11,7 +11,7 @@ test('@gltf-transform/extensions::mesh-quantization', (t) => {
 	const quantizationExtension = doc.createExtension(MeshQuantization);
 	let jsonDoc;
 
-	jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	jsonDoc = new NodeIO().registerExtensions([MeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
 	t.deepEqual(jsonDoc.json.extensionsUsed, [MeshQuantization.EXTENSION_NAME], 'writes extensionsUsed');
 
 	quantizationExtension.dispose();


### PR DESCRIPTION
Extensions registered with I/O are written if used; unregistered extensions are skipped. For example, a Document with the Draco extension attached will be written uncompressed if the extension is not registered with I/O. Avoids some pathological cases where I/O can't handle the extension properly, and allows writing with a particular extension disabled, without deeper changes to the Document.

