### PR TITLE
Use Uint8Array for binary data, not ArrayBuffer

### DIFF
--- a/packages/cli/src/transforms/ktxfix.ts
+++ b/packages/cli/src/transforms/ktxfix.ts
@@ -18,7 +18,7 @@ export function ktxfix (): Transform {
 			const image = texture.getImage();
 			if (!image) continue;
 
-			const ktx = read(new Uint8Array(image));
+			const ktx = read(image);
 			const dfd = ktx.dataFormatDescriptor[0];
 			const slots = getTextureSlots(doc, texture);
 
@@ -41,7 +41,7 @@ export function ktxfix (): Transform {
 			}
 
 			if (changed) {
-				texture.setImage(write(ktx).buffer);
+				texture.setImage(write(ktx));
 				numChanged++;
 			}
 		}

--- a/packages/cli/src/transforms/merge.ts
+++ b/packages/cli/src/transforms/merge.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { BufferUtils, Document, FileUtils, ImageUtils, NodeIO, Transform } from '@gltf-transform/core';
+import { Document, FileUtils, ImageUtils, NodeIO, Transform } from '@gltf-transform/core';
 
 const NAME = 'merge';
 
@@ -24,7 +24,7 @@ const merge = (options: MergeOptions): Transform => {
 			const extension = FileUtils.extension(path).toLowerCase();
 			if (['png', 'jpg', 'jpeg', 'webp', 'ktx2'].includes(extension)) {
 				doc.createTexture(basename)
-					.setImage(BufferUtils.trim(fs.readFileSync(path)))
+					.setImage(fs.readFileSync(path))
 					.setMimeType(ImageUtils.extensionToMimeType(extension))
 					.setURI(basename + '.' + extension);
 			} else if (['gltf', 'glb'].includes(extension)) {

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -4,7 +4,7 @@ const minimatch = require('minimatch');
 const semver = require('semver');
 const tmp = require('tmp');
 
-import { BufferUtils, Document, FileUtils, ImageUtils, Logger, TextureChannel, Transform, vec2 } from '@gltf-transform/core';
+import { Document, FileUtils, ImageUtils, Logger, TextureChannel, Transform, vec2 } from '@gltf-transform/core';
 import { TextureBasisu } from '@gltf-transform/extensions';
 import { commandExistsSync, formatBytes, getTextureChannels, getTextureSlots, spawnSync } from '../util';
 
@@ -173,7 +173,7 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 				// PACK: Replace image data in the glTF asset.
 
 				texture
-					.setImage(BufferUtils.trim(fs.readFileSync(outPath)))
+					.setImage(fs.readFileSync(outPath))
 					.setMimeType('image/ktx2');
 
 				if (texture.getURI()) {

--- a/packages/cli/test/ktxfix.test.ts
+++ b/packages/cli/test/ktxfix.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { KTX2Primaries, read } from 'ktx-parse';
 import test from 'tape';
-import { BufferUtils, Document, Logger, Texture } from '@gltf-transform/core';
+import { Document, Logger, Texture } from '@gltf-transform/core';
 import { ktxfix } from '../';
 
 test('@gltf-transform/cli::ktxfix', async (t) => {
@@ -13,7 +13,7 @@ test('@gltf-transform/cli::ktxfix', async (t) => {
 	const texture = doc
 		.createTexture()
 		.setMimeType('image/ktx2')
-		.setImage(BufferUtils.trim(fs.readFileSync(path.join(__dirname, 'in', 'test.ktx2'))));
+		.setImage(fs.readFileSync(path.join(__dirname, 'in', 'test.ktx2')));
 
 	t.equals(getColorPrimaries(texture), KTX2Primaries.SRGB, 'initial - sRGB');
 
@@ -41,6 +41,6 @@ test('@gltf-transform/cli::ktxfix', async (t) => {
 
 function getColorPrimaries(texture: Texture): KTX2Primaries {
 	const image = texture.getImage();
-	const ktx = read(new Uint8Array(image));
+	const ktx = read(image);
 	return ktx.dataFormatDescriptor[0].colorPrimaries;
 }

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -46,7 +46,7 @@ test('@gltf-transform/cli::toktx | resize', async (t) => {
 
 async function getParams(options: Record<string, unknown>, size: vec2, channels = 0): Promise<string> {
 	const doc = new Document().setLogger(new Logger(Logger.Verbosity.SILENT));
-	const tex = doc.createTexture().setImage(new ArrayBuffer(10)).setMimeType('image/png');
+	const tex = doc.createTexture().setImage(new Uint8Array(10)).setMimeType('image/png');
 	tex.getSize = (): vec2 => size;
 
 	// Assign texture to materials so that the given channels are in use.
@@ -67,7 +67,7 @@ async function getParams(options: Record<string, unknown>, size: vec2, channels 
 
 		// Mock `toktx` compression.
 		actualParams = params;
-		fs.writeFileSync(params[params.length - 2], Buffer.from(new ArrayBuffer(8)));
+		fs.writeFileSync(params[params.length - 2], new Uint8Array(8));
 		return { status: 0 };
 	});
 	mockCommandExistsSync(() => true);

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -2,7 +2,7 @@ import { Format } from '../constants';
 import { Document } from '../document';
 import { JSONDocument } from '../json-document';
 import { GLTF } from '../types/gltf';
-import { BufferUtils, FileUtils } from '../utils/';
+import { FileUtils } from '../utils/';
 import { PlatformIO } from './platform-io';
 
 /**
@@ -84,7 +84,7 @@ export class NodeIO extends PlatformIO {
 		[...images, ...buffers].forEach((resource: GLTF.IBuffer | GLTF.IImage) => {
 			if (resource.uri && !resource.uri.match(/data:/)) {
 				const absURI = this._path.resolve(dir, resource.uri);
-				jsonDoc.resources[resource.uri] = BufferUtils.trim(this._fs.readFileSync(absURI));
+				jsonDoc.resources[resource.uri] = this._fs.readFileSync(absURI);
 				this.lastReadBytes += jsonDoc.resources[resource.uri].byteLength;
 			}
 		});
@@ -97,9 +97,8 @@ export class NodeIO extends PlatformIO {
 	/** @internal */
 	private _readGLB(uri: string): JSONDocument {
 		const buffer: Buffer = this._fs.readFileSync(uri);
-		const arrayBuffer = BufferUtils.trim(buffer);
-		this.lastReadBytes = arrayBuffer.byteLength;
-		const jsonDoc = this._binaryToJSON(arrayBuffer);
+		this.lastReadBytes = buffer.byteLength;
+		const jsonDoc = this._binaryToJSON(buffer);
 		// Read external resources first, before Data URIs are replaced.
 		this._readResourcesExternal(jsonDoc, this._path.dirname(uri));
 		this._readResourcesInternal(jsonDoc);

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -24,12 +24,12 @@ import { PlatformIO } from './platform-io';
  * const io = new NodeIO();
  *
  * // Read.
- * io.read('model.glb');             // → Document
- * io.readBinary(ArrayBuffer);       // → Document
+ * io.read('model.glb');       // → Document
+ * io.readBinary(glb);         // Uint8Array → Document
  *
  * // Write.
  * io.write('model.glb', doc); // → void
- * io.writeBinary(doc);        // → ArrayBuffer
+ * io.writeBinary(doc);        // Document → Uint8Array
  * ```
  *
  * @category I/O

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -73,7 +73,12 @@ export abstract class PlatformIO {
 		// process (e.g. WebIO.read) and should handle that safely.
 
 		function resolveResource(resource: GLTF.IBuffer | GLTF.IImage) {
-			if (!resource.uri || resource.uri in jsonDoc.resources) return;
+			if (!resource.uri) return;
+
+			if (resource.uri in jsonDoc.resources) {
+				BufferUtils.assertView(jsonDoc.resources[resource.uri]);
+				return;
+			}
 
 			if (resource.uri.match(/data:/)) {
 				// Rewrite Data URIs to something short and unique.
@@ -156,7 +161,7 @@ export abstract class PlatformIO {
 
 	/** Converts a GLB-formatted ArrayBuffer to a {@link JSONDocument}. */
 	public binaryToJSON(glb: Uint8Array): JSONDocument {
-		const jsonDoc = this._binaryToJSON(glb);
+		const jsonDoc = this._binaryToJSON(BufferUtils.assertView(glb));
 		const json = jsonDoc.json;
 
 		// Check for external references, which can't be resolved by this method.
@@ -215,7 +220,7 @@ export abstract class PlatformIO {
 
 	/** Converts a GLB-formatted ArrayBuffer to a {@link Document}. */
 	public readBinary(glb: Uint8Array): Document {
-		return this.readJSON(this.binaryToJSON(glb));
+		return this.readJSON(this.binaryToJSON(BufferUtils.assertView(glb)));
 	}
 
 	/** Converts a {@link Document} to a GLB-formatted ArrayBuffer. */

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -155,7 +155,7 @@ export abstract class PlatformIO {
 	 */
 
 	/** Converts a GLB-formatted ArrayBuffer to a {@link JSONDocument}. */
-	public binaryToJSON(glb: ArrayBuffer): JSONDocument {
+	public binaryToJSON(glb: Uint8Array): JSONDocument {
 		const jsonDoc = this._binaryToJSON(glb);
 		const json = jsonDoc.json;
 
@@ -170,9 +170,9 @@ export abstract class PlatformIO {
 	}
 
 	/** @internal For internal use by WebIO and NodeIO. Does not warn about external resources. */
-	protected _binaryToJSON(glb: ArrayBuffer): JSONDocument {
+	protected _binaryToJSON(glb: Uint8Array): JSONDocument {
 		// Decode and verify GLB header.
-		const header = new Uint32Array(glb, 0, 3);
+		const header = new Uint32Array(glb.buffer, glb.byteOffset, 3);
 		if (header[0] !== 0x46546c67) {
 			throw new Error('Invalid glTF asset.');
 		} else if (header[1] !== 2) {
@@ -181,14 +181,14 @@ export abstract class PlatformIO {
 
 		// Decode JSON chunk.
 
-		const jsonChunkHeader = new Uint32Array(glb, 12, 2);
+		const jsonChunkHeader = new Uint32Array(glb.buffer, glb.byteOffset + 12, 2);
 		if (jsonChunkHeader[1] !== ChunkType.JSON) {
 			throw new Error('Missing required GLB JSON chunk.');
 		}
 
 		const jsonByteOffset = 20;
 		const jsonByteLength = jsonChunkHeader[0];
-		const jsonText = BufferUtils.decodeText(glb.slice(jsonByteOffset, jsonByteOffset + jsonByteLength));
+		const jsonText = BufferUtils.decodeText(BufferUtils.toBuffer(glb, jsonByteOffset, jsonByteLength));
 		const json = JSON.parse(jsonText) as GLTF.IGLTF;
 
 		// Decode BIN chunk.
@@ -198,13 +198,13 @@ export abstract class PlatformIO {
 			return { json, resources: {} };
 		}
 
-		const binChunkHeader = new Uint32Array(glb, binByteOffset, 2);
+		const binChunkHeader = new Uint32Array(glb.buffer, glb.byteOffset + binByteOffset, 2);
 		if (binChunkHeader[1] !== ChunkType.BIN) {
 			throw new Error('Expected GLB BIN in second chunk.');
 		}
 
 		const binByteLength = binChunkHeader[0];
-		const binBuffer = glb.slice(binByteOffset + 8, binByteOffset + 8 + binByteLength);
+		const binBuffer = BufferUtils.toBuffer(glb, binByteOffset + 8, binByteLength);
 
 		return { json, resources: { [GLB_BUFFER]: binBuffer } };
 	}
@@ -214,32 +214,32 @@ export abstract class PlatformIO {
 	 */
 
 	/** Converts a GLB-formatted ArrayBuffer to a {@link Document}. */
-	public readBinary(glb: ArrayBuffer): Document {
+	public readBinary(glb: Uint8Array): Document {
 		return this.readJSON(this.binaryToJSON(glb));
 	}
 
 	/** Converts a {@link Document} to a GLB-formatted ArrayBuffer. */
-	public writeBinary(doc: Document): ArrayBuffer {
+	public writeBinary(doc: Document): Uint8Array {
 		const { json, resources } = this.writeJSON(doc, { format: Format.GLB });
 
-		const header = new Uint32Array([0x46546c67, 2, 12]);
+		const header = BufferUtils.toBuffer(new Uint32Array([0x46546c67, 2, 12]));
 
 		const jsonText = JSON.stringify(json);
 		const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-		const jsonChunkHeader = new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]).buffer;
+		const jsonChunkHeader = BufferUtils.toBuffer(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
 		const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
 		header[header.length - 1] += jsonChunk.byteLength;
 
 		const binBuffer = Object.values(resources)[0];
 		if (!binBuffer || !binBuffer.byteLength) {
-			return BufferUtils.concat([header.buffer, jsonChunk]);
+			return BufferUtils.concat([BufferUtils.toBuffer(header), jsonChunk]);
 		}
 
 		const binChunkData = BufferUtils.pad(binBuffer, 0x00);
-		const binChunkHeader = new Uint32Array([binChunkData.byteLength, 0x004e4942]).buffer;
+		const binChunkHeader = BufferUtils.toBuffer(new Uint32Array([binChunkData.byteLength, 0x004e4942]));
 		const binChunk = BufferUtils.concat([binChunkHeader, binChunkData]);
 		header[header.length - 1] += binChunk.byteLength;
 
-		return BufferUtils.concat([header.buffer, jsonChunk, binChunk]);
+		return BufferUtils.concat([header, jsonChunk, binChunk]);
 	}
 }

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -227,7 +227,7 @@ export abstract class PlatformIO {
 	public writeBinary(doc: Document): Uint8Array {
 		const { json, resources } = this.writeJSON(doc, { format: Format.GLB });
 
-		const header = BufferUtils.toView(new Uint32Array([0x46546c67, 2, 12]));
+		const header = new Uint32Array([0x46546c67, 2, 12]);
 
 		const jsonText = JSON.stringify(json);
 		const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
@@ -245,6 +245,6 @@ export abstract class PlatformIO {
 		const binChunk = BufferUtils.concat([binChunkHeader, binChunkData]);
 		header[header.length - 1] += binChunk.byteLength;
 
-		return BufferUtils.concat([header, jsonChunk, binChunk]);
+		return BufferUtils.concat([BufferUtils.toView(header), jsonChunk, binChunk]);
 	}
 }

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -193,7 +193,7 @@ export abstract class PlatformIO {
 
 		const jsonByteOffset = 20;
 		const jsonByteLength = jsonChunkHeader[0];
-		const jsonText = BufferUtils.decodeText(BufferUtils.toBuffer(glb, jsonByteOffset, jsonByteLength));
+		const jsonText = BufferUtils.decodeText(BufferUtils.toView(glb, jsonByteOffset, jsonByteLength));
 		const json = JSON.parse(jsonText) as GLTF.IGLTF;
 
 		// Decode BIN chunk.
@@ -209,7 +209,7 @@ export abstract class PlatformIO {
 		}
 
 		const binByteLength = binChunkHeader[0];
-		const binBuffer = BufferUtils.toBuffer(glb, binByteOffset + 8, binByteLength);
+		const binBuffer = BufferUtils.toView(glb, binByteOffset + 8, binByteLength);
 
 		return { json, resources: { [GLB_BUFFER]: binBuffer } };
 	}
@@ -227,21 +227,21 @@ export abstract class PlatformIO {
 	public writeBinary(doc: Document): Uint8Array {
 		const { json, resources } = this.writeJSON(doc, { format: Format.GLB });
 
-		const header = BufferUtils.toBuffer(new Uint32Array([0x46546c67, 2, 12]));
+		const header = BufferUtils.toView(new Uint32Array([0x46546c67, 2, 12]));
 
 		const jsonText = JSON.stringify(json);
 		const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-		const jsonChunkHeader = BufferUtils.toBuffer(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
+		const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
 		const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
 		header[header.length - 1] += jsonChunk.byteLength;
 
 		const binBuffer = Object.values(resources)[0];
 		if (!binBuffer || !binBuffer.byteLength) {
-			return BufferUtils.concat([BufferUtils.toBuffer(header), jsonChunk]);
+			return BufferUtils.concat([BufferUtils.toView(header), jsonChunk]);
 		}
 
 		const binChunkData = BufferUtils.pad(binBuffer, 0x00);
-		const binChunkHeader = BufferUtils.toBuffer(new Uint32Array([binChunkData.byteLength, 0x004e4942]));
+		const binChunkHeader = BufferUtils.toView(new Uint32Array([binChunkData.byteLength, 0x004e4942]));
 		const binChunk = BufferUtils.concat([binChunkHeader, binChunkData]);
 		header[header.length - 1] += binChunk.byteLength;
 

--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -4,7 +4,7 @@ import { Extension } from '../extension';
 import { JSONDocument } from '../json-document';
 import { Accessor, AnimationSampler, Camera } from '../properties';
 import { GLTF } from '../types/gltf';
-import { FileUtils, ImageUtils, Logger, MathUtils } from '../utils';
+import { BufferUtils, FileUtils, ImageUtils, Logger, MathUtils } from '../utils';
 import { ReaderContext } from './reader-context';
 
 const ComponentTypeToTypedArray = {
@@ -96,8 +96,7 @@ export class GLTFReader {
 				const bufferDef = jsonDoc.json.buffers![bufferViewDef.buffer];
 				const resource = bufferDef.uri ? jsonDoc.resources[bufferDef.uri] : jsonDoc.resources[GLB_BUFFER];
 				const byteOffset = bufferViewDef.byteOffset || 0;
-				const bufferView = new Uint8Array(resource, byteOffset, bufferViewDef.byteLength);
-				context.bufferViews[index] = bufferView;
+				context.bufferViews[index] = BufferUtils.toBuffer(resource, byteOffset, bufferViewDef.byteLength);
 			}
 
 			return context.buffers[bufferViewDef.buffer];

--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -96,7 +96,7 @@ export class GLTFReader {
 				const bufferDef = jsonDoc.json.buffers![bufferViewDef.buffer];
 				const resource = bufferDef.uri ? jsonDoc.resources[bufferDef.uri] : jsonDoc.resources[GLB_BUFFER];
 				const byteOffset = bufferViewDef.byteOffset || 0;
-				context.bufferViews[index] = BufferUtils.toBuffer(resource, byteOffset, bufferViewDef.byteLength);
+				context.bufferViews[index] = BufferUtils.toView(resource, byteOffset, bufferViewDef.byteLength);
 			}
 
 			return context.buffers[bufferViewDef.buffer];

--- a/packages/core/src/io/web-io.ts
+++ b/packages/core/src/io/web-io.ts
@@ -23,10 +23,10 @@ const DEFAULT_INIT: RequestInit = {};
  *
  * // Read.
  * const doc = await io.read('model.glb');  // → Document
- * const doc = io.readBinary(ArrayBuffer);  // → Document
+ * const doc = io.readBinary(glb);  // Uint8Array → Document
  *
  * // Write.
- * const arrayBuffer = io.writeBinary(doc); // → ArrayBuffer
+ * const glb = io.writeBinary(doc); // Document → Uint8Array
  * ```
  *
  * @category I/O

--- a/packages/core/src/io/web-io.ts
+++ b/packages/core/src/io/web-io.ts
@@ -73,7 +73,7 @@ export class WebIO extends PlatformIO {
 				return fetch(_resolve(dir, uri), this._fetchConfig)
 					.then((response) => response.arrayBuffer())
 					.then((arrayBuffer) => {
-						jsonDoc.resources[uri] = arrayBuffer;
+						jsonDoc.resources[uri] = new Uint8Array(arrayBuffer);
 					});
 			}
 		);
@@ -103,7 +103,7 @@ export class WebIO extends PlatformIO {
 		return fetch(uri, this._fetchConfig)
 			.then((response) => response.arrayBuffer())
 			.then(async (arrayBuffer) => {
-				const jsonDoc = this._binaryToJSON(arrayBuffer);
+				const jsonDoc = this._binaryToJSON(new Uint8Array(arrayBuffer));
 				// Read external resources first, before Data URIs are replaced.
 				await this._readResourcesExternal(jsonDoc, _dirname(uri));
 				this._readResourcesInternal(jsonDoc);

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -46,9 +46,9 @@ export class WriterContext {
 	public readonly textureInfoDefMap = new Map<TextureInfo, GLTF.ITextureInfo>();
 	public readonly samplerDefIndexMap = new Map<string, number>(); // samplerDef JSON -> index
 
-	public readonly imageBufferViews: ArrayBuffer[] = [];
-	public readonly otherBufferViews = new Map<Buffer, ArrayBuffer[]>();
-	public readonly otherBufferViewsIndexMap = new Map<ArrayBuffer, number>();
+	public readonly imageBufferViews: Uint8Array[] = [];
+	public readonly otherBufferViews = new Map<Buffer, Uint8Array[]>();
+	public readonly otherBufferViewsIndexMap = new Map<Uint8Array, number>();
 	public readonly extensionData: { [key: string]: unknown } = {};
 
 	public bufferURIGenerator: UniqueURIGenerator;
@@ -147,7 +147,7 @@ export class WriterContext {
 		return accessorDef;
 	}
 
-	public createImageData(imageDef: GLTF.IImage, data: ArrayBuffer, texture: Texture): void {
+	public createImageData(imageDef: GLTF.IImage, data: Uint8Array, texture: Texture): void {
 		if (this.options.format === Format.GLB) {
 			this.imageBufferViews.push(data);
 			imageDef.bufferView = this.jsonDoc.json.bufferViews!.length;

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -61,7 +61,7 @@ export class GLTFWriter {
 
 		interface BufferViewResult {
 			byteLength: number;
-			buffers: ArrayBuffer[];
+			buffers: Uint8Array[];
 		}
 
 		/**
@@ -79,7 +79,7 @@ export class GLTFWriter {
 			bufferByteOffset: number,
 			bufferViewTarget?: number
 		): BufferViewResult {
-			const buffers: ArrayBuffer[] = [];
+			const buffers: Uint8Array[] = [];
 			let byteLength = 0;
 
 			// Create accessor definitions, determining size of final buffer view.
@@ -87,7 +87,8 @@ export class GLTFWriter {
 				const accessorDef = context.createAccessorDef(accessor);
 				accessorDef.bufferView = json.bufferViews!.length;
 
-				const data = BufferUtils.pad(accessor.getArray()!.buffer);
+				const accessorArray = accessor.getArray()!;
+				const data = BufferUtils.pad(BufferUtils.toBuffer(accessorArray));
 				accessorDef.byteOffset = byteLength;
 				byteLength += data.byteLength;
 				buffers.push(data);
@@ -196,7 +197,7 @@ export class GLTFWriter {
 			};
 			json.bufferViews!.push(bufferViewDef);
 
-			return { byteLength, buffers: [buffer] };
+			return { byteLength, buffers: [new Uint8Array(buffer)] };
 		}
 
 		/* Data use pre-processing. */
@@ -301,7 +302,7 @@ export class GLTFWriter {
 
 			// Write accessor groups to buffer views.
 
-			const buffers: ArrayBuffer[] = [];
+			const buffers: Uint8Array[] = [];
 			const bufferIndex = json.buffers!.length;
 			let bufferByteLength = 0;
 
@@ -370,7 +371,7 @@ export class GLTFWriter {
 						// See: https://github.com/KhronosGroup/glTF/issues/1935
 						const imagePadding = 8 - (bufferByteLength % 8);
 						bufferByteLength += imagePadding;
-						buffers.push(new ArrayBuffer(imagePadding));
+						buffers.push(new Uint8Array(imagePadding));
 					}
 				}
 			}

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -88,7 +88,7 @@ export class GLTFWriter {
 				accessorDef.bufferView = json.bufferViews!.length;
 
 				const accessorArray = accessor.getArray()!;
-				const data = BufferUtils.pad(BufferUtils.toBuffer(accessorArray));
+				const data = BufferUtils.pad(BufferUtils.toView(accessorArray));
 				accessorDef.byteOffset = byteLength;
 				byteLength += data.byteLength;
 				buffers.push(data);

--- a/packages/core/src/json-document.ts
+++ b/packages/core/src/json-document.ts
@@ -25,8 +25,8 @@ import { GLTF } from './types/gltf';
  *
  * 	// URI → ArrayBuffer mapping.
  * 	resources: {
- * 		'image1.png': BufferUtils.trim(fs.readFileSync('image1.png')),
- * 		'image2.png': BufferUtils.trim(fs.readFileSync('image2.png')),
+ * 		'image1.png': fs.readFileSync('image1.png'),
+ * 		'image2.png': fs.readFileSync('image2.png'),
  * 	}
  * };
  *
@@ -37,5 +37,5 @@ import { GLTF } from './types/gltf';
  */
 export interface JSONDocument {
 	json: GLTF.IGLTF;
-	resources: { [s: string]: ArrayBuffer };
+	resources: { [s: string]: Uint8Array };
 }

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -1,5 +1,5 @@
 import { Nullable, PropertyType, vec2 } from '../constants';
-import { FileUtils, ImageUtils } from '../utils';
+import { BufferUtils, FileUtils, ImageUtils } from '../utils';
 import { ExtensibleProperty, IExtensibleProperty } from './extensible-property';
 
 interface ITexture extends IExtensibleProperty {
@@ -82,7 +82,7 @@ export class Texture extends ExtensibleProperty<ITexture> {
 
 	/** Sets the raw image data for this texture. */
 	public setImage(image: Uint8Array): this {
-		return this.set('image', image);
+		return this.set('image', BufferUtils.assertView(image));
 	}
 
 	/** Returns the size, in pixels, of this texture. */

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -3,7 +3,7 @@ import { FileUtils, ImageUtils } from '../utils';
 import { ExtensibleProperty, IExtensibleProperty } from './extensible-property';
 
 interface ITexture extends IExtensibleProperty {
-	image: ArrayBuffer | null;
+	image: Uint8Array | null;
 	mimeType: string;
 	uri: string;
 }
@@ -76,12 +76,12 @@ export class Texture extends ExtensibleProperty<ITexture> {
 	 */
 
 	/** Returns the raw image data for this texture. */
-	public getImage(): ArrayBuffer | null {
+	public getImage(): Uint8Array | null {
 		return this.get('image');
 	}
 
 	/** Sets the raw image data for this texture. */
-	public setImage(image: ArrayBuffer): this {
+	public setImage(image: Uint8Array): this {
 		return this.set('image', image);
 	}
 

--- a/packages/core/src/utils/buffer-utils.ts
+++ b/packages/core/src/utils/buffer-utils.ts
@@ -119,4 +119,15 @@ export class BufferUtils {
 	static toBuffer(a: TypedArray, byteOffset = 0, byteLength = Infinity): Uint8Array {
 		return new Uint8Array(a.buffer, a.byteOffset + byteOffset, Math.min(a.byteLength, byteLength));
 	}
+
+	/** @internal */
+	static assertView(view: null): null;
+	static assertView(view: Uint8Array): Uint8Array;
+	static assertView(view: Uint8Array | null): Uint8Array | null;
+	static assertView(view: Uint8Array | null): Uint8Array | null {
+		if (view && !ArrayBuffer.isView(view)) {
+			throw new Error('Method requires Uint8Array parameter.');
+		}
+		return view as Uint8Array;
+	}
 }

--- a/packages/core/src/utils/buffer-utils.ts
+++ b/packages/core/src/utils/buffer-utils.ts
@@ -103,7 +103,7 @@ export class BufferUtils {
 	}
 
 	/**
-	 * Returns a Uint8Array/Buffer view of a typed array, with the same underlying ArrayBuffer.
+	 * Returns a Uint8Array view of a typed array, with the same underlying ArrayBuffer.
 	 *
 	 * A shorthand for:
 	 *
@@ -116,7 +116,7 @@ export class BufferUtils {
 	 * ```
 	 *
 	 */
-	static toBuffer(a: TypedArray, byteOffset = 0, byteLength = Infinity): Uint8Array {
+	static toView(a: TypedArray, byteOffset = 0, byteLength = Infinity): Uint8Array {
 		return new Uint8Array(a.buffer, a.byteOffset + byteOffset, Math.min(a.byteLength, byteLength));
 	}
 

--- a/packages/core/src/utils/property-utils.ts
+++ b/packages/core/src/utils/property-utils.ts
@@ -1,7 +1,6 @@
 import { Link } from 'property-graph';
-import { BufferViewUsage, PropertyType } from '../constants';
-import type { Accessor, Property, Texture } from '../properties';
-import type { Document } from '../document';
+import { BufferViewUsage } from '../constants';
+import type { Property } from '../properties';
 
 export type Ref = Link<Property, Property>;
 export type RefMap = { [key: string]: Ref };

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -46,8 +46,8 @@ test('@gltf-transform/core::io | glb without required buffer', (t) => {
 	const io = new NodeIO();
 
 	let doc = new Document();
-	doc.createTexture('TexA').setImage(new ArrayBuffer(1)).setMimeType('image/png');
-	doc.createTexture('TexB').setImage(new ArrayBuffer(2)).setMimeType('image/png');
+	doc.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
+	doc.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
 
 	t.throws(() => io.writeJSON(doc, { format: Format.GLB }), /buffer required/i, 'writeJSON throws');
 	t.throws(() => io.writeBinary(doc), /buffer required/i, 'writeBinary throws');
@@ -73,8 +73,8 @@ test('@gltf-transform/core::io | glb without required buffer', (t) => {
 
 test('@gltf-transform/core::io | glb with texture-only buffer', (t) => {
 	const doc = new Document();
-	doc.createTexture('TexA').setImage(new ArrayBuffer(1)).setMimeType('image/png');
-	doc.createTexture('TexB').setImage(new ArrayBuffer(2)).setMimeType('image/png');
+	doc.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
+	doc.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
 	doc.createBuffer();
 
 	const io = new NodeIO();
@@ -89,8 +89,8 @@ test('@gltf-transform/core::io | glb with texture-only buffer', (t) => {
 
 	t.equals(rtTextures[0].getName(), 'TexA', 'reads texture 1');
 	t.equals(rtTextures[1].getName(), 'TexB', 'reads texture 1');
-	t.deepEquals(rtTextures[0].getImage(), new ArrayBuffer(1), 'reads texture 1 data');
-	t.deepEquals(rtTextures[1].getImage(), new ArrayBuffer(2), 'reads texture 2 data');
+	t.deepEquals(rtTextures[0].getImage(), new Uint8Array(1), 'reads texture 1 data');
+	t.deepEquals(rtTextures[1].getImage(), new Uint8Array(2), 'reads texture 2 data');
 	t.end();
 });
 

--- a/packages/core/test/io/web-io.test.ts
+++ b/packages/core/test/io/web-io.test.ts
@@ -53,14 +53,14 @@ test('@gltf-transform/core::io | web read glb + resources', (t) => {
 
 	const jsonText = JSON.stringify(json);
 	const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-	const jsonChunkHeader = BufferUtils.toBuffer(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
+	const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
 	const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
 
 	const binaryChunkData = BufferUtils.pad(new Uint8Array(0), 0x00);
-	const binaryChunkHeader = BufferUtils.toBuffer(new Uint32Array([binaryChunkData.byteLength, 0x004e4942]));
+	const binaryChunkHeader = BufferUtils.toView(new Uint32Array([binaryChunkData.byteLength, 0x004e4942]));
 	const binaryChunk = BufferUtils.concat([binaryChunkHeader, binaryChunkData]);
 
-	const header = BufferUtils.toBuffer(
+	const header = BufferUtils.toView(
 		new Uint32Array([0x46546c67, 2, 12 + jsonChunk.byteLength + binaryChunk.byteLength])
 	);
 

--- a/packages/core/test/io/web-io.test.ts
+++ b/packages/core/test/io/web-io.test.ts
@@ -53,20 +53,22 @@ test('@gltf-transform/core::io | web read glb + resources', (t) => {
 
 	const jsonText = JSON.stringify(json);
 	const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-	const jsonChunkHeader = new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]).buffer;
+	const jsonChunkHeader = BufferUtils.toBuffer(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
 	const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
 
-	const binaryChunkData = BufferUtils.pad(new ArrayBuffer(0), 0x00);
-	const binaryChunkHeader = new Uint32Array([binaryChunkData.byteLength, 0x004e4942]).buffer;
+	const binaryChunkData = BufferUtils.pad(new Uint8Array(0), 0x00);
+	const binaryChunkHeader = BufferUtils.toBuffer(new Uint32Array([binaryChunkData.byteLength, 0x004e4942]));
 	const binaryChunk = BufferUtils.concat([binaryChunkHeader, binaryChunkData]);
 
-	const header = new Uint32Array([0x46546c67, 2, 12 + jsonChunk.byteLength + binaryChunk.byteLength]).buffer;
+	const header = BufferUtils.toBuffer(
+		new Uint32Array([0x46546c67, 2, 12 + jsonChunk.byteLength + binaryChunk.byteLength])
+	);
 
 	const responses = [
-		new ArrayBuffer(4),
-		new ArrayBuffer(3),
-		new ArrayBuffer(2),
-		new ArrayBuffer(1),
+		new Uint8Array(4),
+		new Uint8Array(3),
+		new Uint8Array(2),
+		new Uint8Array(1),
 		BufferUtils.concat([header, jsonChunk, binaryChunk]),
 	];
 
@@ -101,7 +103,7 @@ test('@gltf-transform/core::io | web read glb + resources', (t) => {
 });
 
 test('@gltf-transform/core::io | web read gltf', (t) => {
-	const images = [new ArrayBuffer(4), new ArrayBuffer(3), new ArrayBuffer(2), new ArrayBuffer(1)];
+	const images = [new Uint8Array(4), new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
 
 	mockWindow('https://www.example.com/test');
 	const fetchedPaths = mockFetch({
@@ -141,7 +143,7 @@ test('@gltf-transform/core::io | web read gltf', (t) => {
 });
 
 test('@gltf-transform/core::io | web read + data URIs', async (t) => {
-	const images = [new ArrayBuffer(3), new ArrayBuffer(2), new ArrayBuffer(1)];
+	const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
 	const uris = images.map((image) => {
 		return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
 	});
@@ -160,17 +162,18 @@ test('@gltf-transform/core::io | web read + data URIs', async (t) => {
 	const io = new WebIO();
 
 	const doc = await io.read('test.gltf');
+	const textures = doc.getRoot().listTextures();
 
 	t.deepEquals(fetchedPaths, ['test.gltf'], 'one network request');
-	t.equals(doc.getRoot().listTextures().length, 3, 'reads a textures from Data URIs');
-	t.deepEquals(doc.getRoot().listTextures()[0].getImage(), images[0], 'reads texture 0');
-	t.deepEquals(doc.getRoot().listTextures()[1].getImage(), images[1], 'reads texture 1');
-	t.deepEquals(doc.getRoot().listTextures()[2].getImage(), images[2], 'reads texture 2');
+	t.equals(textures.length, 3, 'reads a textures from Data URIs');
+	t.deepEquals(Array.from(textures[0].getImage()), Array.from(images[0]), 'reads texture 0');
+	t.deepEquals(Array.from(textures[1].getImage()), Array.from(images[1]), 'reads texture 1');
+	t.deepEquals(Array.from(textures[2].getImage()), Array.from(images[2]), 'reads texture 2');
 	t.end();
 });
 
 test('@gltf-transform/core::io | web readJSON + data URIs', (t) => {
-	const images = [new ArrayBuffer(3), new ArrayBuffer(2), new ArrayBuffer(1)];
+	const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
 	const uris = images.map((image) => {
 		return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
 	});
@@ -194,11 +197,12 @@ test('@gltf-transform/core::io | web readJSON + data URIs', (t) => {
 		},
 		resources: {},
 	});
+	const textures = doc.getRoot().listTextures();
 
 	t.deepEquals(fetchedPaths, [], 'no network requests');
-	t.equals(doc.getRoot().listTextures().length, 3, 'reads a textures from Data URIs');
-	t.deepEquals(doc.getRoot().listTextures()[0].getImage(), images[0], 'reads texture 0');
-	t.deepEquals(doc.getRoot().listTextures()[1].getImage(), images[1], 'reads texture 1');
-	t.deepEquals(doc.getRoot().listTextures()[2].getImage(), images[2], 'reads texture 2');
+	t.equals(textures.length, 3, 'reads a textures from Data URIs');
+	t.deepEquals(Array.from(textures[0].getImage()), Array.from(images[0]), 'reads texture 0');
+	t.deepEquals(Array.from(textures[1].getImage()), Array.from(images[1]), 'reads texture 1');
+	t.deepEquals(Array.from(textures[2].getImage()), Array.from(images[2]), 'reads texture 2');
 	t.end();
 });

--- a/packages/core/test/properties/accessor.test.ts
+++ b/packages/core/test/properties/accessor.test.ts
@@ -82,29 +82,31 @@ test('@gltf-transform/core::accessor | getElementSize', (t) => {
 
 test('@gltf-transform/core::accessor | interleaved', (t) => {
 	const resources = {
-		'test.bin': new Uint16Array([
-			// vertex 1
-			0,
-			1,
-			2,
-			10,
-			20,
-			100,
-			200,
+		'test.bin': new Uint8Array(
+			new Uint16Array([
+				// vertex 1
+				0,
+				1,
+				2,
+				10,
+				20,
+				100,
+				200,
 
-			0, // pad
+				0, // pad
 
-			// vertex 2
-			3,
-			4,
-			5,
-			40,
-			50,
-			400,
-			500,
+				// vertex 2
+				3,
+				4,
+				5,
+				40,
+				50,
+				400,
+				500,
 
-			0, // pad
-		]).buffer,
+				0, // pad
+			]).buffer
+		),
 	};
 
 	const json = {
@@ -163,8 +165,8 @@ test('@gltf-transform/core::accessor | interleaved', (t) => {
 
 test('@gltf-transform/core::accessor | sparse', (t) => {
 	const resources = {
-		'indices.bin': new Uint16Array([10, 50, 51]).buffer,
-		'values.bin': new Float32Array([1, 2, 3, 10, 12, 14, 25, 50, 75]).buffer,
+		'indices.bin': new Uint8Array(new Uint16Array([10, 50, 51]).buffer),
+		'values.bin': new Uint8Array(new Float32Array([1, 2, 3, 10, 12, 14, 25, 50, 75]).buffer),
 	};
 
 	const json = {

--- a/packages/core/test/properties/material.test.ts
+++ b/packages/core/test/properties/material.test.ts
@@ -1,7 +1,7 @@
 require('source-map-support').install();
 
 import test from 'tape';
-import { Document, Format, NodeIO, Property, PropertyType, Root, Texture, TextureChannel, TextureInfo } from '../../';
+import { Document, Format, NodeIO, Property, PropertyType, Texture, TextureChannel, TextureInfo } from '../../';
 
 const { R, G, B, A } = TextureChannel;
 
@@ -354,7 +354,7 @@ test('@gltf-transform/core::material | i/o', (t) => {
 	doc.createBuffer();
 
 	const createTexture = (name: string) =>
-		doc.createTexture(name).setImage(new ArrayBuffer(10)).setMimeType('image/png');
+		doc.createTexture(name).setImage(new Uint8Array(10)).setMimeType('image/png');
 
 	const baseColor = createTexture('baseColor');
 	const emissive = createTexture('emissive');

--- a/packages/core/test/properties/skin.test.ts
+++ b/packages/core/test/properties/skin.test.ts
@@ -8,7 +8,7 @@ test('@gltf-transform/core::skin', (t) => {
 
 	const joints = [doc.createNode('joint1'), doc.createNode('joint2'), doc.createNode('joint3')];
 
-	doc.createBuffer('skinBuffer');
+	doc.createBuffer('skinBuffer').setURI('skinTest.bin');
 
 	const ibm = doc
 		.createAccessor('ibm')
@@ -45,10 +45,7 @@ test('@gltf-transform/core::skin', (t) => {
 	doc.createAnimation().addChannel(channel).addSampler(sampler);
 
 	const io = new NodeIO();
-	const options = { basename: 'skinTest' }; // TODO: Defaults have changed!
-	const jsonDoc = io.writeJSON(io.readJSON(io.writeJSON(doc, options)), options);
-
-	console.log('JSONDOC', jsonDoc);
+	const jsonDoc = io.writeJSON(io.readJSON(io.writeJSON(doc, {})));
 
 	t.deepEqual(
 		jsonDoc.json.nodes[3],
@@ -75,8 +72,8 @@ test('@gltf-transform/core::skin', (t) => {
 	const inputAccessor = jsonDoc.json.accessors[jsonDoc.json.animations[0].samplers[0].input];
 	t.notEqual(ibmAccessor.bufferView, inputAccessor.bufferView, 'stores IBMs and animation in different buffer views');
 
-	const actualIBM = new Float32Array(jsonDoc.resources['skinTest.bin'].slice(0, 192));
-	t.deepEqual(actualIBM, ibm.getArray(), 'stores skin IBMs');
+	const actualIBM = new Float32Array(jsonDoc.resources['skinTest.bin'].slice(0, 192).buffer);
+	t.deepEqual(Array.from(actualIBM), Array.from(ibm.getArray()), 'stores skin IBMs');
 
 	t.end();
 });

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -16,8 +16,8 @@ test('@gltf-transform/core::texture | read', (t) => {
 			],
 		},
 		resources: {
-			'tex1.png': new ArrayBuffer(1),
-			'tex2.jpeg': new ArrayBuffer(2),
+			'tex1.png': new Uint8Array(1),
+			'tex2.jpeg': new Uint8Array(2),
 		},
 	};
 
@@ -41,8 +41,8 @@ test('@gltf-transform/core::texture | read', (t) => {
 test('@gltf-transform/core::texture | write', (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const image1 = new ArrayBuffer(1);
-	const image2 = new ArrayBuffer(2);
+	const image1 = new Uint8Array(1);
+	const image2 = new Uint8Array(2);
 	const texture1 = doc.createTexture('tex1').setImage(image1).setURI('tex1.png');
 	const texture2 = doc.createTexture('tex2').setImage(image2).setMimeType('image/jpeg');
 	doc.createMaterial('mat1').setBaseColorTexture(texture1).setNormalTexture(texture2);
@@ -67,7 +67,7 @@ test('@gltf-transform/core::texture | copy', (t) => {
 	const doc = new Document();
 	const tex = doc
 		.createTexture('MyTexture')
-		.setImage(new ArrayBuffer(2))
+		.setImage(new Uint8Array(2))
 		.setMimeType('image/gif')
 		.setURI('path/to/image.gif');
 
@@ -84,7 +84,7 @@ test('@gltf-transform/core::texture | extras', (t) => {
 	const io = new NodeIO();
 	const doc = new Document();
 	doc.createBuffer();
-	doc.createTexture('A').setExtras({ foo: 1, bar: 2 }).setImage(new ArrayBuffer(10)).setMimeType('image/png');
+	doc.createTexture('A').setExtras({ foo: 1, bar: 2 }).setImage(new Uint8Array(10)).setMimeType('image/png');
 
 	const doc2 = io.readJSON(io.writeJSON(doc));
 
@@ -100,9 +100,9 @@ test('@gltf-transform/core::texture | padding', (t) => {
 
 	const doc = new Document();
 	doc.createBuffer();
-	doc.createTexture().setImage(new ArrayBuffer(17)).setMimeType('image/png');
-	doc.createTexture().setImage(new ArrayBuffer(21)).setMimeType('image/png');
-	doc.createTexture().setImage(new ArrayBuffer(20)).setMimeType('image/png');
+	doc.createTexture().setImage(new Uint8Array(17)).setMimeType('image/png');
+	doc.createTexture().setImage(new Uint8Array(21)).setMimeType('image/png');
+	doc.createTexture().setImage(new Uint8Array(20)).setMimeType('image/png');
 
 	const jsonDoc = new NodeIO().writeJSON(doc, { format: Format.GLB });
 

--- a/packages/core/test/utils/image-utils.test.ts
+++ b/packages/core/test/utils/image-utils.test.ts
@@ -19,27 +19,27 @@ test.skip('@gltf-transform/core::image-utils | basic', { skip: !IS_NODEJS }, (t)
 	canvas = createCanvas(100, 50);
 	ctx = canvas.getContext('2d');
 	ctx.fillStyle = '#222222';
-	buffer = BufferUtils.trim(canvas.toBuffer('image/png'));
+	buffer = canvas.toBuffer('image/png');
 	t.deepEquals(ImageUtils.getSize(buffer, 'image/png'), [100, 50], 'gets PNG size');
 
 	canvas = createCanvas(16, 32);
 	ctx = canvas.getContext('2d');
 	ctx.fillStyle = '#222222';
-	buffer = BufferUtils.trim(canvas.toBuffer('image/jpeg'));
+	buffer = canvas.toBuffer('image/jpeg');
 	t.deepEquals(ImageUtils.getSize(buffer, 'image/jpeg'), [16, 32], 'gets JPEG size');
 
 	t.end();
 });
 
 test('@gltf-transform/core::image-utils | png', { skip: !IS_NODEJS }, (t) => {
-	const png = BufferUtils.trim(fs.readFileSync(path.join(__dirname, '..', 'in', 'test.png')));
+	const png = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.png'));
 	const fried = BufferUtils.concat([
-		new ArrayBuffer(12),
+		new Uint8Array(12),
 		BufferUtils.encodeText('CgBI'),
-		new ArrayBuffer(16),
-		new ArrayBuffer(8),
+		new Uint8Array(16),
+		new Uint8Array(8),
 	]);
-	const friedView = new DataView(fried);
+	const friedView = new DataView(fried.buffer, fried.byteOffset);
 	friedView.setUint32(32, 12, false);
 	friedView.setUint32(36, 12, false);
 
@@ -54,9 +54,9 @@ test('@gltf-transform/core::image-utils | png', { skip: !IS_NODEJS }, (t) => {
 });
 
 test('@gltf-transform/core::image-utils | jpeg', { skip: !IS_NODEJS }, (t) => {
-	const jpg = BufferUtils.trim(fs.readFileSync(path.join(__dirname, '..', 'in', 'test.jpg')));
-	const buffer = new ArrayBuffer(100);
-	const view = new DataView(buffer);
+	const jpg = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.jpg'));
+	const array = new Uint8Array(100);
+	const view = new DataView(array.buffer, array.byteOffset);
 
 	t.equals(ImageUtils.getMimeType(jpg), 'image/jpeg', 'detects image/jpeg');
 	t.deepEquals(ImageUtils.getSize(jpg, 'image/jpeg'), [256, 256], 'jpg size');
@@ -65,14 +65,14 @@ test('@gltf-transform/core::image-utils | jpeg', { skip: !IS_NODEJS }, (t) => {
 	t.equals(ImageUtils.getMemSize(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
 
 	view.setUint16(4, 1000, false);
-	t.throws(() => ImageUtils.getSize(buffer, 'image/jpeg'), 'oob');
+	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), 'oob');
 
 	view.setUint16(4, 12, false);
-	t.throws(() => ImageUtils.getSize(buffer, 'image/jpeg'), 'invalid');
+	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), 'invalid');
 
 	view.setUint16(4, 94, false);
 	view.setUint8(94 + 4, 0xff);
-	t.throws(() => ImageUtils.getSize(buffer, 'image/jpeg'), 'no size');
+	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), 'no size');
 
 	t.end();
 });

--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -117,7 +117,7 @@ export class MeshoptCompression extends Extension {
 	private _encoderOptions: Required<EncoderOptions> = DEFAULT_ENCODER_OPTIONS;
 	private _encoderFallbackBuffer: Buffer | null = null;
 	private _encoderBufferViews: { [key: string]: EncodedBufferView } = {};
-	private _encoderBufferViewData: { [key: string]: ArrayBuffer[] } = {};
+	private _encoderBufferViewData: { [key: string]: Uint8Array[] } = {};
 	private _encoderBufferViewAccessors: { [key: string]: GLTF.IAccessor[] } = {};
 
 	/** @hidden */
@@ -200,11 +200,12 @@ export class MeshoptCompression extends Extension {
 			const byteLength = meshoptDef.byteLength || 0;
 			const count = meshoptDef.count;
 			const stride = meshoptDef.byteStride;
-			const result = new Uint8Array(new ArrayBuffer(count * stride));
+			const result = new Uint8Array(count * stride);
 
 			const bufferDef = jsonDoc.json.buffers![viewDef.buffer];
+			// TODO(cleanup): Should be encapsulated in writer-context.ts.
 			const resource = bufferDef.uri ? jsonDoc.resources[bufferDef.uri] : jsonDoc.resources[GLB_BUFFER];
-			const source = new Uint8Array(resource, byteOffset, byteLength);
+			const source = BufferUtils.toBuffer(resource, byteOffset, byteLength);
 
 			this._decoder!.decodeGltfBuffer(result, count, stride, source, meshoptDef.mode, meshoptDef.filter);
 
@@ -344,7 +345,7 @@ export class MeshoptCompression extends Extension {
 			bufferViewAccessors.push(accessorDef);
 
 			// Update buffer view.
-			bufferViewData.push(array.slice().buffer);
+			bufferViewData.push(new Uint8Array(array.buffer, array.byteOffset, array.byteLength));
 			bufferView.byteLength += array.byteLength;
 			bufferView.extensions.EXT_meshopt_compression.count += accessor.getCount();
 		}
@@ -361,9 +362,9 @@ export class MeshoptCompression extends Extension {
 			const otherBufferViews = context.otherBufferViews.get(buffer) || [];
 
 			const { count, byteStride, mode } = bufferView.extensions[NAME];
-			const srcArray = new Uint8Array(BufferUtils.concat(bufferViewData));
+			const srcArray = BufferUtils.concat(bufferViewData);
 			const dstArray = encoder.encodeGltfBuffer(srcArray, count, byteStride, mode);
-			const compressedData = BufferUtils.pad(dstArray.slice().buffer);
+			const compressedData = BufferUtils.pad(dstArray);
 
 			bufferView.extensions[NAME].byteLength = dstArray.byteLength;
 

--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -205,7 +205,7 @@ export class MeshoptCompression extends Extension {
 			const bufferDef = jsonDoc.json.buffers![viewDef.buffer];
 			// TODO(cleanup): Should be encapsulated in writer-context.ts.
 			const resource = bufferDef.uri ? jsonDoc.resources[bufferDef.uri] : jsonDoc.resources[GLB_BUFFER];
-			const source = BufferUtils.toBuffer(resource, byteOffset, byteLength);
+			const source = BufferUtils.toView(resource, byteOffset, byteLength);
 
 			this._decoder!.decodeGltfBuffer(result, count, stride, source, meshoptDef.mode, meshoptDef.filter);
 

--- a/packages/extensions/src/khr-draco-mesh-compression/decoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/decoder.ts
@@ -7,10 +7,10 @@ const NAME = KHR_DRACO_MESH_COMPRESSION;
 export let decoderModule: DecoderModule;
 
 // Initialized when decoder module loads.
-let COMPONENT_ARRAY: {[key: number]: TypedArrayConstructor};
-let DATA_TYPE: {[key: number]: DataType};
+let COMPONENT_ARRAY: { [key: number]: TypedArrayConstructor };
+let DATA_TYPE: { [key: number]: DataType };
 
-export function decodeGeometry(decoder: Decoder, data: Int8Array): Mesh {
+export function decodeGeometry(decoder: Decoder, data: Uint8Array): Mesh {
 	const buffer = new decoderModule.DecoderBuffer();
 	try {
 		buffer.Init(data, data.length);
@@ -58,11 +58,11 @@ export function decodeIndex(decoder: Decoder, mesh: Mesh): Uint16Array | Uint32A
 }
 
 export function decodeAttribute(
-		decoder: Decoder,
-		mesh: Mesh,
-		attribute: Attribute,
-		accessorDef: GLTF.IAccessor): TypedArray {
-
+	decoder: Decoder,
+	mesh: Mesh,
+	attribute: Attribute,
+	accessorDef: GLTF.IAccessor
+): TypedArray {
 	const dataType = DATA_TYPE[accessorDef.componentType];
 	const ArrayCtor = COMPONENT_ARRAY[accessorDef.componentType];
 	const numComponents = attribute.num_components();
@@ -78,7 +78,7 @@ export function decodeAttribute(
 	return array;
 }
 
-export function initDecoderModule (_decoderModule: DecoderModule): void {
+export function initDecoderModule(_decoderModule: DecoderModule): void {
 	decoderModule = _decoderModule;
 
 	COMPONENT_ARRAY = {
@@ -99,4 +99,3 @@ export function initDecoderModule (_decoderModule: DecoderModule): void {
 		[Accessor.ComponentType.BYTE]: decoderModule.DT_INT8,
 	};
 }
-

--- a/packages/extensions/src/khr-draco-mesh-compression/decoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/decoder.ts
@@ -13,7 +13,7 @@ let DATA_TYPE: { [key: number]: DataType };
 export function decodeGeometry(decoder: Decoder, data: Uint8Array): Mesh {
 	const buffer = new decoderModule.DecoderBuffer();
 	try {
-		buffer.Init(data, data.length);
+		buffer.Init(data as unknown as Int8Array, data.length);
 
 		const geometryType = decoder.GetEncodedGeometryType(buffer);
 		if (geometryType !== decoderModule.TRIANGULAR_MESH) {

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -183,7 +183,7 @@ export class DracoMeshCompression extends Extension {
 
 						const byteOffset = bufferViewDef.byteOffset || 0;
 						const byteLength = bufferViewDef.byteLength;
-						const compressedData = BufferUtils.toBuffer(resource, byteOffset, byteLength);
+						const compressedData = BufferUtils.toView(resource, byteOffset, byteLength);
 
 						decoder = new this._decoderModule.Decoder();
 						dracoMesh = decodeGeometry(decoder, compressedData);

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -2,6 +2,7 @@ import {
 	Accessor,
 	bbox,
 	bounds,
+	BufferUtils,
 	Document,
 	Extension,
 	GLB_BUFFER,
@@ -175,13 +176,14 @@ export class DracoMeshCompression extends Extension {
 					if (!dracoMesh || !decoder) {
 						const bufferViewDef = jsonDoc.json.bufferViews![dracoDef.bufferView];
 						const bufferDef = jsonDoc.json.buffers![bufferViewDef.buffer];
+						// TODO(cleanup): Should be encapsulated in writer-context.ts.
 						const resource = bufferDef.uri
 							? jsonDoc.resources[bufferDef.uri]
 							: jsonDoc.resources[GLB_BUFFER];
 
 						const byteOffset = bufferViewDef.byteOffset || 0;
 						const byteLength = bufferViewDef.byteLength;
-						const compressedData = new Int8Array(resource, byteOffset, byteLength);
+						const compressedData = BufferUtils.toBuffer(resource, byteOffset, byteLength);
 
 						decoder = new this._decoderModule.Decoder();
 						dracoMesh = decodeGeometry(decoder, compressedData);

--- a/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
+++ b/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
@@ -17,8 +17,7 @@ interface BasisuDef {
 }
 
 class KTX2ImageUtils implements ImageUtilsFormat {
-	match(buffer: ArrayBuffer): boolean {
-		const array = new Uint8Array(buffer);
+	match(array: Uint8Array): boolean {
 		return (
 			array[0] === 0xab &&
 			array[1] === 0x4b &&
@@ -34,12 +33,12 @@ class KTX2ImageUtils implements ImageUtilsFormat {
 			array[11] === 0x0a
 		);
 	}
-	getSize(buffer: ArrayBuffer): vec2 {
-		const container = readKTX(new Uint8Array(buffer));
+	getSize(array: Uint8Array): vec2 {
+		const container = readKTX(array);
 		return [container.pixelWidth, container.pixelHeight];
 	}
-	getChannels(buffer: ArrayBuffer): number {
-		const container = readKTX(new Uint8Array(buffer));
+	getChannels(array: Uint8Array): number {
+		const container = readKTX(array);
 		const dfd = container.dataFormatDescriptor[0];
 		if (dfd.colorModel === KTX2Model.ETC1S) {
 			return dfd.samples.length === 2 && (dfd.samples[1].channelID & 0xf) === 15 ? 4 : 3;
@@ -48,9 +47,9 @@ class KTX2ImageUtils implements ImageUtilsFormat {
 		}
 		throw new Error(`Unexpected KTX2 colorModel, "${dfd.colorModel}".`);
 	}
-	getGPUByteLength(buffer: ArrayBuffer): number {
-		const container = readKTX(new Uint8Array(buffer));
-		const hasAlpha = this.getChannels(buffer) > 3;
+	getGPUByteLength(array: Uint8Array): number {
+		const container = readKTX(array);
+		const hasAlpha = this.getChannels(array) > 3;
 
 		let uncompressedBytes = 0;
 		for (let i = 0; i < container.levels.length; i++) {

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -32,9 +32,9 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', (t) => {
 	const clearcoat = clearcoatExtension
 		.createClearcoat()
 		.setClearcoatFactor(0.9)
-		.setClearcoatTexture(doc.createTexture().setImage(new ArrayBuffer(1)))
-		.setClearcoatRoughnessTexture(doc.createTexture().setImage(new ArrayBuffer(1)))
-		.setClearcoatNormalTexture(doc.createTexture().setImage(new ArrayBuffer(1)))
+		.setClearcoatTexture(doc.createTexture().setImage(new Uint8Array(1)))
+		.setClearcoatRoughnessTexture(doc.createTexture().setImage(new Uint8Array(1)))
+		.setClearcoatNormalTexture(doc.createTexture().setImage(new Uint8Array(1)))
 		.setClearcoatNormalScale(2.0)
 		.setClearcoatRoughnessFactor(0.1);
 

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -15,7 +15,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', (t) => {
 		.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
 		.setSpecularFactor([0.9, 0.5, 0.8])
 		.setGlossinessFactor(0.5)
-		.setSpecularGlossinessTexture(doc.createTexture().setImage(new ArrayBuffer(1)));
+		.setSpecularGlossinessTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
 	const mat = doc.createMaterial('MyMaterial').setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -13,7 +13,7 @@ test('@gltf-transform/extensions::materials-sheen', (t) => {
 	const sheen = sheenExtension
 		.createSheen()
 		.setSheenColorFactor([0.9, 0.5, 0.8])
-		.setSheenColorTexture(doc.createTexture().setImage(new ArrayBuffer(1)));
+		.setSheenColorTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
 	const mat = doc
 		.createMaterial('MyMaterial')

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -14,8 +14,8 @@ test('@gltf-transform/extensions::materials-specular', (t) => {
 		.createSpecular()
 		.setSpecularFactor(0.9)
 		.setSpecularColorFactor([0.9, 0.5, 0.8])
-		.setSpecularTexture(doc.createTexture().setImage(new ArrayBuffer(1)))
-		.setSpecularColorTexture(doc.createTexture().setImage(new ArrayBuffer(1)));
+		.setSpecularTexture(doc.createTexture().setImage(new Uint8Array(1)))
+		.setSpecularColorTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
 	const mat = doc
 		.createMaterial('MyMaterial')

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -13,7 +13,7 @@ test('@gltf-transform/extensions::materials-transmission', (t) => {
 	const transmission = transmissionExtension
 		.createTransmission()
 		.setTransmissionFactor(0.9)
-		.setTransmissionTexture(doc.createTexture().setImage(new ArrayBuffer(1)));
+		.setTransmissionTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
 	const mat = doc
 		.createMaterial('MyTransmissionMaterial')

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -13,7 +13,7 @@ test('@gltf-transform/extensions::materials-volume', (t) => {
 	const volume = volumeExtension
 		.createVolume()
 		.setThicknessFactor(0.9)
-		.setThicknessTexture(doc.createTexture().setImage(new ArrayBuffer(1)))
+		.setThicknessTexture(doc.createTexture().setImage(new Uint8Array(1)))
 		.setAttenuationDistance(2)
 		.setAttenuationColor([0.1, 0.2, 0.3]);
 

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -1,7 +1,7 @@
 require('source-map-support').install();
 
 import test from 'tape';
-import { BufferUtils, Document, ImageUtils, NodeIO } from '@gltf-transform/core';
+import { Document, ImageUtils, NodeIO } from '@gltf-transform/core';
 import { TextureBasisu } from '../';
 
 const IS_NODEJS = typeof window === 'undefined';
@@ -20,8 +20,8 @@ test('@gltf-transform/extensions::texture-basisu', (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const basisuExtension = doc.createExtension(TextureBasisu);
-	const tex1 = doc.createTexture('BasisTexture').setMimeType('image/ktx2').setImage(new ArrayBuffer(10));
-	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new ArrayBuffer(15));
+	const tex1 = doc.createTexture('BasisTexture').setMimeType('image/ktx2').setImage(new Uint8Array(10));
+	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
 	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
 
 	let jsonDoc;
@@ -53,9 +53,9 @@ test('@gltf-transform/extensions::texture-basisu', (t) => {
 });
 
 test('@gltf-transform/extensions::texture-basisu | image-utils', { skip: !IS_NODEJS }, (t) => {
-	const ktx2 = BufferUtils.trim(fs.readFileSync(path.join(__dirname, 'in', 'test.ktx2')));
+	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', 'test.ktx2'));
 
-	t.throws(() => ImageUtils.getSize(new ArrayBuffer(10), 'image/ktx2'), 'corrupt file');
+	t.throws(() => ImageUtils.getSize(new Uint8Array(10), 'image/ktx2'), 'corrupt file');
 	t.deepEquals(ImageUtils.getSize(ktx2, 'image/ktx2'), [256, 256], 'size');
 	t.equals(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
 	t.equals(ImageUtils.getMemSize(ktx2, 'image/ktx2'), 65536, 'gpuSize');

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -12,9 +12,9 @@ test('@gltf-transform/extensions::texture-transform', (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const transformExtension = doc.createExtension(TextureTransform);
-	const tex1 = doc.createTexture().setMimeType('image/png').setImage(new ArrayBuffer(10));
-	const tex2 = doc.createTexture().setMimeType('image/png').setImage(new ArrayBuffer(15));
-	const tex3 = doc.createTexture().setMimeType('image/png').setImage(new ArrayBuffer(20));
+	const tex1 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(10));
+	const tex2 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(15));
+	const tex3 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(20));
 	const mat = doc.createMaterial();
 	mat.setBaseColorTexture(tex1)
 		.getBaseColorTextureInfo()

--- a/packages/extensions/test/texture-webp.test.ts
+++ b/packages/extensions/test/texture-webp.test.ts
@@ -20,8 +20,8 @@ test('@gltf-transform/extensions::texture-webp', (t) => {
 	const doc = new Document();
 	doc.createBuffer();
 	const webpExtension = doc.createExtension(TextureWebP);
-	const tex1 = doc.createTexture('WebPTexture').setMimeType('image/webp').setImage(new ArrayBuffer(10));
-	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new ArrayBuffer(15));
+	const tex1 = doc.createTexture('WebPTexture').setMimeType('image/webp').setImage(new Uint8Array(10));
+	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
 	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
 
 	let jsonDoc;
@@ -53,17 +53,17 @@ test('@gltf-transform/extensions::texture-webp', (t) => {
 });
 
 test('@gltf-transform/core::image-utils | webp', { skip: !IS_NODEJS }, (t) => {
-	const webpLossy = BufferUtils.trim(fs.readFileSync(path.join(__dirname, 'in', 'test-lossy.webp')));
-	const webpLossless = BufferUtils.trim(fs.readFileSync(path.join(__dirname, 'in', 'test-lossless.webp')));
+	const webpLossy = fs.readFileSync(path.join(__dirname, 'in', 'test-lossy.webp'));
+	const webpLossless = fs.readFileSync(path.join(__dirname, 'in', 'test-lossless.webp'));
 	const buffer = BufferUtils.concat([
 		BufferUtils.encodeText('RIFF'),
-		new ArrayBuffer(4),
+		new Uint8Array(4),
 		BufferUtils.encodeText('WEBP'),
 		BufferUtils.encodeText('OTHR'),
 		new Uint8Array([999, 0, 0, 0]),
 	]);
 
-	t.equals(ImageUtils.getSize(new ArrayBuffer(8), 'image/webp'), null, 'invalid');
+	t.equals(ImageUtils.getSize(new Uint8Array(8), 'image/webp'), null, 'invalid');
 	t.equals(ImageUtils.getSize(buffer, 'image/webp'), null, 'no size');
 	t.deepEquals(ImageUtils.getSize(webpLossy, 'image/webp'), [256, 256], 'size (lossy)');
 	t.deepEquals(ImageUtils.getSize(webpLossless, 'image/webp'), [256, 256], 'size (lossless)');

--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -87,7 +87,7 @@ function dedupAccessors(logger: Logger, doc: Document): void {
 
 		for (let i = 0; i < accessors.length; i++) {
 			const a = accessors[i];
-			const aData = a.getArray()!.slice().buffer;
+			const aData = BufferUtils.toBuffer(a.getArray()!);
 
 			if (duplicateAccessors.has(a)) continue;
 
@@ -101,7 +101,7 @@ function dedupAccessors(logger: Logger, doc: Document): void {
 				if (a.getComponentType() !== b.getComponentType()) continue;
 				if (a.getCount() !== b.getCount()) continue;
 				if (a.getNormalized() !== b.getNormalized()) continue;
-				if (BufferUtils.equals(aData, b.getArray()!.slice().buffer)) {
+				if (BufferUtils.equals(aData, BufferUtils.toBuffer(b.getArray()!))) {
 					duplicateAccessors.set(b, a);
 				}
 			}

--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -87,7 +87,7 @@ function dedupAccessors(logger: Logger, doc: Document): void {
 
 		for (let i = 0; i < accessors.length; i++) {
 			const a = accessors[i];
-			const aData = BufferUtils.toBuffer(a.getArray()!);
+			const aData = BufferUtils.toView(a.getArray()!);
 
 			if (duplicateAccessors.has(a)) continue;
 
@@ -101,7 +101,7 @@ function dedupAccessors(logger: Logger, doc: Document): void {
 				if (a.getComponentType() !== b.getComponentType()) continue;
 				if (a.getCount() !== b.getCount()) continue;
 				if (a.getNormalized() !== b.getNormalized()) continue;
-				if (BufferUtils.equals(aData, BufferUtils.toBuffer(b.getArray()!))) {
+				if (BufferUtils.equals(aData, BufferUtils.toView(b.getArray()!))) {
 					duplicateAccessors.set(b, a);
 				}
 			}

--- a/packages/functions/src/texture-resize.ts
+++ b/packages/functions/src/texture-resize.ts
@@ -79,7 +79,7 @@ export function textureResize(_options: TextureResizeOptions = TEXTURE_RESIZE_DE
 				dstHeight = maxHeight;
 			}
 
-			const srcImage = new Uint8Array(texture.getImage() as ArrayBuffer);
+			const srcImage = texture.getImage()!;
 			const srcPixels = await getPixels(srcImage, texture.getMimeType());
 			const dstPixels = ndarray(
 				new Uint8Array(dstWidth * dstHeight * 4), [dstWidth, dstHeight, 4]
@@ -101,7 +101,7 @@ export function textureResize(_options: TextureResizeOptions = TEXTURE_RESIZE_DE
 				throw e;
 			}
 
-			texture.setImage((await savePixels(dstPixels, texture.getMimeType())).buffer);
+			texture.setImage(await savePixels(dstPixels, texture.getMimeType()));
 		}
 
 		logger.debug(`${NAME}: Complete.`);

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -30,7 +30,7 @@ export async function rewriteTexture(
 	const srcImage = source.getImage();
 	if (!srcImage) return null;
 
-	const pixels = await getPixels(new Uint8Array(srcImage), source.getMimeType());
+	const pixels = await getPixels(srcImage, source.getMimeType());
 
 	for(let i = 0; i < pixels.shape[0]; ++i) {
 		for(let j = 0; j < pixels.shape[1]; ++j) {
@@ -38,7 +38,7 @@ export async function rewriteTexture(
 		}
 	}
 
-	const dstImage = (await savePixels(pixels, 'image/png')).buffer;
+	const dstImage = await savePixels(pixels, 'image/png');
 	return target.setImage(dstImage).setMimeType('image/png');
 }
 

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -100,10 +100,10 @@ test('@gltf-transform/functions::dedup | textures', (t) => {
 	const canvas = createCanvas(100, 50);
 	const ctx = canvas.getContext('2d');
 	ctx.fillStyle = '#222222';
-	const buffer = canvas.toBuffer('image/png').slice().buffer;
+	const image = canvas.toBuffer('image/png');
 
-	const tex1 = doc.createTexture('copy 1').setMimeType('image/png').setImage(buffer);
-	const tex2 = doc.createTexture('copy 2').setMimeType('image/png').setImage(buffer.slice(0));
+	const tex1 = doc.createTexture('copy 1').setMimeType('image/png').setImage(image);
+	const tex2 = doc.createTexture('copy 2').setMimeType('image/png').setImage(image.slice());
 
 	const transmission = transmissionExt.createTransmission().setTransmissionTexture(tex2);
 	const mat = doc.createMaterial().setBaseColorTexture(tex1).setExtension('KHR_materials_transmission', transmission);

--- a/packages/functions/test/inspect.test.ts
+++ b/packages/functions/test/inspect.test.ts
@@ -10,7 +10,7 @@ test('@gltf-transform/functions::inspect', (t) => {
 	const doc = io.read(path.join(__dirname, 'in/TwoCubes.glb')).setLogger(new Logger(Logger.Verbosity.SILENT));
 
 	doc.createAnimation('TestAnim');
-	doc.createTexture('TestTex').setImage(new ArrayBuffer(10)).setMimeType('image/fake');
+	doc.createTexture('TestTex').setImage(new Uint8Array(10)).setMimeType('image/fake');
 
 	const report = inspect(doc);
 

--- a/packages/functions/test/metal-rough.test.ts
+++ b/packages/functions/test/metal-rough.test.ts
@@ -24,11 +24,11 @@ const SPEC = ndarray(new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 
 // 1 - gloss * glossFactor
 const ROUGH = ndarray(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 64, 0, 0, 0, 128]), [1, 4, 4]);
 
-async function ndarrayToImage(pixels): Promise<ArrayBuffer> {
-	return (await savePixels(pixels, 'image/png')).buffer;
+async function ndarrayToImage(pixels): Promise<Uint8Array> {
+	return await savePixels(pixels, 'image/png');
 }
 
-test('@gltf-transform/functions::metalRough | textures', async (t) => {
+test.only('@gltf-transform/functions::metalRough | textures', async (t) => {
 	const doc = new Document();
 	const baseColorTex = doc
 		.createTexture()
@@ -79,12 +79,12 @@ test('@gltf-transform/functions::metalRough | textures', async (t) => {
 	t.ok(baseColorTex.isDisposed(), 'disposes baseColorTexture');
 	t.ok(metalRoughTex.isDisposed(), 'disposes metalRoughTexture');
 	t.ok(specGlossTex.isDisposed(), 'disposes specGlossTexture');
-	t.deepEqual(mat.getBaseColorTexture().getImage(), baseColorImage, 'diffuse -> baseColor');
-	t.deepEqual(mat.getMetallicRoughnessTexture().getImage(), roughImage, 'spec -> rough');
+	t.deepEqual(Array.from(mat.getBaseColorTexture().getImage()), Array.from(baseColorImage), 'diffuse -> baseColor');
+	t.deepEqual(Array.from(mat.getMetallicRoughnessTexture().getImage()), Array.from(roughImage), 'spec -> rough');
 	t.deepEqual(
 		mat.getExtension<Specular>('KHR_materials_specular').getSpecularTexture().getImage(),
 		specImage,
-		'diffuse -> baseColor'
+		'spec -> spec'
 	);
 	t.equal(mat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1000, 'ior = 1000');
 	t.equal(mat.getRoughnessFactor(), 1, 'roughnessFactor = 1');

--- a/packages/functions/test/metal-rough.test.ts
+++ b/packages/functions/test/metal-rough.test.ts
@@ -21,7 +21,7 @@ const SPEC_GLOSS = ndarray(new Uint8Array([255, 0, 0, 0, 0, 255, 0, 64, 0, 0, 25
 
 const SPEC = ndarray(new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 0, 0, 0, 255]), [1, 4, 4]);
 
-// orm.R = 1 - specGloss.A * glossFactor
+// orm.G = 1 - specGloss.A * glossFactor
 const ROUGH = ndarray(new Uint8Array([0, 255, 0, 255, 0, 223, 0, 255, 0, 191, 0, 255, 0, 127, 0, 255]), [1, 4, 4]);
 
 test('@gltf-transform/functions::metalRough | textures', async (t) => {

--- a/packages/functions/test/texture-resize.test.ts
+++ b/packages/functions/test/texture-resize.test.ts
@@ -12,8 +12,8 @@ const GRADIENT_HALF = getPixels(path.resolve(__dirname, './in/pattern-half.png')
 const NON_SQUARE = ndarray(new Uint8Array(256 * 512 * 4), [256, 512, 4]);
 
 test('@gltf-transform/functions::textureResize', async (t) => {
-	const gradientImage = (await savePixels(await GRADIENT, 'image/png')).buffer;
-	const gradientHalfImage = (await savePixels(await GRADIENT_HALF, 'image/png')).buffer;
+	const gradientImage = await savePixels(await GRADIENT, 'image/png');
+	const gradientHalfImage = await savePixels(await GRADIENT_HALF, 'image/png');
 
 	const document = new Document();
 	const texture = document.createTexture('target').setImage(gradientImage).setMimeType('image/png');
@@ -24,16 +24,12 @@ test('@gltf-transform/functions::textureResize', async (t) => {
 
 	await document.transform(textureResize({ size: [4, 4], pattern: /target/ }));
 
-	t.deepEqual(
-		Array.from(new Uint8Array(texture.getImage())),
-		Array.from(new Uint8Array(gradientHalfImage)),
-		'match - resize down'
-	);
+	t.deepEqual(Array.from(texture.getImage()), Array.from(gradientHalfImage), 'match - resize down');
 
 	await document.transform(textureResize({ size: [2, 4] }));
 
 	t.deepEqual(
-		(await getPixels(new Uint8Array(texture.getImage()), 'image/png')).shape,
+		(await getPixels(texture.getImage(), 'image/png')).shape,
 		[2, 2, 4],
 		'all - resize down with aspect ratio'
 	);
@@ -42,16 +38,12 @@ test('@gltf-transform/functions::textureResize', async (t) => {
 });
 
 test('@gltf-transform/functions::textureResize | aspect ratio', async (t) => {
-	const nonSquareImage = (await savePixels(await NON_SQUARE, 'image/png')).buffer;
+	const nonSquareImage = await savePixels(await NON_SQUARE, 'image/png');
 	const document = new Document();
 	const texture = document.createTexture('target').setImage(nonSquareImage).setMimeType('image/png');
 
 	await document.transform(textureResize({ size: [16, 16] }));
 
-	t.deepEqual(
-		(await getPixels(new Uint8Array(texture.getImage()), 'image/png')).shape,
-		[8, 16, 4],
-		'maintain aspect ratio'
-	);
+	t.deepEqual((await getPixels(texture.getImage(), 'image/png')).shape, [8, 16, 4], 'maintain aspect ratio');
 	t.end();
 });


### PR DESCRIPTION
Public APIs like `texture.setImage(...)` and `io.readBinary(...)` now deal in Uint8Arrays rather than ArrayBuffers. This allows the library to more efficiently avoid unnecessary data copying, and should prevent a common class of errors where users write something like this...

```js
const image = fs.readFileSync('path/to/image.png');
texture.setImage(image.buffer);
```

... not realizing that the underlying ArrayBuffer may contain other data in Node.js memory, not just the image.

Remaining:

- [x] Roundtrip tests