### PR TITLE
Make extension registration idempotent

### DIFF
--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -60,12 +60,7 @@ export class NodeIO extends PlatformIO {
 
 	/** Loads a local path and returns a {@link Document} instance. */
 	public read(uri: string): Document {
-		const jsonDoc = this.readAsJSON(uri);
-		return GLTFReader.read(jsonDoc, {
-			extensions: this._extensions,
-			dependencies: this._dependencies,
-			logger: this._logger,
-		});
+		return this.readJSON(this.readAsJSON(uri));
 	}
 
 	/** Loads a local path and returns a {@link JSONDocument} struct, without parsing. */

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -69,6 +69,9 @@ export abstract class PlatformIO {
 
 	/** @internal */
 	protected _readResourcesInternal(jsonDoc: JSONDocument): void {
+		// NOTICE: This method may be called more than once during the loading
+		// process (e.g. WebIO.read) and should handle that safely.
+
 		function resolveResource(resource: GLTF.IBuffer | GLTF.IImage) {
 			if (!resource.uri || resource.uri in jsonDoc.resources) return;
 

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -29,9 +29,9 @@ type PublicWriterOptions = Partial<Pick<WriterOptions, 'format' | 'basename'>>;
  */
 export abstract class PlatformIO {
 	protected _logger = Logger.DEFAULT_INSTANCE;
-	protected _extensions: typeof Extension[] = [];
-	protected _dependencies: { [key: string]: unknown } = {};
-	protected _vertexLayout = VertexLayout.INTERLEAVED;
+	private _extensions = new Set<typeof Extension>();
+	private _dependencies: { [key: string]: unknown } = {};
+	private _vertexLayout = VertexLayout.INTERLEAVED;
 
 	/** Sets the {@link Logger} used by this I/O instance. Defaults to Logger.DEFAULT_INSTANCE. */
 	public setLogger(logger: Logger): this {
@@ -42,7 +42,7 @@ export abstract class PlatformIO {
 	/** Registers extensions, enabling I/O class to read and write glTF assets requiring them. */
 	public registerExtensions(extensions: typeof Extension[]): this {
 		for (const extension of extensions) {
-			this._extensions.push(extension);
+			this._extensions.add(extension);
 			extension.register();
 		}
 		return this;
@@ -104,7 +104,7 @@ export abstract class PlatformIO {
 		jsonDoc = this._copyJSON(jsonDoc);
 		this._readResourcesInternal(jsonDoc);
 		return GLTFReader.read(jsonDoc, {
-			extensions: this._extensions,
+			extensions: Array.from(this._extensions),
 			dependencies: this._dependencies,
 			logger: this._logger,
 		});
@@ -121,7 +121,7 @@ export abstract class PlatformIO {
 			logger: this._logger,
 			vertexLayout: this._vertexLayout,
 			dependencies: { ...this._dependencies },
-			extensions: [...this._extensions],
+			extensions: Array.from(this._extensions),
 		} as Required<WriterOptions>);
 	}
 


### PR DESCRIPTION
In this code...

```ts
import { WebIO } from '@gltf-transform/core';
import { MaterialsVolume, KHRONOS_EXTENSIONS } from '@gltf-transform/extensions';

const io = new WebIO().registerExtensions([MaterialsVolume, ...KHRONOS_EXTENSIONS]);
```

...`MaterialsVolume` is registered twice, because it occurs in `KHRONOS_EXTENSIONS`. That's probably not obvious to users, and should 'just work' without causing weird edge cases. I'm not aware that problems occur now, but it's hard to guarantee that for all extensions, so the I/O classes should just ensure that additional registrations for the same extension are de-duplicated.