### PR TITLE
I/O: Separation of file and URL resolution

### DIFF
--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -78,13 +78,6 @@ export class NodeIO extends PlatformIO {
 		return this;
 	}
 
-	/** @hidden */
-	protected detectFormat(uri: string): Format {
-		// Override PlatformIO, which only uses HTTPUtils.
-		const extension = HTTPUtils.isAbsoluteURL(uri) ? HTTPUtils.extension(uri) : FileUtils.extension(uri);
-		return extension === 'glb' ? Format.GLB : Format.GLTF;
-	}
-
 	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array>;
 	protected async readURI(uri: string, type: 'text'): Promise<string>;
 	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string> {

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -78,6 +78,13 @@ export class NodeIO extends PlatformIO {
 		return this;
 	}
 
+	/** @hidden */
+	protected detectFormat(uri: string): Format {
+		// Override PlatformIO, which only uses HTTPUtils.
+		const extension = HTTPUtils.isAbsoluteURL(uri) ? HTTPUtils.extension(uri) : FileUtils.extension(uri);
+		return extension === 'glb' ? Format.GLB : Format.GLTF;
+	}
+
 	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array>;
 	protected async readURI(uri: string, type: 'text'): Promise<string>;
 	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string> {
@@ -145,7 +152,7 @@ export class NodeIO extends PlatformIO {
 		await fs.writeFile(uri, jsonContent);
 		const pending = Object.keys(resources).map(async (resourceURI) => {
 			if (HTTPUtils.isAbsoluteURL(resourceURI)) {
-				if (FileUtils.extension(resourceURI) === 'bin') {
+				if (HTTPUtils.extension(resourceURI) === 'bin') {
 					throw new Error(`Cannot write buffer to path "${resourceURI}".`);
 				}
 				return;

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -3,7 +3,7 @@ import { Document } from '../document';
 import { Extension } from '../extension';
 import { JSONDocument } from '../json-document';
 import { GLTF } from '../types/gltf';
-import { BufferUtils, FileUtils, Logger, uuid } from '../utils/';
+import { BufferUtils, FileUtils, HTTPUtils, Logger, uuid } from '../utils/';
 import { GLTFReader } from './reader';
 import { GLTFWriter, WriterOptions } from './writer';
 
@@ -91,7 +91,7 @@ export abstract class PlatformIO {
 
 	/** Loads a URI and returns a {@link JSONDocument} struct, without parsing. */
 	public async readAsJSON(uri: string): Promise<JSONDocument> {
-		const isGLB = uri.match(/^data:application\/octet-stream;/) || FileUtils.extension(uri) === 'glb';
+		const isGLB = uri.match(/^data:application\/octet-stream;/) || this.detectFormat(uri) === Format.GLB;
 		return isGLB ? this._readGLB(uri) : this._readGLTF(uri);
 	}
 
@@ -174,6 +174,12 @@ export abstract class PlatformIO {
 	/**********************************************************************************************
 	 * Internal.
 	 */
+
+	/** @hidden */
+	protected detectFormat(uri: string): Format {
+		// NodeIO overrides this to use FileUtils, instead.
+		return HTTPUtils.extension(uri) === 'glb' ? Format.GLB : Format.GLTF;
+	}
 
 	private async _readGLTF(uri: string): Promise<JSONDocument> {
 		this.lastReadBytes = 0;

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -177,8 +177,9 @@ export abstract class PlatformIO {
 
 	/** @hidden */
 	protected detectFormat(uri: string): Format {
-		// NodeIO overrides this to use FileUtils, instead.
-		return HTTPUtils.extension(uri) === 'glb' ? Format.GLB : Format.GLTF;
+		// Overriden by WebIO, which only uses HTTPUtils.
+		const extension = HTTPUtils.isAbsoluteURL(uri) ? HTTPUtils.extension(uri) : FileUtils.extension(uri);
+		return extension === 'glb' ? Format.GLB : Format.GLTF;
 	}
 
 	private async _readGLTF(uri: string): Promise<JSONDocument> {

--- a/packages/core/src/io/web-io.ts
+++ b/packages/core/src/io/web-io.ts
@@ -1,5 +1,6 @@
 import { PlatformIO } from './platform-io';
 import { HTTPUtils } from '../utils';
+import { Format } from '../constants';
 
 /**
  * # WebIO
@@ -58,5 +59,10 @@ export class WebIO extends PlatformIO {
 
 	protected dirname(uri: string): string {
 		return HTTPUtils.dirname(uri);
+	}
+
+	/** @hidden */
+	protected detectFormat(uri: string): Format {
+		return HTTPUtils.extension(uri) === 'glb' ? Format.GLB : Format.GLTF;
 	}
 }

--- a/packages/core/src/utils/file-utils.ts
+++ b/packages/core/src/utils/file-utils.ts
@@ -1,6 +1,4 @@
-// Need a placeholder domain to construct a URL from a relative path. We only
-// access `url.pathname`, so the domain doesn't matter.
-const NULL_DOMAIN = 'https://null.example';
+import { ImageUtils } from './image-utils';
 
 /**
  * # FileUtils
@@ -10,24 +8,30 @@ const NULL_DOMAIN = 'https://null.example';
  * @category Utilities
  */
 export class FileUtils {
-	/** Extracts the basename from a path, e.g. "folder/model.glb" -> "model". */
-	static basename(path: string): string {
-		path = new URL(path, NULL_DOMAIN).pathname;
-		const fileName = path.split(/[\\/]/).pop()!;
+	/**
+	 * Extracts the basename from a file path, e.g. "folder/model.glb" -> "model".
+	 * See: {@link HTTPUtils.basename}
+	 */
+	static basename(uri: string): string {
+		const fileName = uri.split(/[\\/]/).pop()!;
 		return fileName.substring(0, fileName.lastIndexOf('.'));
 	}
 
-	/** Extracts the extension from a path, e.g. "folder/model.glb" -> "glb". */
-	static extension(path: string): string {
-		if (path.indexOf('data:') !== 0) {
-			path = new URL(path, NULL_DOMAIN).pathname;
-			return path.split(/[\\/]/).pop()!.split(/[.]/).pop()!;
-		} else if (path.indexOf('data:image/png') === 0) {
-			return 'png';
-		} else if (path.indexOf('data:image/jpeg') === 0) {
-			return 'jpeg';
-		} else {
+	/**
+	 * Extracts the extension from a file path, e.g. "folder/model.glb" -> "glb".
+	 * See: {@link HTTPUtils.extension}
+	 */
+	static extension(uri: string): string {
+		if (uri.startsWith('data:image/')) {
+			const mimeType = uri.match(/data:(image\/\w+)/)![1];
+			return ImageUtils.mimeTypeToExtension(mimeType);
+		} else if (uri.startsWith('data:model/gltf+json')) {
+			return 'gltf';
+		} else if (uri.startsWith('data:model/gltf-binary')) {
+			return 'glb';
+		} else if (uri.startsWith('data:application/')) {
 			return 'bin';
 		}
+		return uri.split(/[\\/]/).pop()!.split(/[.]/).pop()!;
 	}
 }

--- a/packages/core/src/utils/http-utils.ts
+++ b/packages/core/src/utils/http-utils.ts
@@ -1,4 +1,16 @@
-/** @internal */
+import { FileUtils } from './file-utils';
+
+// Need a placeholder domain to construct a URL from a relative path. We only
+// access `url.pathname`, so the domain doesn't matter.
+const NULL_DOMAIN = 'https://null.example';
+
+/**
+ * # HTTPUtils
+ *
+ * *Utility class for working with URLs.*
+ *
+ * @category Utilities
+ */
 export class HTTPUtils {
 	static readonly DEFAULT_INIT: RequestInit = {};
 	static readonly PROTOCOL_REGEXP = /^[a-zA-Z]+:\/\//;
@@ -7,6 +19,22 @@ export class HTTPUtils {
 		const index = path.lastIndexOf('/');
 		if (index === -1) return './';
 		return path.substring(0, index + 1);
+	}
+
+	/**
+	 * Extracts the basename from a URL, e.g. "folder/model.glb" -> "model".
+	 * See: {@link FileUtils.basename}
+	 */
+	static basename(uri: string): string {
+		return FileUtils.basename(new URL(uri, NULL_DOMAIN).pathname);
+	}
+
+	/**
+	 * Extracts the extension from a URL, e.g. "folder/model.glb" -> "glb".
+	 * See: {@link FileUtils.extension}
+	 */
+	static extension(uri: string): string {
+		return FileUtils.extension(new URL(uri, NULL_DOMAIN).pathname);
 	}
 
 	static resolve(base: string, path: string) {

--- a/packages/core/test/utils/file-utils.test.ts
+++ b/packages/core/test/utils/file-utils.test.ts
@@ -10,7 +10,7 @@ test('@gltf-transform/core::file-utils | basename', (t) => {
 test('@gltf-transform/core::file-utils | extension', (t) => {
 	t.equals(FileUtils.extension('http://foo.com/path/to/index.html'), 'html', 'URI');
 	t.equals(FileUtils.extension('data:image/png;base64,iVBORw0K'), 'png', 'PNG data URI');
-	t.equals(FileUtils.extension('data:image/jpeg;base64,iVBORw0K'), 'jpeg', 'JPEG data URI');
+	t.equals(FileUtils.extension('data:image/jpeg;base64,iVBORw0K'), 'jpg', 'JPEG data URI');
 	t.equals(FileUtils.extension('data:application/octet-stream;base64,iVBORw0K'), 'bin', 'binary data URI');
 	t.end();
 });


### PR DESCRIPTION
Fixes #510.

Summary:

- NodeIO
  - URIs without protocol are considered file paths
  - URIs with protocol are considered HTTP paths
- WebIO
  - all paths are HTTP paths

To support that separation, this PR includes some separation of methods in HTTPUtils and FileUtils.

Remaining:

- [x] Update DenoIO to match NodeIO