### PR TITLE
Add scene names to merged documents

### DIFF
--- a/packages/cli/src/transforms/merge.ts
+++ b/packages/cli/src/transforms/merge.ts
@@ -28,11 +28,13 @@ const merge = (options: MergeOptions): Transform => {
 					.setMimeType(ImageUtils.extensionToMimeType(extension))
 					.setURI(basename + '.' + extension);
 			} else if (['gltf', 'glb'].includes(extension)) {
-				doc.merge(await io.read(path));
+				doc.merge(renameScenes(basename, await io.read(path)));
 			} else {
 				throw new Error(`Unknown file extension: "${extension}".`);
 			}
 		}
+
+		doc.getRoot().setDefaultScene(doc.getRoot().listScenes()[0]);
 
 		if (!options.partition) {
 			const buffer = doc.getRoot().listBuffers()[0];
@@ -47,5 +49,17 @@ const merge = (options: MergeOptions): Transform => {
 		logger.debug(`${NAME}: Complete.`);
 	};
 };
+
+function renameScenes(name: string, document: Document): Document {
+	const scenes = document.getRoot().listScenes();
+
+	for (let i = 0; i < scenes.length; i++) {
+		if (!scenes[i].getName()) {
+			scenes[i].setName(name + (scenes.length > 1 ? ` (${i + 1}/${scenes.length})` : ''));
+		}
+	}
+
+	return document;
+}
 
 export { merge };

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -75,7 +75,7 @@ test('@gltf-transform/cli::merge', async (t) => {
 	await io.write(inputA, docA);
 
 	const docB = new Document();
-	docB.createScene('SceneB');
+	docB.createScene('');
 	const bufB = docB.createBuffer('BufferB');
 	docB.createAccessor()
 		.setArray(new Uint8Array([1, 2, 3]))
@@ -84,19 +84,15 @@ test('@gltf-transform/cli::merge', async (t) => {
 
 	fs.writeFileSync(inputC, Buffer.from([1, 2, 3, 4, 5]));
 
-	return (
-		program
-			// https://github.com/mattallty/Caporal.js/issues/195
-			.exec(['merge', [inputA, inputB, inputC, output].join(',')], { silent: true })
-			.then(async () => {
-				const doc = await io.read(output);
-				const sceneNames = doc
-					.getRoot()
-					.listScenes()
-					.map((s) => s.getName());
-				const texName = doc.getRoot().listTextures()[0].getName();
-				t.deepEquals(sceneNames, ['SceneA', 'SceneB'], 'merge scenes');
-				t.equals(texName, FileUtils.basename(inputC), 'merge textures');
-			})
-	);
+	await program
+		// https://github.com/mattallty/Caporal.js/issues/195
+		.exec(['merge', [inputA, inputB, inputC, output].join(',')], { silent: true });
+
+	const doc = await io.read(output);
+	const root = doc.getRoot();
+	const sceneNames = root.listScenes().map((s) => s.getName());
+	const texName = root.listTextures()[0].getName();
+	t.deepEquals(sceneNames, ['SceneA', FileUtils.basename(inputB)], 'merge scenes');
+	t.equals(texName, FileUtils.basename(inputC), 'merge textures');
+	t.end();
 });


### PR DESCRIPTION
When merging multiple glTF documents through the CLI, use filenames as scene names if not otherwise specified.