### PR TITLE
The node of IAnimationChannelTarget should be optional

### DIFF
--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -455,9 +455,9 @@ export class GLTFReader {
 				const channel = doc
 					.createAnimationChannel()
 					.setSampler(samplers[channelDef.sampler])
-					.setTargetNode(context.nodes[channelDef.target.node])
 					.setTargetPath(channelDef.target.path);
 
+				if (channelDef.target.node !== undefined) channel.setTargetNode(context.nodes[channelDef.target.node]);
 				if (channelDef.extras) channel.setExtras(channelDef.extras);
 
 				animation.addChannel(channel);

--- a/packages/core/src/types/gltf.ts
+++ b/packages/core/src/types/gltf.ts
@@ -161,9 +161,9 @@ export declare module GLTF {
 	 */
 	interface IAnimationChannelTarget extends IProperty {
 		/**
-		 * The index of the node to target
+		 * The index of the node to target, when undefined, the animated object MAY be defined by an extension.
 		 */
-		node: number;
+		node?: number;
 		/**
 		 * The name of the node's TRS property to modify, or the weights of the Morph Targets it
 		 * instantiates


### PR DESCRIPTION
See https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-animation-channel-target
<img width="915" alt="image" src="https://user-images.githubusercontent.com/800043/174007621-55e85abd-5fc4-4249-ba22-b08f8aa001bc.png">
