### PR TITLE
Add dequantize() function

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
 import { Logger, NodeIO, PropertyType, VertexLayout, vec2 } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
-import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, textureResize, unweld, weld, reorder } from '@gltf-transform/functions';
+import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, textureResize, unweld, weld, reorder, dequantize } from '@gltf-transform/functions';
 import { InspectFormat, inspect } from './inspect';
 import { DRACO_DEFAULTS, DracoCLIOptions, ETC1S_DEFAULTS, Filter, Mode, UASTC_DEFAULTS, draco, ktxfix, merge, toktx, unlit, meshopt, MeshoptCLIOptions } from './transforms';
 import { Session, formatBytes } from './util';
@@ -479,6 +479,27 @@ Requires KHR_mesh_quantization support.`.trim())
 		const pattern = minimatch.makeRe(String(options.pattern), {nocase: true});
 		return Session.create(io, logger, args.input, args.output)
 			.transform(quantize({...options, pattern}));
+	});
+
+// DEQUANTIZE
+program
+	.command('dequantize', 'Dequantize geometry')
+	.help(`
+Removes quantization from an asset. This will increase the size of the asset on
+disk and in memory, but may be necessary for applications that don't support
+quantization.
+
+Removes KHR_mesh_quantization, if present.`.trim())
+	.argument('<input>', 'Path to read glTF 2.0 (.glb, .gltf) input')
+	.argument('<output>', 'Path to write output')
+	.option('--pattern <pattern>', 'Pattern for vertex attributes (case-insensitive glob)', {
+		validator: program.STRING,
+		default: '!JOINTS_*',
+	})
+	.action(({args, options, logger}) => {
+		const pattern = minimatch.makeRe(String(options.pattern), {nocase: true});
+		return Session.create(io, logger, args.input, args.output)
+			.transform(dequantize({...options, pattern}));
 	});
 
 // WELD

--- a/packages/functions/src/dequantize.ts
+++ b/packages/functions/src/dequantize.ts
@@ -8,13 +8,13 @@ const NAME = 'dequantize';
 export interface DequantizeOptions {
 	/**
 	 * Pattern (regex) used to filter vertex attribute semantics for quantization.
-	 * Default: `/^(JOINTS)(_\d+)$/`.
+	 * Default: `/^((?!JOINTS)(_\d+))*$/`.
 	 */
 	pattern?: RegExp;
 }
 
 const DEQUANTIZE_DEFAULTS: DequantizeOptions = {
-	pattern: /^(JOINTS)(_\d+)$/,
+	pattern: /^((?!JOINTS)(_\d+))*$/,
 };
 
 /**
@@ -43,7 +43,7 @@ function dequantizePrimitive(prim: Primitive, options: Required<DequantizeOption
 	}
 	for (const target of prim.listTargets()) {
 		for (const semantic of target.listSemantics()) {
-			dequantizeAttribute(semantic, prim.getAttribute(semantic)!, options);
+			dequantizeAttribute(semantic, target.getAttribute(semantic)!, options);
 		}
 	}
 }

--- a/packages/functions/src/dequantize.ts
+++ b/packages/functions/src/dequantize.ts
@@ -8,13 +8,13 @@ const NAME = 'dequantize';
 export interface DequantizeOptions {
 	/**
 	 * Pattern (regex) used to filter vertex attribute semantics for quantization.
-	 * Default: `/^((?!JOINTS)(_\d+))*$/`.
+	 * Default: `/^((?!JOINTS_).)*$/`.
 	 */
 	pattern?: RegExp;
 }
 
 const DEQUANTIZE_DEFAULTS: DequantizeOptions = {
-	pattern: /^((?!JOINTS)(_\d+))*$/,
+	pattern: /^((?!JOINTS_).)*$/,
 };
 
 /**

--- a/packages/functions/src/dequantize.ts
+++ b/packages/functions/src/dequantize.ts
@@ -1,0 +1,65 @@
+import { Accessor, Document, Primitive, Transform } from '@gltf-transform/core';
+import { MeshQuantization } from '@gltf-transform/extensions';
+import { createTransform } from './utils';
+
+const NAME = 'dequantize';
+
+/** Options for the {@link dequantize} function. */
+export interface DequantizeOptions {
+	/**
+	 * Pattern (regex) used to filter vertex attribute semantics for quantization.
+	 * Default: `/^(JOINTS)(_\d+)$/`.
+	 */
+	pattern?: RegExp;
+}
+
+const DEQUANTIZE_DEFAULTS: DequantizeOptions = {
+	pattern: /^(JOINTS)(_\d+)$/,
+};
+
+/**
+ * Dequantize {@link Primitive Primitives}, removing {@link MeshQuantization `KHR_mesh_quantization`}
+ * if present. Dequantization will increase the size of the mesh on disk and in memory, but may be
+ * necessary for compatibility with applications that don't support quantization.
+ */
+export function dequantize(_options: DequantizeOptions = DEQUANTIZE_DEFAULTS): Transform {
+	const options = {...DEQUANTIZE_DEFAULTS, ..._options} as Required<DequantizeOptions>;
+
+	return createTransform(NAME, (doc: Document): void => {
+		const logger = doc.getLogger();
+		for (const mesh of doc.getRoot().listMeshes()) {
+			for (const prim of mesh.listPrimitives()) {
+				dequantizePrimitive(prim, options);
+			}
+		}
+		doc.createExtension(MeshQuantization).dispose();
+		logger.debug(`${NAME}: Complete.`);
+	});
+}
+
+function dequantizePrimitive(prim: Primitive, options: Required<DequantizeOptions>): void {
+	for (const semantic of prim.listSemantics()) {
+		dequantizeAttribute(semantic, prim.getAttribute(semantic)!, options);
+	}
+	for (const target of prim.listTargets()) {
+		for (const semantic of target.listSemantics()) {
+			dequantizeAttribute(semantic, prim.getAttribute(semantic)!, options);
+		}
+	}
+}
+
+function dequantizeAttribute(semantic: string, attribute: Accessor, options: Required<DequantizeOptions>): void {
+	if (!attribute.getArray()) return;
+	if (!options.pattern.test(semantic)) return;
+	if (attribute.getComponentSize() >= 4) return;
+
+	const srcArray = attribute.getArray()!;
+	const dstArray = new Float32Array(srcArray.length);
+
+	for (let i = 0, il = attribute.getCount(), el = [] as number[]; i < il; i++) {
+		el = attribute.getElement(i, el);
+		attribute.setArray(dstArray).setElement(i, el).setArray(srcArray);
+	}
+
+	attribute.setArray(dstArray).setNormalized(false);
+}

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -41,6 +41,7 @@ export { bounds } from '@gltf-transform/core'; // backwards compatibility, remov
 export * from './center';
 export * from './colorspace';
 export * from './dedup';
+export * from './dequantize';
 export * from './inspect';
 export * from './instance';
 export * from './metal-rough';

--- a/packages/functions/test/dequantize.test.ts
+++ b/packages/functions/test/dequantize.test.ts
@@ -1,0 +1,78 @@
+require('source-map-support').install();
+
+import test from 'tape';
+import { bbox, bounds, Document, Logger, Primitive, PrimitiveTarget, Scene, vec3 } from '@gltf-transform/core';
+import { dequantize } from '../';
+
+const logger = new Logger(Logger.Verbosity.WARN);
+
+test('@gltf-transform/functions::dequantize', async (t) => {
+	const doc = new Document().setLogger(logger);
+	const scene = createScene(doc);
+	const node = doc.getRoot().listNodes()[0];
+	const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+
+	const bboxScenePrev = bounds(scene);
+	const bboxNodePrev = bounds(node);
+	const bboxMeshPrev = primBounds(prim);
+
+	t.deepEquals(bboxScenePrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
+	t.deepEquals(bboxNodePrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - node');
+	t.deepEquals(bboxMeshPrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - mesh');
+
+	await doc.transform(dequantize());
+
+	const bboxScene = bounds(scene);
+	const bboxNode = bounds(node);
+	const bboxMesh = primBounds(prim);
+
+	t.ok(prim.getAttribute('POSITION').getArray() instanceof Float32Array, 'position - float32');
+	t.ok(prim.getAttribute('JOINTS_0').getArray() instanceof Uint8Array, 'joints - uint8');
+	t.ok(prim.getAttribute('WEIGHTS_0').getArray() instanceof Float32Array, 'weights - float32');
+	t.deepEquals(bboxScene, bboxScenePrev, 'bbox - scene');
+	t.deepEquals(bboxNode, bboxNodePrev, 'bbox - nodeA');
+	t.deepEquals(bboxMesh, bboxMeshPrev, 'bbox - meshA');
+	t.equals(doc.getRoot().listNodes().length, 1, 'total nodes');
+	t.equals(doc.getRoot().listAccessors().length, 3, 'total accessors');
+	t.end();
+});
+
+/* UTILITIES */
+
+function primBounds(prim: Primitive | PrimitiveTarget): bbox {
+	return {
+		min: prim.getAttribute('POSITION').getMinNormalized([]) as vec3,
+		max: prim.getAttribute('POSITION').getMaxNormalized([]) as vec3,
+	};
+}
+
+function createScene(doc: Document): Scene {
+	const prim = doc
+		.createPrimitive()
+		.setMode(Primitive.Mode.TRIANGLES)
+		.setAttribute(
+			'POSITION',
+			doc
+				.createAccessor('POSITION')
+				.setType('VEC3')
+				.setArray(new Uint16Array([0, 0, 0, 10, 15, 8, 50, 50, 50, 15, 15, 0, 10, 10, 0]))
+		)
+		.setAttribute(
+			'JOINTS_0',
+			doc
+				.createAccessor('JOINTS_0')
+				.setType('VEC4')
+				.setArray(new Uint8Array([0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0]))
+		)
+		.setAttribute(
+			'WEIGHTS_0',
+			doc
+				.createAccessor('WEIGHTS_0')
+				.setType('VEC4')
+				.setArray(new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0]))
+		);
+
+	const scene = doc.createScene();
+	scene.addChild(doc.createNode().setMesh(doc.createMesh().addPrimitive(prim)));
+	return scene;
+}


### PR DESCRIPTION
Adds `dequantize()` function, removing `KHR_mesh_quantization` and converting vertex attributes to `float32`.


Usage:

```js
import { dequantize } from '@gltf-transform/functions';
await document.transform(dequantize());
```

```shell
gltf-transform dequantize input.glb output.glb
```

Remaining:

- [x] Unit tests