### PR TITLE
NodeIO: Async read/write

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -66,7 +66,7 @@ import { MaterialsUnlit } from '@gltf-transform/extensions';
 const io = new WebIO().registerExtensions([MaterialsUnlit]);
 
 // Read a file that requires the KHR_materials_unlit extension.
-const doc = await io.readGLB('unlit.glb');
+const document = await io.readGLB('unlit.glb');
 ```
 
 Reading or writing files requires registering the necessary Extensions with the I/O class. Some
@@ -87,7 +87,7 @@ const io = new NodeIO()
     'draco3d.encoder': await draco3d.createEncoderModule(), // Optional.
   });
 
-const doc = io.read('compressed.glb');
+const document = await io.read('compressed.glb');
 ```
 
 ## Custom extensions

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-import fs from 'fs/promises';
+import {promises as fs} from 'fs';
 import minimatch from 'minimatch';
 import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-import fs from 'fs';
+import fs from 'fs/promises';
 import minimatch from 'minimatch';
 import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
@@ -67,7 +67,7 @@ Use --format=csv or --format=md for alternative display formats.
 	.action(async ({args, options, logger}) => {
 		io.setLogger(logger as unknown as Logger);
 		await inspect(
-			io.readAsJSON(args.input as string),
+			await io.readAsJSON(args.input as string),
 			io,
 			logger as unknown as Logger,
 			options.format as InspectFormat
@@ -268,16 +268,14 @@ and can be skipped. Other compression strategies, like Meshopt and quantization,
 work best when combined with gzip.
 `)
 	.argument('<input>', INPUT_DESC)
-	.action(({args, logger}) => {
-		const inBuffer = fs.readFileSync(args.input as string);
-		return gzip(inBuffer)
-			.then((outBuffer) => {
-				const fileName = args.input + '.gz';
-				const inSize = formatBytes(inBuffer.byteLength);
-				const outSize = formatBytes(outBuffer.byteLength);
-				fs.writeFileSync(fileName, outBuffer);
-				logger.info(`Created ${fileName} (${inSize} → ${outSize})`);
-			});
+	.action(async ({args, logger}) => {
+		const inBuffer = await fs.readFile(args.input as string);
+		const outBuffer = await gzip(inBuffer);
+		const fileName = args.input + '.gz';
+		const inSize = formatBytes(inBuffer.byteLength);
+		const outSize = formatBytes(outBuffer.byteLength);
+		await fs.writeFile(fileName, outBuffer);
+		logger.info(`Created ${fileName} (${inSize} → ${outSize})`);
 	});
 
 program.command('', '\n\n🌍 SCENE ────────────────────────────────────────────');
@@ -670,7 +668,7 @@ preserving original aspect ratio. Texture dimensions are never increased.
 		const pattern = options.pattern
 			? minimatch.makeRe(String(options.pattern), {nocase: true})
 			: null;
-		return await Session.create(io, logger, args.input, args.output)
+		return Session.create(io, logger, args.input, args.output)
 			.transform(textureResize({
 				size: [options.width, options.height] as vec2,
 				filter: options.filter as TextureResizeFilter,

--- a/packages/cli/src/inspect.ts
+++ b/packages/cli/src/inspect.ts
@@ -47,7 +47,7 @@ export async function inspect (
 	// Parse.
 	let doc;
 	try {
-		doc = io.readJSON(jsonDoc);
+		doc = await io.readJSON(jsonDoc);
 	} catch (e) {
 		logger.warn('Unable to parse document.');
 		throw e;

--- a/packages/cli/src/transforms/merge.ts
+++ b/packages/cli/src/transforms/merge.ts
@@ -13,11 +13,11 @@ const merge = (options: MergeOptions): Transform => {
 
 	const {paths, io} = options;
 
-	return (doc: Document): void => {
+	return async (doc: Document): Promise<void> => {
 
 		const logger = doc.getLogger();
 
-		paths.forEach((path, index) => {
+		await Promise.all(paths.map(async (path, index) => {
 			logger.debug(`Merging ${index + 1} / ${paths.length}, ${path}`);
 
 			const basename = FileUtils.basename(path);
@@ -28,11 +28,11 @@ const merge = (options: MergeOptions): Transform => {
 					.setMimeType(ImageUtils.extensionToMimeType(extension))
 					.setURI(basename + '.' + extension);
 			} else if (['gltf', 'glb'].includes(extension)) {
-				doc.merge(io.read(path));
+				doc.merge(await io.read(path));
 			} else {
 				throw new Error(`Unknown file extension: "${extension}".`);
 			}
-		});
+		}));
 
 		if (!options.partition) {
 			const buffer = doc.getRoot().listBuffers()[0];

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -92,7 +92,7 @@ export class Session {
 
 	public async transform (...transforms: Transform[]): Promise<void> {
 		const doc = this._input
-			? this._io.read(this._input).setLogger(this._logger)
+			? (await this._io.read(this._input)).setLogger(this._logger)
 			: new Document().setLogger(this._logger);
 
 		// Warn and remove lossy compression, to avoid increasing loss on round trip.
@@ -107,7 +107,7 @@ export class Session {
 
 		await doc.transform(...transforms);
 
-		this._io.write(this._output, doc);
+		await this._io.write(this._output, doc);
 
 		const {lastReadBytes, lastWriteBytes} = this._io;
 		if (!this._input) {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -18,10 +18,10 @@ test('@gltf-transform/cli::copy', async (t) => {
 	doc.createBuffer();
 	doc.createAccessor().setArray(new Uint8Array([1, 2, 3]));
 	doc.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
-	io.write(input, doc);
+	await io.write(input, doc);
 
-	return program.exec(['copy', input, output]).then(() => {
-		const doc2 = io.read(output);
+	return program.exec(['copy', input, output]).then(async () => {
+		const doc2 = await io.read(output);
 		t.ok(doc2, 'roundtrip document');
 		t.equal(doc2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'roundtrip material');
 	});
@@ -36,7 +36,7 @@ test('@gltf-transform/cli::validate', async (_t) => {
 	doc.createBuffer();
 	doc.createAccessor().setArray(new Uint8Array([1, 2, 3]));
 	doc.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
-	io.write(input, doc);
+	await io.write(input, doc);
 
 	return program.exec(['validate', input], { silent: true });
 });
@@ -53,7 +53,7 @@ test('@gltf-transform/cli::inspect', async (_t) => {
 	doc.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
 	doc.createScene('MyScene').addChild(doc.createNode('MyNode'));
 	doc.createAnimation();
-	io.write(input, doc);
+	await io.write(input, doc);
 
 	return program.exec(['inspect', input], { silent: true });
 });
@@ -72,7 +72,7 @@ test('@gltf-transform/cli::merge', async (t) => {
 	docA.createAccessor()
 		.setArray(new Uint8Array([1, 2, 3]))
 		.setBuffer(bufA);
-	io.write(inputA, docA);
+	await io.write(inputA, docA);
 
 	const docB = new Document();
 	docB.createScene('SceneB');
@@ -80,7 +80,7 @@ test('@gltf-transform/cli::merge', async (t) => {
 	docB.createAccessor()
 		.setArray(new Uint8Array([1, 2, 3]))
 		.setBuffer(bufB);
-	io.write(inputB, docB);
+	await io.write(inputB, docB);
 
 	fs.writeFileSync(inputC, Buffer.from([1, 2, 3, 4, 5]));
 
@@ -88,8 +88,8 @@ test('@gltf-transform/cli::merge', async (t) => {
 		program
 			// https://github.com/mattallty/Caporal.js/issues/195
 			.exec(['merge', [inputA, inputB, inputC, output].join(',')], { silent: true })
-			.then(() => {
-				const doc = io.read(output);
+			.then(async () => {
+				const doc = await io.read(output);
 				const sceneNames = doc
 					.getRoot()
 					.listScenes()

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -44,16 +44,17 @@ export type Transform = (doc: Document, context?: TransformContext) => void;
  * 'create' methods on the document. Resources are destroyed by calling {@link Property.dispose}().
  *
  * ```ts
+ * import fs from 'fs/promises';
  * import { Document } from '@gltf-transform/core';
  * import { dedup } from '@gltf-transform/functions';
  *
  * const doc = new Document();
  *
  * const texture1 = doc.createTexture('myTexture')
- * 	.setImage(arrayBuffer)
+ * 	.setImage(await fs.readFile('path/to/image.png'))
  * 	.setMimeType('image/png');
  * const texture2 = doc.createTexture('myTexture2')
- * 	.setImage(arrayBuffer)
+ * 	.setImage(await fs.readFile('path/to/image2.png'))
  * 	.setMimeType('image/png');
  *
  * // Document containing duplicate copies of the same texture.

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -17,8 +17,6 @@ import { PlatformIO } from './platform-io';
  * Usage:
  *
  * ```typescript
- * const fs = require('fs');
- * const path = require('path');
  * const { NodeIO } = require('@gltf-transform/core');
  *
  * const io = new NodeIO();
@@ -29,8 +27,8 @@ import { PlatformIO } from './platform-io';
  * document = await io.readBinary(glb);   // Uint8Array → Document
  *
  * // Write.
- * await io.write('model.glb', doc);      // → void
- * const glb = await io.writeBinary(doc); // Document → Uint8Array
+ * await io.write('model.glb', document);      // → void
+ * const glb = await io.writeBinary(document); // Document → Uint8Array
  * ```
  *
  * @category I/O

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -47,7 +47,7 @@ export class NodeIO extends PlatformIO {
 	constructor() {
 		super();
 		// Excluded from browser builds with 'package.browser' field.
-		this._fs = require('fs/promises');
+		this._fs = require('fs').promises;
 		this._path = require('path');
 	}
 

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -48,7 +48,7 @@ export class NodeIO extends PlatformIO {
 	constructor() {
 		super();
 		// Excluded from browser builds with 'package.browser' field.
-		this._fs = require('fs');
+		this._fs = require('fs/promises');
 		this._path = require('path');
 	}
 
@@ -57,20 +57,20 @@ export class NodeIO extends PlatformIO {
 	 */
 
 	/** Loads a local path and returns a {@link Document} instance. */
-	public read(uri: string): Document {
-		return this.readJSON(this.readAsJSON(uri));
+	public async read(uri: string): Promise<Document> {
+		return this.readJSON(await this.readAsJSON(uri));
 	}
 
 	/** Loads a local path and returns a {@link JSONDocument} struct, without parsing. */
-	public readAsJSON(uri: string): JSONDocument {
+	public async readAsJSON(uri: string): Promise<JSONDocument> {
 		const isGLB = !!(uri.match(/\.glb$/) || uri.match(/^data:application\/octet-stream;/));
 		return isGLB ? this._readGLB(uri) : this._readGLTF(uri);
 	}
 
 	/** Writes a {@link Document} instance to a local path. */
-	public write(uri: string, doc: Document): void {
+	public async write(uri: string, doc: Document): Promise<void> {
 		const isGLB = !!uri.match(/\.glb$/);
-		isGLB ? this._writeGLB(uri, doc) : this._writeGLTF(uri, doc);
+		await (isGLB ? this._writeGLB(uri, doc) : this._writeGLTF(uri, doc));
 	}
 
 	/**********************************************************************************************
@@ -78,16 +78,17 @@ export class NodeIO extends PlatformIO {
 	 */
 
 	/** @internal */
-	protected _readResourcesExternal(jsonDoc: JSONDocument, dir: string): void {
+	private async _readResourcesExternal(jsonDoc: JSONDocument, dir: string): Promise<void> {
 		const images = jsonDoc.json.images || [];
 		const buffers = jsonDoc.json.buffers || [];
-		[...images, ...buffers].forEach((resource: GLTF.IBuffer | GLTF.IImage) => {
+		const resources = [...images, ...buffers].map(async (resource: GLTF.IBuffer | GLTF.IImage) => {
 			if (resource.uri && !resource.uri.match(/data:/)) {
 				const absURI = this._path.resolve(dir, resource.uri);
-				jsonDoc.resources[resource.uri] = this._fs.readFileSync(absURI);
+				jsonDoc.resources[resource.uri] = await this._fs.readFile(absURI);
 				this.lastReadBytes += jsonDoc.resources[resource.uri].byteLength;
 			}
 		});
+		await Promise.all(resources);
 	}
 
 	/**********************************************************************************************
@@ -95,32 +96,32 @@ export class NodeIO extends PlatformIO {
 	 */
 
 	/** @internal */
-	private _readGLB(uri: string): JSONDocument {
-		const buffer: Buffer = this._fs.readFileSync(uri);
+	private async _readGLB(uri: string): Promise<JSONDocument> {
+		const buffer: Buffer = await this._fs.readFile(uri);
 		this.lastReadBytes = buffer.byteLength;
 		const jsonDoc = this._binaryToJSON(buffer);
 		// Read external resources first, before Data URIs are replaced.
-		this._readResourcesExternal(jsonDoc, this._path.dirname(uri));
-		this._readResourcesInternal(jsonDoc);
+		await this._readResourcesExternal(jsonDoc, this._path.dirname(uri));
+		await this._readResourcesInternal(jsonDoc);
 		return jsonDoc;
 	}
 
 	/** @internal */
-	private _readGLTF(uri: string): JSONDocument {
+	private async _readGLTF(uri: string): Promise<JSONDocument> {
 		this.lastReadBytes = 0;
-		const jsonContent = this._fs.readFileSync(uri, 'utf8');
+		const jsonContent = await this._fs.readFile(uri, 'utf8');
 		this.lastReadBytes += jsonContent.length;
 		const jsonDoc = { json: JSON.parse(jsonContent), resources: {} } as JSONDocument;
 		// Read external resources first, before Data URIs are replaced.
-		this._readResourcesExternal(jsonDoc, this._path.dirname(uri));
-		this._readResourcesInternal(jsonDoc);
+		await this._readResourcesExternal(jsonDoc, this._path.dirname(uri));
+		await this._readResourcesInternal(jsonDoc);
 		return jsonDoc;
 	}
 
 	/** @internal */
-	private _writeGLTF(uri: string, doc: Document): void {
+	private async _writeGLTF(uri: string, doc: Document): Promise<void> {
 		this.lastWriteBytes = 0;
-		const { json, resources } = this.writeJSON(doc, {
+		const { json, resources } = await this.writeJSON(doc, {
 			format: Format.GLTF,
 			basename: FileUtils.basename(uri),
 		});
@@ -128,18 +129,19 @@ export class NodeIO extends PlatformIO {
 		const dir = path.dirname(uri);
 		const jsonContent = JSON.stringify(json, null, 2);
 		this.lastWriteBytes += jsonContent.length;
-		fs.writeFileSync(uri, jsonContent);
-		Object.keys(resources).forEach((resourceName) => {
+		await fs.writeFile(uri, jsonContent);
+		const pending = Object.keys(resources).map(async (resourceName) => {
 			const resource = Buffer.from(resources[resourceName]);
-			fs.writeFileSync(path.join(dir, resourceName), resource);
+			await fs.writeFile(path.join(dir, resourceName), resource);
 			this.lastWriteBytes += resource.byteLength;
 		});
+		await Promise.all(pending);
 	}
 
 	/** @internal */
-	private _writeGLB(uri: string, doc: Document): void {
-		const buffer = Buffer.from(this.writeBinary(doc));
-		this._fs.writeFileSync(uri, buffer);
+	private async _writeGLB(uri: string, doc: Document): Promise<void> {
+		const buffer = Buffer.from(await this.writeBinary(doc));
+		await this._fs.writeFile(uri, buffer);
 		this.lastWriteBytes = buffer.byteLength;
 	}
 }

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -24,12 +24,13 @@ import { PlatformIO } from './platform-io';
  * const io = new NodeIO();
  *
  * // Read.
- * io.read('model.glb');       // → Document
- * io.readBinary(glb);         // Uint8Array → Document
+ * let document;
+ * document = await io.read('model.glb'); // → Document
+ * document = await io.readBinary(glb);   // Uint8Array → Document
  *
  * // Write.
- * io.write('model.glb', doc); // → void
- * io.writeBinary(doc);        // Document → Uint8Array
+ * await io.write('model.glb', doc);      // → void
+ * const glb = await io.writeBinary(doc); // Document → Uint8Array
  * ```
  *
  * @category I/O
@@ -58,7 +59,7 @@ export class NodeIO extends PlatformIO {
 
 	/** Loads a local path and returns a {@link Document} instance. */
 	public async read(uri: string): Promise<Document> {
-		return this.readJSON(await this.readAsJSON(uri));
+		return await this.readJSON(await this.readAsJSON(uri));
 	}
 
 	/** Loads a local path and returns a {@link JSONDocument} struct, without parsing. */

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -108,7 +108,7 @@ export abstract class PlatformIO {
 	 */
 
 	/** Converts glTF-formatted JSON and a resource map to a {@link Document}. */
-	public readJSON(jsonDoc: JSONDocument): Document {
+	public async readJSON(jsonDoc: JSONDocument): Promise<Document> {
 		jsonDoc = this._copyJSON(jsonDoc);
 		this._readResourcesInternal(jsonDoc);
 		return GLTFReader.read(jsonDoc, {
@@ -119,7 +119,7 @@ export abstract class PlatformIO {
 	}
 
 	/** Converts a {@link Document} to glTF-formatted JSON and a resource map. */
-	public writeJSON(doc: Document, _options: PublicWriterOptions = {}): JSONDocument {
+	public async writeJSON(doc: Document, _options: PublicWriterOptions = {}): Promise<JSONDocument> {
 		if (_options.format === Format.GLB && doc.getRoot().listBuffers().length > 1) {
 			throw new Error('GLB must have 0–1 buffers.');
 		}
@@ -160,7 +160,7 @@ export abstract class PlatformIO {
 	 */
 
 	/** Converts a GLB-formatted ArrayBuffer to a {@link JSONDocument}. */
-	public binaryToJSON(glb: Uint8Array): JSONDocument {
+	public async binaryToJSON(glb: Uint8Array): Promise<JSONDocument> {
 		const jsonDoc = this._binaryToJSON(BufferUtils.assertView(glb));
 		this._readResourcesInternal(jsonDoc);
 		const json = jsonDoc.json;
@@ -220,13 +220,13 @@ export abstract class PlatformIO {
 	 */
 
 	/** Converts a GLB-formatted ArrayBuffer to a {@link Document}. */
-	public readBinary(glb: Uint8Array): Document {
-		return this.readJSON(this.binaryToJSON(BufferUtils.assertView(glb)));
+	public async readBinary(glb: Uint8Array): Promise<Document> {
+		return this.readJSON(await this.binaryToJSON(BufferUtils.assertView(glb)));
 	}
 
 	/** Converts a {@link Document} to a GLB-formatted ArrayBuffer. */
-	public writeBinary(doc: Document): Uint8Array {
-		const { json, resources } = this.writeJSON(doc, { format: Format.GLB });
+	public async writeBinary(doc: Document): Promise<Uint8Array> {
+		const { json, resources } = await this.writeJSON(doc, { format: Format.GLB });
 
 		const header = new Uint32Array([0x46546c67, 2, 12]);
 

--- a/packages/core/src/io/web-io.ts
+++ b/packages/core/src/io/web-io.ts
@@ -27,7 +27,7 @@ const DEFAULT_INIT: RequestInit = {};
  * document = await io.readBinary(glb);    // Uint8Array → Document
  *
  * // Write.
- * const glb = await io.writeBinary(doc); // Document → Uint8Array
+ * const glb = await io.writeBinary(document); // Document → Uint8Array
  * ```
  *
  * @category I/O

--- a/packages/core/src/json-document.ts
+++ b/packages/core/src/json-document.ts
@@ -30,7 +30,7 @@ import { GLTF } from './types/gltf';
  * 	}
  * };
  *
- * const doc = new NodeIO().readJSON(jsonDocument);
+ * const doc = await new NodeIO().readJSON(jsonDocument);
  * ```
  *
  * @category Documents

--- a/packages/core/src/json-document.ts
+++ b/packages/core/src/json-document.ts
@@ -16,6 +16,8 @@ import { GLTF } from './types/gltf';
  * Usage:
  *
  * ```ts
+ * import fs from 'fs/promises';
+ *
  * const jsonDocument = {
  * 	// glTF JSON schema.
  * 	json: {
@@ -25,8 +27,8 @@ import { GLTF } from './types/gltf';
  *
  * 	// URI → ArrayBuffer mapping.
  * 	resources: {
- * 		'image1.png': fs.readFileSync('image1.png'),
- * 		'image2.png': fs.readFileSync('image2.png'),
+ * 		'image1.png': await fs.readFile('image1.png'),
+ * 		'image2.png': await fs.readFile('image2.png'),
  * 	}
  * };
  *

--- a/packages/core/src/properties/buffer.ts
+++ b/packages/core/src/properties/buffer.ts
@@ -50,7 +50,7 @@ interface IBuffer extends IExtensibleProperty {
  *
  * // Write to disk. Each mesh's binary data will be in a separate binary file;
  * // any remaining accessors will be in a third (default) buffer.
- * new NodeIO().write('scene.gltf', doc);
+ * await new NodeIO().write('scene.gltf', doc);
  * // → scene.gltf, part1.bin, part2.bin
  * ```
  *

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -96,7 +96,7 @@ test('@gltf-transform/core::extension | property', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::extension | i/o', (t) => {
+test('@gltf-transform/core::extension | i/o', async (t) => {
 	const io = new NodeIO().registerExtensions([GizmoExtension]);
 	const doc = new Document();
 	const extension = doc.createExtension(GizmoExtension) as GizmoExtension;
@@ -109,19 +109,19 @@ test('@gltf-transform/core::extension | i/o', (t) => {
 
 	// Write (unregistered).
 
-	jsonDoc = new NodeIO().writeJSON(doc, options);
+	jsonDoc = await new NodeIO().writeJSON(doc, options);
 	t.deepEqual(jsonDoc.json.extensionsUsed, undefined, 'write extensionsUsed (unregistered)');
 
 	// Write (registered).
 
-	jsonDoc = io.writeJSON(doc, options);
+	jsonDoc = await io.writeJSON(doc, options);
 	t.deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)');
 	t.equal(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
 	t.equal(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
 
 	// Read.
 
-	resultDoc = io.readJSON(jsonDoc);
+	resultDoc = await io.readJSON(jsonDoc);
 	t.deepEqual(
 		resultDoc
 			.getRoot()
@@ -140,9 +140,9 @@ test('@gltf-transform/core::extension | i/o', (t) => {
 	// Write + read with extensionsRequired.
 
 	extension.setRequired(true);
-	jsonDoc = io.writeJSON(doc, options);
+	jsonDoc = await io.writeJSON(doc, options);
 	t.deepEqual(jsonDoc.json.extensionsRequired, ['TEST_node_gizmo'], 'write extensionsRequired');
-	resultDoc = io.readJSON(jsonDoc);
+	resultDoc = await io.readJSON(jsonDoc);
 	t.deepEqual(
 		resultDoc
 			.getRoot()

--- a/packages/core/test/io/node-io.test.ts
+++ b/packages/core/test/io/node-io.test.ts
@@ -47,38 +47,44 @@ test('@gltf-transform/core::io | node.js read gltf', { skip: !IS_NODEJS }, (t) =
 	t.end();
 });
 
-test('@gltf-transform/core::io | node.js write glb', { skip: !IS_NODEJS }, (t) => {
+test('@gltf-transform/core::io | node.js write glb', { skip: !IS_NODEJS }, async (t) => {
 	let count = 0;
-	glob.sync(path.join(__dirname, '../in/**/*.gltf')).forEach((inputURI) => {
-		const basepath = inputURI.replace(path.join(__dirname, '../in'), '.');
-		const outputURI = path.join(__dirname, '../out', basepath);
+	const uris = glob.sync(path.join(__dirname, '../in/**/*.gltf'));
+	await Promise.all(
+		uris.map(async (inputURI) => {
+			const basepath = inputURI.replace(path.join(__dirname, '../in'), '.');
+			const outputURI = path.join(__dirname, '../out', basepath);
 
-		const io = new NodeIO();
-		const doc = io.read(inputURI);
+			const io = new NodeIO();
+			const doc = await io.read(inputURI);
 
-		ensureDir(outputURI);
-		io.write(outputURI.replace('.gltf', '.glb'), doc);
-		t.ok(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
-		count++;
-	});
+			ensureDir(outputURI);
+			await io.write(outputURI.replace('.gltf', '.glb'), doc);
+			t.ok(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
+			count++;
+		})
+	);
 	t.ok(count > 0, 'tests completed');
 	t.end();
 });
 
-test('@gltf-transform/core::io | node.js write gltf', { skip: !IS_NODEJS }, (t) => {
+test('@gltf-transform/core::io | node.js write gltf', { skip: !IS_NODEJS }, async (t) => {
 	let count = 0;
-	glob.sync(path.join(__dirname, '../in/**/*.glb')).forEach((inputURI) => {
-		const basepath = inputURI.replace(path.join(__dirname, '../in'), '.');
-		const outputURI = path.join(__dirname, '../out', basepath);
+	const uris = glob.sync(path.join(__dirname, '../in/**/*.glb'));
+	await Promise.all(
+		uris.map(async (inputURI) => {
+			const basepath = inputURI.replace(path.join(__dirname, '../in'), '.');
+			const outputURI = path.join(__dirname, '../out', basepath);
 
-		const io = new NodeIO();
-		const doc = io.read(inputURI);
+			const io = new NodeIO();
+			const doc = await io.read(inputURI);
 
-		ensureDir(outputURI);
-		io.write(outputURI.replace('.glb', '.gltf'), doc);
-		t.ok(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
-		count++;
-	});
+			ensureDir(outputURI);
+			await io.write(outputURI.replace('.glb', '.gltf'), doc);
+			t.ok(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
+			count++;
+		})
+	);
 	t.ok(count > 0, 'tests completed');
 	t.end();
 });

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -5,13 +5,24 @@ import fs from 'fs';
 import path from 'path';
 import { BufferUtils, Document, Format, GLB_BUFFER, JSONDocument, NodeIO } from '../../';
 
-test('@gltf-transform/core::io | common', (t) => {
-	t.throws(
-		async () =>
-			await new NodeIO().readJSON({
+const throwsAsync = async (t: test.Test, fn: () => Promise<unknown>, re: RegExp, msg: string): Promise<void> => {
+	try {
+		await fn();
+		t.fail(msg);
+	} catch (e) {
+		t.match((e as Error).message, re, msg);
+	}
+};
+
+test('@gltf-transform/core::io | common', async (t) => {
+	await throwsAsync(
+		t,
+		() =>
+			new NodeIO().readJSON({
 				json: { asset: { version: '1.0' } },
 				resources: {},
 			}),
+		/Unsupported/,
 		'1.0'
 	);
 	t.end();
@@ -48,8 +59,8 @@ test('@gltf-transform/core::io | glb without required buffer', async (t) => {
 	doc.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
 	doc.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
 
-	t.throws(async () => io.writeJSON(doc, { format: Format.GLB }), /buffer required/i, 'writeJSON throws');
-	t.throws(async () => io.writeBinary(doc), /buffer required/i, 'writeBinary throws');
+	await throwsAsync(t, () => io.writeJSON(doc, { format: Format.GLB }), /buffer required/i, 'writeJSON throws');
+	await throwsAsync(t, () => io.writeBinary(doc), /buffer required/i, 'writeBinary throws');
 
 	doc.createBuffer();
 
@@ -60,8 +71,8 @@ test('@gltf-transform/core::io | glb without required buffer', async (t) => {
 	doc.createAccessor().setArray(new Float32Array(10));
 	doc.createAccessor().setArray(new Float32Array(20));
 
-	t.throws(async () => io.writeJSON(doc, { format: Format.GLB }), /buffer required/i, 'writeJSON throws');
-	t.throws(async () => io.writeBinary(doc), /buffer required/i, 'writeBinary throws');
+	await throwsAsync(t, () => io.writeJSON(doc, { format: Format.GLB }), /buffer required/i, 'writeJSON throws');
+	await throwsAsync(t, () => io.writeBinary(doc), /buffer required/i, 'writeBinary throws');
 
 	doc.createBuffer();
 

--- a/packages/core/test/io/web-io.test.ts
+++ b/packages/core/test/io/web-io.test.ts
@@ -172,7 +172,7 @@ test('@gltf-transform/core::io | web read + data URIs', async (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::io | web readJSON + data URIs', (t) => {
+test('@gltf-transform/core::io | web readJSON + data URIs', async (t) => {
 	const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
 	const uris = images.map((image) => {
 		return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
@@ -190,7 +190,7 @@ test('@gltf-transform/core::io | web readJSON + data URIs', (t) => {
 
 	const io = new WebIO();
 
-	const doc = io.readJSON({
+	const doc = await io.readJSON({
 		json: {
 			asset: { version: '2.0' },
 			images: uris.map((uri) => ({ uri })),

--- a/packages/core/test/properties/accessor.test.ts
+++ b/packages/core/test/properties/accessor.test.ts
@@ -80,7 +80,7 @@ test('@gltf-transform/core::accessor | getElementSize', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::accessor | interleaved', (t) => {
+test('@gltf-transform/core::accessor | interleaved', async (t) => {
 	const resources = {
 		'test.bin': new Uint8Array(
 			new Uint16Array([
@@ -151,7 +151,7 @@ test('@gltf-transform/core::accessor | interleaved', (t) => {
 	};
 
 	const io = new NodeIO();
-	const doc = io.readJSON({ json, resources });
+	const doc = await io.readJSON({ json, resources });
 	const arrays = doc
 		.getRoot()
 		.listAccessors()
@@ -163,7 +163,7 @@ test('@gltf-transform/core::accessor | interleaved', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::accessor | sparse', (t) => {
+test('@gltf-transform/core::accessor | sparse', async (t) => {
 	const resources = {
 		'indices.bin': new Uint8Array(new Uint16Array([10, 50, 51]).buffer),
 		'values.bin': new Uint8Array(new Float32Array([1, 2, 3, 10, 12, 14, 25, 50, 75]).buffer),
@@ -211,7 +211,7 @@ test('@gltf-transform/core::accessor | sparse', (t) => {
 	};
 
 	const io = new NodeIO();
-	const doc = io.readJSON({ json, resources });
+	const doc = await io.readJSON({ json, resources });
 	const accessors = doc.getRoot().listAccessors();
 
 	const actual = [];
@@ -237,7 +237,7 @@ test('@gltf-transform/core::accessor | minmax', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::accessor | extras', (t) => {
+test('@gltf-transform/core::accessor | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createAccessor('A')
@@ -245,7 +245,7 @@ test('@gltf-transform/core::accessor | extras', (t) => {
 		.setExtras({ foo: 1, bar: 2 })
 		.setBuffer(doc.createBuffer());
 
-	const doc2 = io.readBinary(io.writeBinary(doc));
+	const doc2 = await io.readBinary(await io.writeBinary(doc));
 
 	t.deepEqual(doc.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
 	t.deepEqual(doc2.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');

--- a/packages/core/test/properties/animation.test.ts
+++ b/packages/core/test/properties/animation.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import { Accessor, Document, NodeIO } from '../../';
 
-test('@gltf-transform/core::animation', (t) => {
+test('@gltf-transform/core::animation', async (t) => {
 	const doc = new Document();
 
 	const buffer = doc.createBuffer('default');
@@ -31,7 +31,7 @@ test('@gltf-transform/core::animation', (t) => {
 	const io = new NodeIO();
 
 	const options = { basename: 'animationTest' };
-	const jsonDoc = io.writeJSON(io.readJSON(io.writeJSON(doc, options)), options);
+	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(doc, options)), options);
 
 	t.deepEqual(
 		jsonDoc.json.animations[0],
@@ -57,7 +57,7 @@ test('@gltf-transform/core::animation', (t) => {
 		'animation samplers and channels'
 	);
 
-	const finalDoc = io.readJSON(jsonDoc);
+	const finalDoc = await io.readJSON(jsonDoc);
 
 	t.deepEqual(finalDoc.getRoot().listAccessors()[0].getArray(), input.getArray(), 'sampler times');
 	t.deepEqual(finalDoc.getRoot().listAccessors()[1].getArray(), output.getArray(), 'sampler values');
@@ -109,7 +109,7 @@ test('@gltf-transform/core::animationSampler | copy', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::animation | extras', (t) => {
+test('@gltf-transform/core::animation | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createAnimation('A')
@@ -117,7 +117,7 @@ test('@gltf-transform/core::animation | extras', (t) => {
 		.addChannel(doc.createAnimationChannel().setExtras({ channel: true }))
 		.addSampler(doc.createAnimationSampler().setExtras({ sampler: true }));
 
-	const doc2 = io.readJSON(io.writeJSON(doc, { basename: 'test' }));
+	const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
 
 	const anim = doc.getRoot().listAnimations()[0];
 	const anim2 = doc2.getRoot().listAnimations()[0];

--- a/packages/core/test/properties/buffer.test.ts
+++ b/packages/core/test/properties/buffer.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import { Document, NodeIO } from '../../';
 
-test('@gltf-transform/core::buffer', (t) => {
+test('@gltf-transform/core::buffer', async (t) => {
 	const doc = new Document();
 	const buffer1 = doc.createBuffer().setURI('mybuffer.bin');
 	const buffer2 = doc.createBuffer().setURI('');
@@ -22,7 +22,7 @@ test('@gltf-transform/core::buffer', (t) => {
 		.setBuffer(buffer3);
 
 	const io = new NodeIO();
-	const jsonDoc = io.writeJSON(doc, { basename: 'basename' });
+	const jsonDoc = await io.writeJSON(doc, { basename: 'basename' });
 
 	t.true('mybuffer.bin' in jsonDoc.resources, 'explicitly named buffer');
 	t.true('basename_1.bin' in jsonDoc.resources, 'implicitly named buffer #1');
@@ -41,7 +41,7 @@ test('@gltf-transform/core::buffer | copy', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::buffer | extras', (t) => {
+test('@gltf-transform/core::buffer | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	const buffer = doc.createBuffer('A').setExtras({ foo: 1, bar: 2 });
@@ -49,7 +49,7 @@ test('@gltf-transform/core::buffer | extras', (t) => {
 		.setArray(new Uint8Array([1, 2, 3]))
 		.setBuffer(buffer);
 
-	const doc2 = io.readJSON(io.writeJSON(doc, { basename: 'test' }));
+	const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
 
 	t.deepEqual(doc.getRoot().listBuffers()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
 	t.deepEqual(doc2.getRoot().listBuffers()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');

--- a/packages/core/test/properties/camera.test.ts
+++ b/packages/core/test/properties/camera.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import { Document, NodeIO } from '../../';
 
-test('@gltf-transform/core::camera', (t) => {
+test('@gltf-transform/core::camera', async (t) => {
 	const doc = new Document();
 
 	doc.createCamera('p')
@@ -18,7 +18,7 @@ test('@gltf-transform/core::camera', (t) => {
 	const io = new NodeIO();
 
 	const options = { basename: 'cameraTest' };
-	const jsonDoc = io.writeJSON(io.readJSON(io.writeJSON(doc, options)), options);
+	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(doc, options)), options);
 
 	t.deepEqual(
 		jsonDoc.json.cameras[0],

--- a/packages/core/test/properties/material.test.ts
+++ b/packages/core/test/properties/material.test.ts
@@ -343,7 +343,7 @@ test('@gltf-transform/core::material | equals', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::material | i/o', (t) => {
+test('@gltf-transform/core::material | i/o', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 
@@ -366,7 +366,7 @@ test('@gltf-transform/core::material | i/o', (t) => {
 		.setOcclusionStrength(0.4);
 
 	const io = new NodeIO();
-	const rtDoc = io.readJSON(io.writeJSON(doc, { format: Format.GLB }));
+	const rtDoc = await io.readJSON(await io.writeJSON(doc, { format: Format.GLB }));
 	const rtMat = rtDoc.getRoot().listMaterials()[0];
 
 	t.ok(rtMat.getBaseColorTexture(), 'baseColorTexture');

--- a/packages/core/test/properties/mesh.test.ts
+++ b/packages/core/test/properties/mesh.test.ts
@@ -47,7 +47,7 @@ test('@gltf-transform/core::mesh | primitive', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::mesh | primitive targets', (t) => {
+test('@gltf-transform/core::mesh | primitive targets', async (t) => {
 	const doc = new Document();
 	const mesh = doc.createMesh('mesh');
 	const prim = doc.createPrimitive();
@@ -78,7 +78,7 @@ test('@gltf-transform/core::mesh | primitive targets', (t) => {
 
 	const io = new NodeIO();
 	const options = { basename: 'targetTest' };
-	const jsonDoc = io.writeJSON(io.readJSON(io.writeJSON(doc, options)), options);
+	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(doc, options)), options);
 	const meshDef = jsonDoc.json.meshes[0];
 
 	t.deepEquals(meshDef.extras.targetNames, ['trg1', 'trg2', 'trg3'], 'writes target names');
@@ -121,14 +121,14 @@ test('@gltf-transform/core::primitive | copy', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::mesh | extras', (t) => {
+test('@gltf-transform/core::mesh | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createMesh('A')
 		.setExtras({ foo: 1, bar: 2 })
 		.addPrimitive(doc.createPrimitive().setExtras({ baz: 3 }));
 
-	const doc2 = io.readJSON(io.writeJSON(doc, { basename: 'test' }));
+	const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
 
 	t.deepEqual(doc.getRoot().listMeshes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores mesh extras');
 	t.deepEqual(doc2.getRoot().listMeshes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips mesh extras');
@@ -141,7 +141,7 @@ test('@gltf-transform/core::mesh | extras', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::mesh | empty i/o', (t) => {
+test('@gltf-transform/core::mesh | empty i/o', async (t) => {
 	// Technically meshes must have primitives for the file to be valid, but we'll test that
 	// reading/writing works anyway.
 
@@ -149,14 +149,14 @@ test('@gltf-transform/core::mesh | empty i/o', (t) => {
 	doc.createMesh('EmptyMesh').setWeights([1, 0, 0, 0]);
 
 	const io = new NodeIO();
-	let rtDoc = io.readJSON(io.writeJSON(doc, {}));
+	let rtDoc = await io.readJSON(await io.writeJSON(doc, {}));
 	let rtMesh = rtDoc.getRoot().listMeshes()[0];
 
 	t.deepEquals(rtMesh.listPrimitives(), [], 'primitives');
 	t.deepEquals(rtMesh.getName(), 'EmptyMesh', 'name');
 	t.deepEquals(rtMesh.getWeights(), [1, 0, 0, 0], 'weights');
 
-	rtDoc = io.readJSON({
+	rtDoc = await io.readJSON({
 		json: {
 			asset: { version: '2.0' },
 			meshes: [
@@ -177,7 +177,7 @@ test('@gltf-transform/core::mesh | empty i/o', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::mesh | primitive i/o', (t) => {
+test('@gltf-transform/core::mesh | primitive i/o', async (t) => {
 	const doc = new Document();
 	const prim = doc.createPrimitive();
 	const buffer = doc.createBuffer();
@@ -235,7 +235,7 @@ test('@gltf-transform/core::mesh | primitive i/o', (t) => {
 	doc.createMesh().addPrimitive(prim);
 
 	const io = new NodeIO();
-	const rtDoc = io.readBinary(io.writeBinary(doc));
+	const rtDoc = await io.readBinary(await io.writeBinary(doc));
 	const rtPrim = rtDoc.getRoot().listMeshes()[0].listPrimitives()[0];
 
 	t.deepEquals(rtPrim.getAttribute('POSITION').getArray(), new Float32Array([0, 0, 0]), 'float32');
@@ -247,7 +247,7 @@ test('@gltf-transform/core::mesh | primitive i/o', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::mesh | primitive vertex layout', (t) => {
+test('@gltf-transform/core::mesh | primitive vertex layout', async (t) => {
 	const doc = new Document();
 	const prim = doc.createPrimitive();
 	const buffer = doc.createBuffer();
@@ -291,7 +291,7 @@ test('@gltf-transform/core::mesh | primitive vertex layout', (t) => {
 	const io = new NodeIO();
 
 	io.setVertexLayout(VertexLayout.INTERLEAVED);
-	const interleavedJSON = io.binaryToJSON(io.writeBinary(doc));
+	const interleavedJSON = await io.binaryToJSON(await io.writeBinary(doc));
 	t.deepEquals(
 		interleavedJSON.json.bufferViews,
 		[{ buffer: 0, target: 34962, byteOffset: 0, byteLength: 36, byteStride: 36 }],
@@ -299,7 +299,7 @@ test('@gltf-transform/core::mesh | primitive vertex layout', (t) => {
 	);
 
 	io.setVertexLayout(VertexLayout.SEPARATE);
-	const separateJSON = io.binaryToJSON(io.writeBinary(doc));
+	const separateJSON = await io.binaryToJSON(await io.writeBinary(doc));
 	t.deepEquals(
 		separateJSON.json.bufferViews,
 		[

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -94,12 +94,12 @@ test('@gltf-transform/core::node | setMatrix', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::node | extras', (t) => {
+test('@gltf-transform/core::node | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createNode('A').setExtras({ foo: 1, bar: 2 });
 
-	const doc2 = io.readJSON(io.writeJSON(doc, { basename: 'test' }));
+	const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
 
 	t.deepEqual(doc.getRoot().listNodes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
 	t.deepEqual(doc2.getRoot().listNodes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
@@ -107,7 +107,7 @@ test('@gltf-transform/core::node | extras', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::node | identity transforms', (t) => {
+test('@gltf-transform/core::node | identity transforms', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 
@@ -115,7 +115,7 @@ test('@gltf-transform/core::node | identity transforms', (t) => {
 	doc.createNode('B').setTranslation([1, 2, 1]);
 	doc.createNode('C').setTranslation([1, 2, 1]).setRotation([1, 0, 0, 0]).setScale([1, 2, 1]);
 
-	const { nodes } = io.writeJSON(doc, { basename: 'test' }).json;
+	const { nodes } = (await io.writeJSON(doc, { basename: 'test' })).json;
 
 	const a = nodes.find((n) => n.name === 'A');
 	const b = nodes.find((n) => n.name === 'B');

--- a/packages/core/test/properties/root.test.ts
+++ b/packages/core/test/properties/root.test.ts
@@ -44,7 +44,7 @@ test('@gltf-transform/core::root', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::root | default scene', (t) => {
+test('@gltf-transform/core::root | default scene', async (t) => {
 	const doc = new Document();
 	const root = doc.getRoot();
 	const sceneA = doc.createScene('A');
@@ -64,7 +64,11 @@ test('@gltf-transform/core::root | default scene', (t) => {
 
 	t.equals(doc.clone().getRoot().getDefaultScene().getName(), 'B', 'clone / copy persistence');
 
-	t.equals(io.readJSON(io.writeJSON(doc, {})).getRoot().getDefaultScene().getName(), 'B', 'read / write persistence');
+	t.equals(
+		(await io.readJSON(await io.writeJSON(doc, {}))).getRoot().getDefaultScene().getName(),
+		'B',
+		'read / write persistence'
+	);
 
 	t.end();
 });
@@ -79,16 +83,16 @@ test('@gltf-transform/core::root | clone child of root', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::root | extras', (t) => {
+test('@gltf-transform/core::root | extras', async (t) => {
 	const doc = new Document();
 	const io = new NodeIO();
 
-	const jsonDocNoExtras = io.writeJSON(doc);
+	const jsonDocNoExtras = await io.writeJSON(doc);
 	doc.getRoot().setExtras({ custom: 'value' });
-	const jsonDocExtras = io.writeJSON(doc);
+	const jsonDocExtras = await io.writeJSON(doc);
 
-	const rtDocNoExtras = io.readJSON(jsonDocNoExtras);
-	const rtDocExtras = io.readJSON(jsonDocExtras);
+	const rtDocNoExtras = await io.readJSON(jsonDocNoExtras);
+	const rtDocExtras = await io.readJSON(jsonDocExtras);
 
 	t.equals(jsonDocNoExtras.json.extras, undefined, 'no empty extras');
 	t.deepEquals(jsonDocExtras.json.extras, { custom: 'value' }, 'write extras');
@@ -97,7 +101,7 @@ test('@gltf-transform/core::root | extras', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::root | asset', (t) => {
+test('@gltf-transform/core::root | asset', async (t) => {
 	const doc = new Document();
 	const root = doc.getRoot();
 	const io = new NodeIO();
@@ -105,16 +109,16 @@ test('@gltf-transform/core::root | asset', (t) => {
 	let jsonDoc: JSONDocument;
 	let generator: string;
 
-	jsonDoc = io.writeJSON(doc);
+	jsonDoc = await io.writeJSON(doc);
 	generator = jsonDoc.json.asset.generator;
 	t.match(generator, /^glTF-Transform.*/i, 'write default generator');
 
 	root.getAsset().generator = 'Custom Tool v123';
-	jsonDoc = io.writeJSON(doc);
+	jsonDoc = await io.writeJSON(doc);
 	generator = jsonDoc.json.asset.generator;
 	t.match(generator, /^Custom Tool.*/i, 'write custom generator');
 
-	generator = io.readJSON(jsonDoc).getRoot().getAsset().generator;
+	generator = (await io.readJSON(jsonDoc)).getRoot().getAsset().generator;
 	t.match(generator, /^glTF-Transform.*/i, 'read default generator');
 	t.end();
 });

--- a/packages/core/test/properties/scene.test.ts
+++ b/packages/core/test/properties/scene.test.ts
@@ -21,12 +21,12 @@ test('@gltf-transform/core::scene | traverse', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::scene | extras', (t) => {
+test('@gltf-transform/core::scene | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createScene('A').setExtras({ foo: 1, bar: 2 });
 
-	const doc2 = io.readJSON(io.writeJSON(doc, { basename: 'test' }));
+	const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
 
 	t.deepEqual(doc.getRoot().listScenes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
 	t.deepEqual(doc2.getRoot().listScenes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');

--- a/packages/core/test/properties/skin.test.ts
+++ b/packages/core/test/properties/skin.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import { Accessor, AnimationChannel, Document, NodeIO } from '../../';
 
-test('@gltf-transform/core::skin', (t) => {
+test('@gltf-transform/core::skin', async (t) => {
 	const doc = new Document();
 
 	const joints = [doc.createNode('joint1'), doc.createNode('joint2'), doc.createNode('joint3')];
@@ -45,7 +45,7 @@ test('@gltf-transform/core::skin', (t) => {
 	doc.createAnimation().addChannel(channel).addSampler(sampler);
 
 	const io = new NodeIO();
-	const jsonDoc = io.writeJSON(io.readJSON(io.writeJSON(doc, {})));
+	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(doc, {})));
 
 	t.deepEqual(
 		jsonDoc.json.nodes[3],
@@ -101,12 +101,12 @@ test('@gltf-transform/core::skin | copy', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::skin | extras', (t) => {
+test('@gltf-transform/core::skin | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createSkin('A').setExtras({ foo: 1, bar: 2 });
 
-	const doc2 = io.readJSON(io.writeJSON(doc));
+	const doc2 = await io.readJSON(await io.writeJSON(doc));
 
 	t.deepEqual(doc.getRoot().listSkins()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
 	t.deepEqual(doc2.getRoot().listSkins()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import { Document, Format, JSONDocument, NodeIO, TextureInfo } from '../../';
 
-test('@gltf-transform/core::texture | read', (t) => {
+test('@gltf-transform/core::texture | read', async (t) => {
 	const jsonDoc = {
 		json: {
 			asset: { version: '2.0' },
@@ -22,7 +22,7 @@ test('@gltf-transform/core::texture | read', (t) => {
 	};
 
 	const io = new NodeIO();
-	const doc = io.readJSON(jsonDoc as unknown as JSONDocument);
+	const doc = await io.readJSON(jsonDoc as unknown as JSONDocument);
 	const root = doc.getRoot();
 	const mat1 = root.listMaterials()[0];
 	const mat2 = root.listMaterials()[1];
@@ -38,7 +38,7 @@ test('@gltf-transform/core::texture | read', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::texture | write', (t) => {
+test('@gltf-transform/core::texture | write', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const image1 = new Uint8Array(1);
@@ -52,7 +52,7 @@ test('@gltf-transform/core::texture | write', (t) => {
 		.setWrapS(TextureInfo.WrapMode.CLAMP_TO_EDGE);
 
 	const io = new NodeIO();
-	const jsonDoc = io.writeJSON(doc, { basename: 'basename' });
+	const jsonDoc = await io.writeJSON(doc, { basename: 'basename' });
 
 	t.false('basename.bin' in jsonDoc.resources, 'external image resources');
 	t.true('tex1.png' in jsonDoc.resources, 'writes tex1.png');
@@ -80,13 +80,13 @@ test('@gltf-transform/core::texture | copy', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::texture | extras', (t) => {
+test('@gltf-transform/core::texture | extras', async (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createBuffer();
 	doc.createTexture('A').setExtras({ foo: 1, bar: 2 }).setImage(new Uint8Array(10)).setMimeType('image/png');
 
-	const doc2 = io.readJSON(io.writeJSON(doc));
+	const doc2 = await io.readJSON(await io.writeJSON(doc));
 
 	t.deepEqual(doc.getRoot().listTextures()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
 	t.deepEqual(doc2.getRoot().listTextures()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');
@@ -94,7 +94,7 @@ test('@gltf-transform/core::texture | extras', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::texture | padding', (t) => {
+test('@gltf-transform/core::texture | padding', async (t) => {
 	// Ensure that buffer views are padded to 8-byte boundaries. See:
 	// https://github.com/KhronosGroup/glTF/issues/1935
 
@@ -104,7 +104,7 @@ test('@gltf-transform/core::texture | padding', (t) => {
 	doc.createTexture().setImage(new Uint8Array(21)).setMimeType('image/png');
 	doc.createTexture().setImage(new Uint8Array(20)).setMimeType('image/png');
 
-	const jsonDoc = new NodeIO().writeJSON(doc, { format: Format.GLB });
+	const jsonDoc = await new NodeIO().writeJSON(doc, { format: Format.GLB });
 
 	t.deepEqual(
 		jsonDoc.json.images,

--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -84,7 +84,7 @@ type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
  * document.createExtension(MeshoptCompression)
  * 	.setRequired(true)
  * 	.setEncoderOptions({ method: MeshoptCompression.EncoderMethod.QUANTIZE });
- * io.write('compressed-medium.glb', document);
+ * await io.write('compressed-medium.glb', document);
  *
  * // Write and encode. (High, -cc)
  * await document.transform(
@@ -94,7 +94,7 @@ type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
  * document.createExtension(MeshoptCompression)
  * 	.setRequired(true)
  * 	.setEncoderOptions({ method: MeshoptCompression.EncoderMethod.FILTER });
- * io.write('compressed-high.glb', document);
+ * await io.write('compressed-high.glb', document);
  * ```
  */
 export class MeshoptCompression extends Extension {

--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -77,7 +77,7 @@ type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
  *	});
  *
  * // Read and decode.
- * const document = io.read('compressed.glb');
+ * const document = await io.read('compressed.glb');
  *
  * // Write and encode. (Medium, -c)
  * await document.transform(reorder(), quantize());

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -87,17 +87,17 @@ interface DracoWriterContext {
  *	});
  *
  * // Read and decode.
- * const doc = io.read('compressed.glb');
+ * const document = await io.read('compressed.glb');
  *
  * // Write and encode.
- * doc.createExtension(DracoMeshCompression)
+ * document.createExtension(DracoMeshCompression)
  * 	.setRequired(true)
  * 	.setEncoderOptions({
  * 		method: DracoMeshCompression.EncoderMethod.EDGEBREAKER,
  * 		encodeSpeed: 5,
  * 		decodeSpeed: 5,
  * 	});
- * io.write('compressed.glb', doc);
+ * await io.write('compressed.glb', document);
  * ```
  */
 export class DracoMeshCompression extends Extension {

--- a/packages/extensions/test/draco-mesh-compression.test.ts
+++ b/packages/extensions/test/draco-mesh-compression.test.ts
@@ -9,7 +9,7 @@ import { DracoMeshCompression } from '../';
 
 test('@gltf-transform/extensions::draco-mesh-compression | decoding', async (t) => {
 	const io = await createDecoderIO();
-	const doc = io.read(path.join(__dirname, 'in', 'BoxDraco.gltf'));
+	const doc = await io.read(path.join(__dirname, 'in', 'BoxDraco.gltf'));
 	const bbox = bounds(doc.getRoot().listScenes()[0]);
 	t.deepEquals(
 		bbox.min.map((v) => +v.toFixed(3)),
@@ -45,7 +45,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding complete', a
 	doc.createNode().setMesh(mesh);
 
 	let io = await createEncoderIO();
-	const jsonDoc = io.writeJSON(doc, { format: Format.GLB });
+	const jsonDoc = await io.writeJSON(doc, { format: Format.GLB });
 	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
 
 	t.equals(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
@@ -112,7 +112,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding complete', a
 	t.deepEquals(jsonDoc.json.extensionsUsed, ['KHR_draco_mesh_compression'], 'included in extensionsUsed');
 
 	io = await createDecoderIO();
-	const roundtripDoc = io.readJSON(jsonDoc);
+	const roundtripDoc = await io.readJSON(jsonDoc);
 	const roundtripNode = roundtripDoc.getRoot().listNodes()[0];
 	const bbox = bounds(roundtripNode);
 	t.deepEquals(
@@ -146,7 +146,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding skipped', as
 	const mesh = doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
 	const io = await createEncoderIO();
-	const jsonDoc = io.writeJSON(doc, { format: Format.GLB });
+	const jsonDoc = await io.writeJSON(doc, { format: Format.GLB });
 	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
 
 	t.equals(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
@@ -189,7 +189,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | mixed indices', async
 	doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
 	const io = await createEncoderIO();
-	const jsonDoc = io.writeJSON(doc, { format: Format.GLB });
+	const jsonDoc = await io.writeJSON(doc, { format: Format.GLB });
 	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
 
 	// The two primitives have different indices, and must be encoded as entirely separate buffer
@@ -251,7 +251,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | mixed attributes', as
 	doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
 	const io = await createEncoderIO();
-	const jsonDoc = io.writeJSON(doc, { format: Format.GLB });
+	const jsonDoc = await io.writeJSON(doc, { format: Format.GLB });
 	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
 
 	// The two primitives have different attributes, and must be encoded as entirely separate

--- a/packages/extensions/test/draco-mesh-compression.test.ts
+++ b/packages/extensions/test/draco-mesh-compression.test.ts
@@ -7,6 +7,15 @@ import { Accessor, Buffer, Document, Format, NodeIO, Primitive } from '@gltf-tra
 import { bounds } from '@gltf-transform/functions';
 import { DracoMeshCompression } from '../';
 
+const throwsAsync = async (t: test.Test, fn: () => Promise<unknown>, re: RegExp, msg: string): Promise<void> => {
+	try {
+		await fn();
+		t.fail(msg);
+	} catch (e) {
+		t.match((e as Error).message, re, msg);
+	}
+};
+
 test('@gltf-transform/extensions::draco-mesh-compression | decoding', async (t) => {
 	const io = await createDecoderIO();
 	const doc = await io.read(path.join(__dirname, 'in', 'BoxDraco.gltf'));
@@ -299,7 +308,12 @@ test('@gltf-transform/extensions::draco-mesh-compression | non-primitive parent'
 	doc.createMesh().addPrimitive(prim);
 
 	const io = await createEncoderIO();
-	t.throws(() => io.writeJSON(doc, { format: Format.GLB }), 'invalid accessor reuse');
+	await throwsAsync(
+		t,
+		() => io.writeJSON(doc, { format: Format.GLB }),
+		/indices or vertex attributes/,
+		'invalid accessor reuse'
+	);
 	t.end();
 });
 

--- a/packages/extensions/test/lights-punctual.test.ts
+++ b/packages/extensions/test/lights-punctual.test.ts
@@ -6,7 +6,7 @@ import { Light, LightsPunctual } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::lights-punctual', (t) => {
+test('@gltf-transform/extensions::lights-punctual', async (t) => {
 	const doc = new Document();
 	const lightsExtension = doc.createExtension(LightsPunctual);
 	const light = lightsExtension
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::lights-punctual', (t) => {
 
 	t.equal(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
@@ -44,7 +44,7 @@ test('@gltf-transform/extensions::lights-punctual', (t) => {
 	lightsExtension.dispose();
 	t.equal(node.getExtension('KHR_lights_punctual'), null, 'light is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([LightsPunctual]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([LightsPunctual]).readJSON(jsonDoc);
 	const roundtripNode = roundtripDoc.getRoot().listNodes().pop();
 	const light2 = roundtripNode.getExtension<Light>('KHR_lights_punctual');
 
@@ -91,7 +91,7 @@ test('@gltf-transform/extensions::lights-punctual | hex', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/extensions::lights-punctual | i/o', (t) => {
+test('@gltf-transform/extensions::lights-punctual | i/o', async (t) => {
 	const doc = new Document();
 	const lightsExtension = doc.createExtension(LightsPunctual);
 	const light = lightsExtension.createLight().setType(Light.Type.POINT).setIntensity(2.0);
@@ -100,7 +100,7 @@ test('@gltf-transform/extensions::lights-punctual | i/o', (t) => {
 
 	t.equal(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -6,7 +6,7 @@ import { Clearcoat, MaterialsClearcoat } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-clearcoat | factors', (t) => {
+test('@gltf-transform/extensions::materials-clearcoat | factors', async (t) => {
 	const doc = new Document();
 	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
 	const clearcoat = clearcoatExtension.createClearcoat().setClearcoatFactor(0.9).setClearcoatRoughnessFactor(0.1);
@@ -16,7 +16,7 @@ test('@gltf-transform/extensions::materials-clearcoat | factors', (t) => {
 		.setExtension('KHR_materials_clearcoat', clearcoat);
 
 	const io = new NodeIO().registerExtensions([MaterialsClearcoat]);
-	const roundtripDoc = io.readJSON(io.writeJSON(doc));
+	const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
 
@@ -25,7 +25,7 @@ test('@gltf-transform/extensions::materials-clearcoat | factors', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/extensions::materials-clearcoat | textures', (t) => {
+test('@gltf-transform/extensions::materials-clearcoat | textures', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
@@ -45,7 +45,7 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_clearcoat'), clearcoat, 'clearcoat is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -67,7 +67,7 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', (t) => {
 	clearcoatExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_clearcoat'), null, 'clearcoat is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsClearcoat]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsClearcoat]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
 
@@ -80,13 +80,13 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/extensions::materials-clearcoat | disabled', (t) => {
+test('@gltf-transform/extensions::materials-clearcoat | disabled', async (t) => {
 	const doc = new Document();
 	doc.createExtension(MaterialsClearcoat);
 	doc.createMaterial();
 
 	const io = new NodeIO().registerExtensions([MaterialsClearcoat]);
-	const roundtripDoc = io.readJSON(io.writeJSON(doc));
+	const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	t.equals(roundtripMat.getExtension('KHR_materials_clearcoat'), null, 'no effect when not attached');
 	t.end();

--- a/packages/extensions/test/materials-emissive-strength.test.ts
+++ b/packages/extensions/test/materials-emissive-strength.test.ts
@@ -6,7 +6,7 @@ import { EmissiveStrength, MaterialsEmissiveStrength } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-emissive-strength', (t) => {
+test('@gltf-transform/extensions::materials-emissive-strength', async (t) => {
 	const doc = new Document();
 	const emissiveStrengthExtension = doc.createExtension(MaterialsEmissiveStrength);
 	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
@@ -18,7 +18,7 @@ test('@gltf-transform/extensions::materials-emissive-strength', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_emissive_strength'), emissiveStrength, 'emissive strength is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsEmissiveStrength]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsEmissiveStrength]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -32,7 +32,7 @@ test('@gltf-transform/extensions::materials-emissive-strength', (t) => {
 	emissiveStrengthExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_emissive_strength'), null, 'emissive strength is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsEmissiveStrength]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsEmissiveStrength]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
 	t.equal(

--- a/packages/extensions/test/materials-ior.test.ts
+++ b/packages/extensions/test/materials-ior.test.ts
@@ -6,7 +6,7 @@ import { IOR, MaterialsIOR } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-ior', (t) => {
+test('@gltf-transform/extensions::materials-ior', async (t) => {
 	const doc = new Document();
 	const iorExtension = doc.createExtension(MaterialsIOR);
 	const ior = iorExtension.createIOR().setIOR(1.2);
@@ -18,7 +18,7 @@ test('@gltf-transform/extensions::materials-ior', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_ior'), ior, 'ior is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -28,7 +28,7 @@ test('@gltf-transform/extensions::materials-ior', (t) => {
 	iorExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_ior'), null, 'ior is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsIOR]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsIOR]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
 	t.equal(roundtripMat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1.2, 'reads ior');

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -6,7 +6,7 @@ import { MaterialsPBRSpecularGlossiness, PBRSpecularGlossiness } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-pbr-specular-glossiness', (t) => {
+test('@gltf-transform/extensions::materials-pbr-specular-glossiness', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
@@ -21,7 +21,9 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), specGloss, 'specGloss is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsPBRSpecularGlossiness]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO()
+		.registerExtensions([MaterialsPBRSpecularGlossiness])
+		.writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(
@@ -41,7 +43,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', (t) => {
 	specGlossExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), null, 'specGloss is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsPBRSpecularGlossiness]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsPBRSpecularGlossiness]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
 

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -6,7 +6,7 @@ import { MaterialsSheen, Sheen } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-sheen', (t) => {
+test('@gltf-transform/extensions::materials-sheen', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const sheenExtension = doc.createExtension(MaterialsSheen);
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-sheen', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_sheen'), sheen, 'sheen is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -42,7 +42,7 @@ test('@gltf-transform/extensions::materials-sheen', (t) => {
 	sheenExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_sheen'), null, 'sheen is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsSheen]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsSheen]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Sheen>('KHR_materials_sheen');
 

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -6,7 +6,7 @@ import { MaterialsSpecular, Specular } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-specular', (t) => {
+test('@gltf-transform/extensions::materials-specular', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const specularExtension = doc.createExtension(MaterialsSpecular);
@@ -24,7 +24,7 @@ test('@gltf-transform/extensions::materials-specular', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_specular'), specular, 'specular is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -45,7 +45,7 @@ test('@gltf-transform/extensions::materials-specular', (t) => {
 	specularExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_specular'), null, 'specular is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsSpecular]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsSpecular]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Specular>('KHR_materials_specular');
 

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -6,7 +6,7 @@ import { MaterialsTransmission, Transmission } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-transmission', (t) => {
+test('@gltf-transform/extensions::materials-transmission', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const transmissionExtension = doc.createExtension(MaterialsTransmission);
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-transmission', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_transmission'), transmission, 'transmission is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsTransmission]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsTransmission]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -41,7 +41,7 @@ test('@gltf-transform/extensions::materials-transmission', (t) => {
 	transmissionExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_transmission'), null, 'transmission is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsTransmission]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsTransmission]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Transmission>('KHR_materials_transmission');
 

--- a/packages/extensions/test/materials-unlit.test.ts
+++ b/packages/extensions/test/materials-unlit.test.ts
@@ -6,7 +6,7 @@ import { MaterialsUnlit } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-unlit', (t) => {
+test('@gltf-transform/extensions::materials-unlit', async (t) => {
 	const doc = new Document();
 	const unlitExtension = doc.createExtension(MaterialsUnlit);
 	const unlit = unlitExtension.createUnlit();
@@ -20,14 +20,14 @@ test('@gltf-transform/extensions::materials-unlit', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_unlit'), unlit, 'unlit is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
 	t.deepEqual(materialDef.extensions, { KHR_materials_unlit: {} }, 'writes unlit extension');
 	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsUnlit.EXTENSION_NAME], 'writes extensionsUsed');
 
-	const rtDoc = new NodeIO().registerExtensions([MaterialsUnlit]).readJSON(jsonDoc);
+	const rtDoc = await new NodeIO().registerExtensions([MaterialsUnlit]).readJSON(jsonDoc);
 	const rtMat = rtDoc.getRoot().listMaterials()[0];
 	t.ok(rtMat.getExtension('KHR_materials_unlit'), 'unlit is round tripped');
 

--- a/packages/extensions/test/materials-variants.test.ts
+++ b/packages/extensions/test/materials-variants.test.ts
@@ -4,7 +4,7 @@ import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { MappingList, MaterialsVariants } from '../';
 
-test('@gltf-transform/extensions::materials-variants', (t) => {
+test('@gltf-transform/extensions::materials-variants', async (t) => {
 	const doc = new Document();
 	const variantsExtension = doc.createExtension(MaterialsVariants);
 	const var2 = variantsExtension.createVariant('Damaged1');
@@ -27,7 +27,7 @@ test('@gltf-transform/extensions::materials-variants', (t) => {
 	//
 
 	const io = new NodeIO().registerExtensions([MaterialsVariants]);
-	const rtDoc = io.readJSON(io.writeJSON(doc, {}));
+	const rtDoc = await io.readJSON(await io.writeJSON(doc, {}));
 	const rtPrim1 = rtDoc.getRoot().listMeshes()[0].listPrimitives()[0];
 	const rtPrim2 = rtDoc.getRoot().listMeshes()[1].listPrimitives()[0];
 	const rtMappingList = rtPrim1.getExtension<MappingList>('KHR_materials_variants');

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -6,7 +6,7 @@ import { MaterialsVolume, Volume } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::materials-volume', (t) => {
+test('@gltf-transform/extensions::materials-volume', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const volumeExtension = doc.createExtension(MaterialsVolume);
@@ -24,7 +24,7 @@ test('@gltf-transform/extensions::materials-volume', (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_volume'), volume, 'volume is attached');
 
-	const jsonDoc = new NodeIO().registerExtensions([MaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([MaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -45,7 +45,7 @@ test('@gltf-transform/extensions::materials-volume', (t) => {
 	volumeExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_volume'), null, 'volume is detached');
 
-	const roundtripDoc = new NodeIO().registerExtensions([MaterialsVolume]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsVolume]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Volume>('KHR_materials_volume');
 

--- a/packages/extensions/test/mesh-gpu-instancing.test.ts
+++ b/packages/extensions/test/mesh-gpu-instancing.test.ts
@@ -8,7 +8,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([MeshGPUInstancing]);
 
-test('@gltf-transform/extensions::mesh-gpu-instancing', (t) => {
+test('@gltf-transform/extensions::mesh-gpu-instancing', async (t) => {
 	const doc = new Document();
 	const data = doc
 		.createAccessor('unused')
@@ -31,7 +31,7 @@ test('@gltf-transform/extensions::mesh-gpu-instancing', (t) => {
 
 	t.equal(node.getExtension('EXT_mesh_gpu_instancing'), batch, 'batch is attached');
 
-	const jsonDoc = io.writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.equal(jsonDoc.json.bufferViews.length, 3, 'creates three buffer views');
@@ -49,7 +49,7 @@ test('@gltf-transform/extensions::mesh-gpu-instancing', (t) => {
 	t.equal(jsonDoc.json.accessors[2].bufferView, 1, 'buffer view assignment (3/4)');
 	t.equal(jsonDoc.json.accessors[3].bufferView, 2, 'buffer view assignment (4/4)');
 
-	const rtDoc = io.readJSON(jsonDoc);
+	const rtDoc = await io.readJSON(jsonDoc);
 	const rtNode = rtDoc.getRoot().listNodes().pop();
 	const batch2 = rtNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 

--- a/packages/extensions/test/mesh-quantization.test.ts
+++ b/packages/extensions/test/mesh-quantization.test.ts
@@ -1,22 +1,22 @@
 require('source-map-support').install();
 
 import test from 'tape';
-import { Document, NodeIO } from '@gltf-transform/core';
+import { Document, JSONDocument, NodeIO } from '@gltf-transform/core';
 import { MeshQuantization } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('@gltf-transform/extensions::mesh-quantization', (t) => {
+test('@gltf-transform/extensions::mesh-quantization', async (t) => {
 	const doc = new Document();
 	const quantizationExtension = doc.createExtension(MeshQuantization);
-	let jsonDoc;
+	let jsonDoc: JSONDocument;
 
-	jsonDoc = new NodeIO().registerExtensions([MeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
+	jsonDoc = await new NodeIO().registerExtensions([MeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
 	t.deepEqual(jsonDoc.json.extensionsUsed, [MeshQuantization.EXTENSION_NAME], 'writes extensionsUsed');
 
 	quantizationExtension.dispose();
 
-	jsonDoc = new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+	jsonDoc = await new NodeIO().writeJSON(doc, WRITER_OPTIONS);
 	t.equal(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
 	t.end();
 });

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -14,7 +14,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | decoding', async (t) 
 		.registerExtensions([MeshoptCompression, MeshQuantization])
 		.registerDependencies({ 'meshopt.decoder': MeshoptDecoder });
 
-	const doc = io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
+	const doc = await io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
 	const bbox = bounds(doc.getRoot().listScenes()[0]);
 	t.deepEquals(
 		bbox.min.map((v) => +v.toFixed(3)),
@@ -37,9 +37,9 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding', async (t) 
 		'meshopt.encoder': MeshoptEncoder,
 	});
 
-	const doc = io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
-	const glb = io.writeBinary(doc);
-	const rtDoc = io.readBinary(glb);
+	const doc = await io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
+	const glb = await io.writeBinary(doc);
+	const rtDoc = await io.readBinary(glb);
 
 	const extensionsRequired = rtDoc
 		.getRoot()

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -1,7 +1,7 @@
 require('source-map-support').install();
 
 import test from 'tape';
-import { Document, ImageUtils, NodeIO } from '@gltf-transform/core';
+import { Document, GLTF, ImageUtils, JSONDocument, NodeIO } from '@gltf-transform/core';
 import { TextureBasisu } from '../';
 
 const IS_NODEJS = typeof window === 'undefined';
@@ -16,7 +16,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([TextureBasisu]);
 
-test('@gltf-transform/extensions::texture-basisu', (t) => {
+test('@gltf-transform/extensions::texture-basisu', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const basisuExtension = doc.createExtension(TextureBasisu);
@@ -24,18 +24,22 @@ test('@gltf-transform/extensions::texture-basisu', (t) => {
 	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
 	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
 
-	let jsonDoc;
+	let jsonDoc: JSONDocument;
 
-	jsonDoc = io.writeJSON(doc, WRITER_OPTIONS);
+	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 
 	// Writing to file.
 	t.deepEqual(jsonDoc.json.extensionsUsed, [TextureBasisu.EXTENSION_NAME], 'writes extensionsUsed');
 	t.equal(jsonDoc.json.textures[0].source, undefined, 'omits .source on KTX2 texture');
 	t.equal(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
-	t.equal(jsonDoc.json.textures[0].extensions['KHR_texture_basisu'].source, 0, 'includes .source on KTX2 extension');
+	t.equal(
+		(jsonDoc.json.textures[0].extensions['KHR_texture_basisu'] as GLTF.ITexture).source,
+		0,
+		'includes .source on KTX2 extension'
+	);
 
 	// Read (roundtrip) from file.
-	const rtDoc = io.readJSON(jsonDoc);
+	const rtDoc = await io.readJSON(jsonDoc);
 	const rtRoot = rtDoc.getRoot();
 	t.equal(rtRoot.listTextures()[0].getMimeType(), 'image/ktx2', 'reads KTX2 mimetype');
 	t.equal(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
@@ -45,7 +49,7 @@ test('@gltf-transform/extensions::texture-basisu', (t) => {
 	// Clean up extension data, revert to core glTF.
 	basisuExtension.dispose();
 	tex1.dispose();
-	jsonDoc = io.writeJSON(doc, WRITER_OPTIONS);
+	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 	t.equal(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
 	t.equal(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
 	t.equal(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -8,7 +8,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([TextureTransform]);
 
-test('@gltf-transform/extensions::texture-transform', (t) => {
+test('@gltf-transform/extensions::texture-transform', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const transformExtension = doc.createExtension(TextureTransform);
@@ -31,7 +31,7 @@ test('@gltf-transform/extensions::texture-transform', (t) => {
 	mat.setOcclusionTexture(tex3);
 
 	// Read (roundtrip) from file.
-	const rtDoc = io.readJSON(io.writeJSON(doc, WRITER_OPTIONS));
+	const rtDoc = await io.readJSON(await io.writeJSON(doc, WRITER_OPTIONS));
 	const rtMat = rtDoc.getRoot().listMaterials()[0];
 	const rtTransform1 = rtMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
 	const rtTransform2 = rtMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
@@ -108,7 +108,7 @@ test('@gltf-transform/extensions::texture-transform | clone', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/extensions::texture-transform | i/o', (t) => {
+test('@gltf-transform/extensions::texture-transform | i/o', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const transformExtension = doc.createExtension(TextureTransform);
@@ -125,7 +125,7 @@ test('@gltf-transform/extensions::texture-transform | i/o', (t) => {
 			transformExtension.createTransform().setTexCoord(0).setOffset([0.5, 0.5]).setRotation(Math.PI)
 		);
 
-	const jsonDoc = io.writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 	const baseColorTextureInfoDef = materialDef.pbrMetallicRoughness.baseColorTexture;
 	const emissiveTextureInfoDef = materialDef.emissiveTexture;

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -31,7 +31,7 @@
  * 	dedup()
  * );
  *
- * io.write('output.glb', document);
+ * await io.write('output.glb', document);
  * ```
  *
  * @module functions

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -23,7 +23,7 @@
  * import { dedup, quantize, weld } from '@gltf-transform/functions';
  *
  * const io = new NodeIO();
- * const document = io.read('input.glb');
+ * const document = await io.read('input.glb');
  *
  * await document.transform(
  * 	weld(),

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -7,9 +7,9 @@ import { Document, NodeIO, PropertyType } from '@gltf-transform/core';
 import { dedup } from '../';
 import { MaterialsTransmission } from '@gltf-transform/extensions';
 
-test('@gltf-transform/functions::dedup | accessors', (t) => {
+test('@gltf-transform/functions::dedup | accessors', async (t) => {
 	const io = new NodeIO();
-	const doc = io.read(path.join(__dirname, 'in/many-cubes.gltf'));
+	const doc = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));
 	t.equal(doc.getRoot().listAccessors().length, 1503, 'begins with duplicate accessors');
 
 	dedup({ propertyTypes: [PropertyType.TEXTURE] })(doc);
@@ -73,9 +73,9 @@ test('@gltf-transform/functions::dedup | materials', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/functions::dedup | meshes', (t) => {
+test('@gltf-transform/functions::dedup | meshes', async (t) => {
 	const io = new NodeIO();
-	const doc = io.read(path.join(__dirname, 'in/many-cubes.gltf'));
+	const doc = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));
 	const root = doc.getRoot();
 	t.equal(root.listMeshes().length, 501, 'begins with duplicate meshes');
 

--- a/packages/functions/test/inspect.test.ts
+++ b/packages/functions/test/inspect.test.ts
@@ -5,9 +5,10 @@ import test from 'tape';
 import { Logger, NodeIO } from '@gltf-transform/core';
 import { inspect } from '../';
 
-test('@gltf-transform/functions::inspect', (t) => {
+test('@gltf-transform/functions::inspect', async (t) => {
 	const io = new NodeIO();
-	const doc = io.read(path.join(__dirname, 'in/TwoCubes.glb')).setLogger(new Logger(Logger.Verbosity.SILENT));
+	const doc = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));
+	doc.setLogger(new Logger(Logger.Verbosity.SILENT));
 
 	doc.createAnimation('TestAnim');
 	doc.createTexture('TestTex').setImage(new Uint8Array(10)).setMimeType('image/fake');

--- a/packages/functions/test/partition.test.ts
+++ b/packages/functions/test/partition.test.ts
@@ -5,9 +5,10 @@ import test from 'tape';
 import { Logger, NodeIO } from '@gltf-transform/core';
 import { partition } from '../';
 
-test('@gltf-transform/functions::partition', (t) => {
+test('@gltf-transform/functions::partition', async (t) => {
 	const io = new NodeIO();
-	const doc = io.read(path.join(__dirname, 'in/TwoCubes.glb')).setLogger(new Logger(Logger.Verbosity.SILENT));
+	const doc = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));
+	doc.setLogger(new Logger(Logger.Verbosity.SILENT));
 	t.equal(doc.getRoot().listBuffers().length, 1, 'initialized with one buffer');
 
 	partition({ meshes: [] })(doc);
@@ -17,7 +18,7 @@ test('@gltf-transform/functions::partition', (t) => {
 
 	partition({ meshes: ['CubeA', 'CubeB'] })(doc);
 
-	const jsonDoc = io.writeJSON(doc, { basename: 'partition-test' });
+	const jsonDoc = await io.writeJSON(doc, { basename: 'partition-test' });
 	t.deepEqual(
 		jsonDoc.json.buffers,
 		[


### PR DESCRIPTION
Fixes #440.

Breaking change expected for v2.0, making NodeIO read/write methods asynchronous. This should make the WebIO and NodeIO classes closely interchangeable, ~~but there's probably a bit more work to do here to get method signatures aligned between them.~~

It'd also be nice if the NodeIO and WebIO implementations were such that anyone could extend PlatformIO with a new custom I/O class. This isn't so trivial because many of the shared methods in PlatformIO are marked `@internal` and thus stripped from type definitions and obfuscated. Future work.

Related:
- #440
- #379 
- #380 

Remaining:
- [x] Update CLI
- [x] Update unit tests
- [ ] Update documentation