### PR TITLE
NodeIO: Add 'setAllowHTTP(bool)'

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
     "meshoptimizer": "^0.17.0",
     "mikktspace": "^1.1.0",
     "minimatch": "^3.0.4",
+    "node-fetch": "^2.6.6",
     "node-gzip": "^1.1.2",
     "semver": "^7.3.5",
     "tmp": "^0.2.1"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -975,20 +975,20 @@ so this workflow is not a replacement for video playback.
 			.transform(sequence({...options, pattern} as SequenceOptions));
 	});
 
-program.option('--vertex-layout <layout>', 'Vertex layout method', {
-	global: true,
-	default: VertexLayout.INTERLEAVED,
-	validator: [VertexLayout.INTERLEAVED, VertexLayout.SEPARATE],
-	action: ({options}) => {
-		io.setVertexLayout(options.vertexLayout as VertexLayout);
-	},
-});
-program.option('--allow-http', 'Allows HTTP requests', {
+program.option('--allow-http', 'Allows reads from HTTP requests.', {
 	global: true,
 	default: false,
 	validator: program.BOOLEAN,
 	action: ({options}) => {
 		if (options.allowHttp) io.setAllowHTTP(true);
+	},
+});
+program.option('--vertex-layout <layout>', 'Vertex buffer layout preset.', {
+	global: true,
+	default: VertexLayout.INTERLEAVED,
+	validator: [VertexLayout.INTERLEAVED, VertexLayout.SEPARATE],
+	action: ({options}) => {
+		io.setVertexLayout(options.vertexLayout as VertexLayout);
 	},
 });
 program.disableGlobalOption('--quiet');

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -15,6 +15,7 @@ import { ValidateOptions, validate } from './validate';
 let io: NodeIO;
 
 // Use require() so microbundle doesn't compile these.
+const fetch = require('node-fetch');
 const draco3d = require('draco3dgltf');
 const mikktspace = require('mikktspace');
 const { MeshoptDecoder, MeshoptEncoder } = require('meshoptimizer');
@@ -26,7 +27,7 @@ const programReady = new Promise<void>((resolve) => {
 		MeshoptDecoder.ready,
 		MeshoptEncoder.ready,
 	]).then(([decoder, encoder, _]) => {
-		io = new NodeIO()
+		io = new NodeIO(fetch)
 			.registerExtensions(ALL_EXTENSIONS)
 			.registerDependencies({
 				'draco3d.decoder': decoder,
@@ -980,6 +981,14 @@ program.option('--vertex-layout <layout>', 'Vertex layout method', {
 	validator: [VertexLayout.INTERLEAVED, VertexLayout.SEPARATE],
 	action: ({options}) => {
 		io.setVertexLayout(options.vertexLayout as VertexLayout);
+	},
+});
+program.option('--allow-http', 'Allows HTTP requests', {
+	global: true,
+	default: false,
+	validator: program.BOOLEAN,
+	action: ({options}) => {
+		if (options.allowHttp) io.setAllowHTTP(true);
 	},
 });
 program.disableGlobalOption('--quiet');

--- a/packages/core/test/io/node-io.test.ts
+++ b/packages/core/test/io/node-io.test.ts
@@ -60,7 +60,7 @@ test('@gltf-transform/core::io | node.js read glb http', { skip: environment !==
 		glob.sync(path.join(__dirname, '../in/**/*.glb')).map(async (inputURI) => {
 			const basepath = inputURI.replace(path.join(__dirname, '../in'), MOCK_DOMAIN);
 
-			const io = new NodeIO(fetch);
+			const io = new NodeIO(fetch).setAllowHTTP(true);
 			const doc = await io.read(basepath);
 
 			t.ok(doc, `Read "${basepath}".`);
@@ -77,7 +77,7 @@ test('@gltf-transform/core::io | node.js read gltf http', { skip: environment !=
 		glob.sync(path.join(__dirname, '../in/**/*.gltf')).map(async (inputURI) => {
 			const basepath = inputURI.replace(path.join(__dirname, '../in'), MOCK_DOMAIN);
 
-			const io = new NodeIO(fetch);
+			const io = new NodeIO(fetch).setAllowHTTP(true);
 			const doc = await io.read(basepath);
 
 			t.ok(doc, `Read "${basepath}".`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6155,6 +6155,13 @@ node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
+  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp@^5.0.2:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.1.1.tgz#eb915f7b631c937d282e33aed44cb7a025f62a3e"
@@ -8673,6 +8680,11 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -9016,10 +9028,23 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.4.0:
   version "8.5.0"


### PR DESCRIPTION
Allows HTTP requests from Node.js if Fetch API is provided _and_ `setAllowHTTP(true)` or `--allow-http` are invoked.

Example:

```shell
gltf-transform inspect https://example.com/path/to/model.glb --allow-http
```