### PR TITLE
Add test scaffold for Deno

### DIFF
--- a/test/deno-import-map.json
+++ b/test/deno-import-map.json
@@ -1,0 +1,10 @@
+{
+   "imports": {
+      "tape": "../test/deno-tape.ts",
+      "canvas": "https://deno.land/x/canvas/mod.ts",
+      "@gltf-transform/core": "../packages/core/dist/core.modern.js",
+      "gl-matrix/mat4": "../node_modules/gl-matrix/esm/mat4.js",
+      "gl-matrix/vec3": "../node_modules/gl-matrix/esm/vec3.js",
+      "property-graph": "../node_modules/property-graph/dist/property-graph.modern.js"
+   }
+}

--- a/test/deno-tape.ts
+++ b/test/deno-tape.ts
@@ -1,0 +1,39 @@
+
+import { assert, assertEquals, assertNotEquals, assertStrictEquals, assertNotStrictEquals, assertMatch, assertThrows } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+
+class TestInstance {
+	ok = assert;
+	equal = assertStrictEquals;
+	equals = assertStrictEquals;
+	notEqual = assertNotStrictEquals;
+	notEquals = assertNotStrictEquals;
+	deepEqual = assertEquals;
+	deepEquals = assertEquals;
+	notDeepEqual = assertNotEquals;
+	notDeepEquals = assertNotEquals;
+	match = assertMatch;
+	throws = assertThrows;
+	fail(msg: string) {
+		throw new Error(msg);
+	}
+	end() {};
+}
+
+interface TestOptions {
+	skip?: boolean;
+}
+
+type TestCallback = (t: any) => any;
+
+function test(name: string, fn: TestCallback): void;
+function test(name: string, opts: TestOptions, fn: TestCallback): void;
+function test(name: string, fnOrOpts: TestOptions | TestCallback, fn?: TestCallback): void {
+	const t  = new TestInstance();
+	if (typeof fnOrOpts === 'function') {
+		Deno.test(name, fnOrOpts.bind(t, t));
+	} else if (!fnOrOpts.skip) {
+		Deno.test(name, (fn as TestCallback).bind(t, t));
+	}
+}
+
+export default test;


### PR DESCRIPTION
Work in progress, attempting to get the unit tests (or most of them, at least) to run in Deno. I'm creating a shim for the 'tape' dependency, based on Deno's built-in `Deno.test` and assertions. This still gives tap-compatible output, which is nice.

```shell
deno test --import-map test/deno-import-map.json --no-check packages/core/test/
```

Currently any tests relying on NodeIO fails (a lot of tests); this depends on #380. Ideally the unit tests (excluding NodeIO-specific tests) would use a shared utility to get an I/O instance appropriate for the current test environment.

- Fixes #457