### PR TITLE
Don't use meshopt filters for animation sampler input

### DIFF
--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -172,7 +172,7 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 		}
 
 		// See: https://github.com/donmccurdy/glTF-Transform/issues/489
-		if (refName === 'input') return { filter: MeshoptFilter.NONE, bits: 12 };
+		if (refName === 'input') return { filter: MeshoptFilter.NONE };
 
 		if (refName === 'inverseBindMatrices') return { filter: MeshoptFilter.NONE };
 	}

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -170,7 +170,10 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 			if (targetPath === 'scale') return { filter: MeshoptFilter.EXPONENTIAL, bits: 12 };
 			return { filter: MeshoptFilter.NONE };
 		}
-		if (refName === 'input') return { filter: MeshoptFilter.EXPONENTIAL, bits: 12 };
+
+		// See: https://github.com/donmccurdy/glTF-Transform/issues/489
+		if (refName === 'input') return { filter: MeshoptFilter.NONE, bits: 12 };
+
 		if (refName === 'inverseBindMatrices') return { filter: MeshoptFilter.NONE };
 	}
 


### PR DESCRIPTION
Fixes https://github.com/donmccurdy/glTF-Transform/issues/489.

@hybridherbst this passes validation, but could you confirm the asset created after this patch (attached) has the animation data you expect? I'm not sure how to reproduce the graph you showed in the original issue. Thanks! 

[Arm.CUST-meshopt-high.glb.zip](https://github.com/donmccurdy/glTF-Transform/files/8028460/Arm.CUST-meshopt-high.glb.zip)
 