### PR TITLE
Add engines.node entry for CLI

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,9 @@
   "browserslist": [
     "node >= 14"
   ],
+  "engines": {
+    "node": ">=14"
+  },
   "scripts": {
     "dist": "microbundle --format cjs --target node",
     "watch": "microbundle watch --format cjs --target node",


### PR DESCRIPTION
Marks `@gltf-transform/cli` as incompatible with node <14. The compatibility requirement began with gltf transform v2 but was not marked in package.json at the time, leading to issues like https://github.com/donmccurdy/glTF-Transform/discussions/594.