### PR TITLE
Add ILogger interface

### DIFF
--- a/packages/cli/src/inspect.ts
+++ b/packages/cli/src/inspect.ts
@@ -1,6 +1,6 @@
 import CLITable from 'cli-table3';
 import { stringify } from 'csv-stringify';
-import type { JSONDocument, Logger, NodeIO, WebIO } from '@gltf-transform/core';
+import type { JSONDocument, ILogger, NodeIO, WebIO } from '@gltf-transform/core';
 import {
 	InspectAnimationReport,
 	InspectMaterialReport,
@@ -47,7 +47,7 @@ const CLI_TABLE_MARKDOWN_CHARS = {
 export async function inspect(
 	jsonDoc: JSONDocument,
 	io: NodeIO | WebIO,
-	logger: Logger,
+	logger: ILogger,
 	format: InspectFormat
 ): Promise<void> {
 	// Summary (does not require parsing).
@@ -101,7 +101,7 @@ export async function inspect(
 async function reportSection(
 	type: string,
 	format: InspectFormat,
-	logger: Logger,
+	logger: ILogger,
 	section: InspectPropertyReport<AnyPropertyReport>
 ) {
 	const properties = section.properties;

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -1,4 +1,4 @@
-import { Document, NodeIO, Logger, FileUtils, Transform, Format } from '@gltf-transform/core';
+import { Document, NodeIO, Logger, FileUtils, Transform, Format, ILogger } from '@gltf-transform/core';
 import type { Packet, XMP } from '@gltf-transform/extensions';
 import { unpartition } from '@gltf-transform/functions';
 import { formatBytes, XMPContext } from './util';
@@ -7,7 +7,7 @@ import { formatBytes, XMPContext } from './util';
 export class Session {
 	private _outputFormat: Format;
 
-	constructor(private _io: NodeIO, private _logger: Logger, private _input: string, private _output: string) {
+	constructor(private _io: NodeIO, private _logger: ILogger, private _input: string, private _output: string) {
 		_io.setLogger(_logger);
 		this._outputFormat = FileUtils.extension(_output) === 'glb' ? Format.GLB : Format.GLTF;
 	}

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -6,7 +6,16 @@ const semver = require('semver');
 const tmp = require('tmp');
 const pLimit = require('p-limit');
 
-import { Document, FileUtils, ImageUtils, Logger, TextureChannel, Transform, vec2 } from '@gltf-transform/core';
+import {
+	Document,
+	FileUtils,
+	ILogger,
+	ImageUtils,
+	Logger,
+	TextureChannel,
+	Transform,
+	vec2,
+} from '@gltf-transform/core';
 import { TextureBasisu } from '@gltf-transform/extensions';
 import { getTextureChannelMask, listTextureSlots } from '@gltf-transform/functions';
 import { spawn, commandExists, formatBytes, waitExit, MICROMATCH_OPTIONS } from '../util';
@@ -226,7 +235,7 @@ function createParams(
 	slots: string[],
 	channels: number,
 	size: vec2,
-	logger: Logger,
+	logger: ILogger,
 	numTextures: number,
 	options: ETC1SOptions | UASTCOptions,
 	version: string
@@ -336,7 +345,7 @@ function createParams(
 	return params;
 }
 
-async function checkKTXSoftware(logger: Logger): Promise<string> {
+async function checkKTXSoftware(logger: ILogger): Promise<string> {
 	if (!(await commandExists('toktx')) && !process.env.CI) {
 		throw new Error(
 			'Command "toktx" not found. Please install KTX-Software, from:\n\nhttps://github.com/KhronosGroup/KTX-Software'

--- a/packages/cli/src/transforms/xmp.ts
+++ b/packages/cli/src/transforms/xmp.ts
@@ -1,4 +1,4 @@
-import type { Document, Logger, Transform } from '@gltf-transform/core';
+import type { Document, ILogger, Transform } from '@gltf-transform/core';
 import { Packet, XMP } from '@gltf-transform/extensions';
 import inquirer from 'inquirer';
 import { check as validateLanguage } from 'language-tags';
@@ -348,7 +348,7 @@ function validatePacket(packetDef: Record<string, unknown>): Record<string, unkn
  * environments. Check errors and try to provide a useful warning to the user.
  * See: https://github.com/SBoudrias/Inquirer.js#Support.
  */
-function checkTTY(error: unknown, logger: Logger) {
+function checkTTY(error: unknown, logger: ILogger) {
 	if ((error as { isTtyError?: boolean }).isTtyError) {
 		logger.warn(
 			'Unable to run "inquirer" session in this terminal environment.' +

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import CLITable from 'cli-table3';
 import type Validator from 'gltf-validator';
-import type { Logger } from '@gltf-transform/core';
+import type { ILogger } from '@gltf-transform/core';
 import { formatHeader } from './util';
 
 const validator = createValidator();
@@ -32,7 +32,7 @@ interface ValidatorMessage {
 	severity: number;
 }
 
-export function validate(input: string, options: ValidateOptions, logger: Logger): void {
+export function validate(input: string, options: ValidateOptions, logger: ILogger): void {
 	const buffer = fs.readFileSync(input);
 	return validator
 		.validateBytes(new Uint8Array(buffer), {
@@ -55,7 +55,7 @@ export function validate(input: string, options: ValidateOptions, logger: Logger
 		});
 }
 
-function printIssueSection(header: string, severity: number, report: ValidatorReport, logger: Logger): void {
+function printIssueSection(header: string, severity: number, report: ValidatorReport, logger: ILogger): void {
 	console.log(formatHeader(header));
 	const messages = report.issues.messages.filter((msg) => msg.severity === severity);
 	if (messages.length) {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -34,6 +34,7 @@ export {
 	FileUtils,
 	ImageUtils,
 	ImageUtilsFormat,
+	ILogger,
 	Logger,
 	MathUtils,
 	bounds,

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -19,7 +19,7 @@ import {
 	Skin,
 	Texture,
 } from './properties';
-import { Logger } from './utils';
+import { ILogger, Logger } from './utils';
 
 export interface TransformContext {
 	stack: string[];
@@ -78,7 +78,7 @@ export type Transform = (doc: Document, context?: TransformContext) => void;
 export class Document {
 	private _graph: Graph<Property> = new Graph<Property>();
 	private _root: Root = new Root(this._graph);
-	private _logger = Logger.DEFAULT_INSTANCE;
+	private _logger: ILogger = Logger.DEFAULT_INSTANCE;
 
 	/** Returns the glTF {@link Root} property. */
 	public getRoot(): Root {
@@ -95,7 +95,7 @@ export class Document {
 	}
 
 	/** Returns the {@link Logger} instance used for any operations performed on this document. */
-	public getLogger(): Logger {
+	public getLogger(): ILogger {
 		return this._logger;
 	}
 
@@ -110,7 +110,7 @@ export class Document {
 	 * 	.transform(dedup(), weld());
 	 * ```
 	 */
-	public setLogger(logger: Logger): Document {
+	public setLogger(logger: ILogger): Document {
 		this._logger = logger;
 		return this;
 	}

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -3,7 +3,7 @@ import type { Document } from '../document';
 import type { Extension } from '../extension';
 import type { JSONDocument } from '../json-document';
 import type { GLTF } from '../types/gltf';
-import { BufferUtils, FileUtils, HTTPUtils, Logger, uuid } from '../utils/';
+import { BufferUtils, FileUtils, HTTPUtils, ILogger, Logger, uuid } from '../utils/';
 import { GLTFReader } from './reader';
 import { GLTFWriter, WriterOptions } from './writer';
 
@@ -28,7 +28,7 @@ type PublicWriterOptions = Partial<Pick<WriterOptions, 'format' | 'basename'>>;
  * @category I/O
  */
 export abstract class PlatformIO {
-	protected _logger = Logger.DEFAULT_INSTANCE;
+	protected _logger: ILogger = Logger.DEFAULT_INSTANCE;
 	private _extensions = new Set<typeof Extension>();
 	private _dependencies: { [key: string]: unknown } = {};
 	private _vertexLayout = VertexLayout.INTERLEAVED;
@@ -40,7 +40,7 @@ export abstract class PlatformIO {
 	public lastWriteBytes = 0;
 
 	/** Sets the {@link Logger} used by this I/O instance. Defaults to Logger.DEFAULT_INSTANCE. */
-	public setLogger(logger: Logger): this {
+	public setLogger(logger: ILogger): this {
 		this._logger = logger;
 		return this;
 	}

--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -4,7 +4,7 @@ import type { Extension } from '../extension';
 import type { JSONDocument } from '../json-document';
 import { Accessor, AnimationSampler, Camera } from '../properties';
 import type { GLTF } from '../types/gltf';
-import { BufferUtils, FileUtils, ImageUtils, Logger, MathUtils } from '../utils';
+import { BufferUtils, FileUtils, ILogger, ImageUtils, Logger, MathUtils } from '../utils';
 import { ReaderContext } from './reader-context';
 
 const ComponentTypeToTypedArray = {
@@ -17,7 +17,7 @@ const ComponentTypeToTypedArray = {
 };
 
 export interface ReaderOptions {
-	logger?: Logger;
+	logger?: ILogger;
 	extensions: typeof Extension[];
 	dependencies: { [key: string]: unknown };
 }

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -16,7 +16,7 @@ import type {
 	TextureInfo,
 } from '../properties';
 import type { GLTF } from '../types/gltf';
-import { ImageUtils, Logger } from '../utils';
+import { ILogger, ImageUtils } from '../utils';
 import type { WriterOptions } from './writer';
 
 type PropertyDef = GLTF.IScene | GLTF.INode | GLTF.IMaterial | GLTF.ISkin | GLTF.ITexture;
@@ -68,7 +68,7 @@ export class WriterContext {
 
 	public bufferURIGenerator: UniqueURIGenerator;
 	public imageURIGenerator: UniqueURIGenerator;
-	public logger: Logger;
+	public logger: ILogger;
 
 	private readonly _accessorUsageMap = new Map<Accessor, BufferViewUsage | string>();
 	public readonly accessorUsageGroupedByParent = new Set<string>(['ARRAY_BUFFER']);

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,3 +1,28 @@
+/** Logger verbosity thresholds. */
+export enum Verbosity {
+	/** No events are logged. */
+	SILENT = 4,
+
+	/** Only error events are logged. */
+	ERROR = 3,
+
+	/** Only error and warn events are logged. */
+	WARN = 2,
+
+	/** Only error, warn, and info events are logged. (DEFAULT) */
+	INFO = 1,
+
+	/** All events are logged. */
+	DEBUG = 0,
+}
+
+export interface ILogger {
+	debug(text: string): void;
+	info(text: string): void;
+	warn(text: string): void;
+	error(text: string): void;
+}
+
 /**
  * # Logger
  *
@@ -5,26 +30,9 @@
  *
  * @category Utilities
  */
-class Logger {
-	/**
-	 * Log verbosity thresholds.
-	 */
-	static Verbosity = {
-		/** No events are logged. */
-		SILENT: 4,
-
-		/** Only error events are logged. */
-		ERROR: 3,
-
-		/** Only error and warn events are logged. */
-		WARN: 2,
-
-		/** Only error, warn, and info events are logged. (DEFAULT) */
-		INFO: 1,
-
-		/** All events are logged. */
-		DEBUG: 0,
-	};
+export class Logger implements ILogger {
+	/** Logger verbosity thresholds. */
+	static Verbosity = Verbosity;
 
 	/** Default logger instance. */
 	public static DEFAULT_INSTANCE = new Logger(Logger.Verbosity.INFO);
@@ -60,5 +68,3 @@ class Logger {
 		}
 	}
 }
-
-export { Logger };

--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -2,7 +2,7 @@ import {
 	Accessor,
 	BufferUtils,
 	Document,
-	Logger,
+	ILogger,
 	Material,
 	Mesh,
 	Primitive,
@@ -63,7 +63,7 @@ export const dedup = function (_options: DedupOptions = DEDUP_DEFAULTS): Transfo
 	});
 };
 
-function dedupAccessors(logger: Logger, doc: Document): void {
+function dedupAccessors(logger: ILogger, doc: Document): void {
 	// Find all accessors used for mesh data.
 	const indicesAccessors: Set<Accessor> = new Set();
 	const attributeAccessors: Set<Accessor> = new Set();
@@ -166,7 +166,7 @@ function dedupAccessors(logger: Logger, doc: Document): void {
 	Array.from(duplicateOutputs.keys()).forEach((output) => output.dispose());
 }
 
-function dedupMeshes(logger: Logger, doc: Document): void {
+function dedupMeshes(logger: ILogger, doc: Document): void {
 	const root = doc.getRoot();
 
 	// Create Reference -> ID lookup table.
@@ -203,7 +203,7 @@ function dedupMeshes(logger: Logger, doc: Document): void {
 	logger.debug(`${NAME}: Found ${numMeshes - uniqueMeshes.size} duplicates among ${numMeshes} meshes.`);
 }
 
-function dedupImages(logger: Logger, doc: Document): void {
+function dedupImages(logger: ILogger, doc: Document): void {
 	const root = doc.getRoot();
 	const textures = root.listTextures();
 	const duplicates: Map<Texture, Texture> = new Map();
@@ -247,7 +247,7 @@ function dedupImages(logger: Logger, doc: Document): void {
 	});
 }
 
-function dedupMaterials(logger: Logger, doc: Document): void {
+function dedupMaterials(logger: ILogger, doc: Document): void {
 	const root = doc.getRoot();
 	const materials = root.listMaterials();
 	const duplicates: Map<Material, Material> = new Map();

--- a/packages/functions/src/partition.ts
+++ b/packages/functions/src/partition.ts
@@ -1,4 +1,4 @@
-import { Document, Logger, PropertyType, Transform } from '@gltf-transform/core';
+import { Document, ILogger, Logger, PropertyType, Transform } from '@gltf-transform/core';
 import { prune } from './prune';
 import { createTransform } from './utils';
 
@@ -9,7 +9,7 @@ export interface PartitionOptions {
 	meshes?: boolean | Array<string>;
 }
 
-const PARTITION_DEFAULTS: Required<PartitionOptions> =  {
+const PARTITION_DEFAULTS: Required<PartitionOptions> = {
 	animations: true,
 	meshes: true,
 };
@@ -30,8 +30,7 @@ const PARTITION_DEFAULTS: Required<PartitionOptions> =  {
  * ```
  */
 const partition = (_options: PartitionOptions = PARTITION_DEFAULTS): Transform => {
-
-	const options = {...PARTITION_DEFAULTS, ..._options} as Required<PartitionOptions>;
+	const options = { ...PARTITION_DEFAULTS, ..._options } as Required<PartitionOptions>;
 
 	return createTransform(NAME, async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
@@ -43,73 +42,77 @@ const partition = (_options: PartitionOptions = PARTITION_DEFAULTS): Transform =
 			logger.warn(`${NAME}: Select animations or meshes to create a partition.`);
 		}
 
-		await doc.transform(prune({propertyTypes: [PropertyType.BUFFER]}));
+		await doc.transform(prune({ propertyTypes: [PropertyType.BUFFER] }));
 
 		logger.debug(`${NAME}: Complete.`);
 	});
-
 };
 
-function partitionMeshes (doc: Document, logger: Logger, options: PartitionOptions): void {
-	const existingURIs = new Set<string>(doc.getRoot().listBuffers().map((b) => b.getURI()));
+function partitionMeshes(doc: Document, logger: ILogger, options: PartitionOptions): void {
+	const existingURIs = new Set<string>(
+		doc
+			.getRoot()
+			.listBuffers()
+			.map((b) => b.getURI())
+	);
 
-	doc.getRoot().listMeshes()
+	doc.getRoot()
+		.listMeshes()
 		.forEach((mesh, meshIndex) => {
 			if (Array.isArray(options.meshes) && !options.meshes.includes(mesh.getName())) {
-				logger.debug(
-					`${NAME}: Skipping mesh #${meshIndex} with name "${mesh.getName()}".`
-				);
+				logger.debug(`${NAME}: Skipping mesh #${meshIndex} with name "${mesh.getName()}".`);
 				return;
 			}
 
 			logger.debug(`${NAME}: Creating buffer for mesh "${mesh.getName()}".`);
 
-			const buffer = doc.createBuffer(mesh.getName())
+			const buffer = doc
+				.createBuffer(mesh.getName())
 				.setURI(createBufferURI(mesh.getName() || 'mesh', existingURIs));
 
-			mesh.listPrimitives()
-				.forEach((primitive) => {
-					const indices = primitive.getIndices();
-					if (indices) indices.setBuffer(buffer);
-					primitive.listAttributes()
-						.forEach((attribute) => attribute.setBuffer(buffer));
-					primitive.listTargets()
-						.forEach((primTarget) => {
-							primTarget.listAttributes()
-								.forEach((attribute) => attribute.setBuffer(buffer));
-						});
+			mesh.listPrimitives().forEach((primitive) => {
+				const indices = primitive.getIndices();
+				if (indices) indices.setBuffer(buffer);
+				primitive.listAttributes().forEach((attribute) => attribute.setBuffer(buffer));
+				primitive.listTargets().forEach((primTarget) => {
+					primTarget.listAttributes().forEach((attribute) => attribute.setBuffer(buffer));
 				});
+			});
 		});
 }
 
-function partitionAnimations (doc: Document, logger: Logger, options: PartitionOptions): void {
-	const existingURIs = new Set<string>(doc.getRoot().listBuffers().map((b) => b.getURI()));
+function partitionAnimations(doc: Document, logger: ILogger, options: PartitionOptions): void {
+	const existingURIs = new Set<string>(
+		doc
+			.getRoot()
+			.listBuffers()
+			.map((b) => b.getURI())
+	);
 
-	doc.getRoot().listAnimations()
+	doc.getRoot()
+		.listAnimations()
 		.forEach((anim, animIndex) => {
 			if (Array.isArray(options.animations) && !options.animations.includes(anim.getName())) {
-				logger.debug(
-					`${NAME}: Skipping animation #${animIndex} with name "${anim.getName()}".`
-				);
+				logger.debug(`${NAME}: Skipping animation #${animIndex} with name "${anim.getName()}".`);
 				return;
 			}
 
 			logger.debug(`${NAME}: Creating buffer for animation "${anim.getName()}".`);
 
-			const buffer = doc.createBuffer(anim.getName())
+			const buffer = doc
+				.createBuffer(anim.getName())
 				.setURI(createBufferURI(anim.getName() || 'animation', existingURIs));
 
-			anim.listSamplers()
-				.forEach((sampler) => {
-					const input = sampler.getInput();
-					const output = sampler.getOutput();
-					if (input) input.setBuffer(buffer);
-					if (output) output.setBuffer(buffer);
-				});
+			anim.listSamplers().forEach((sampler) => {
+				const input = sampler.getInput();
+				const output = sampler.getOutput();
+				if (input) input.setBuffer(buffer);
+				if (output) output.setBuffer(buffer);
+			});
 		});
 }
 
-function createBufferURI (basename: string, existing: Set<string>): string {
+function createBufferURI(basename: string, existing: Set<string>): string {
 	let uri = `${basename}.bin`;
 	let i = 1;
 	while (existing.has(uri)) uri = `${basename}_${i++}.bin`;

--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -3,7 +3,7 @@ import {
 	AnimationChannel,
 	bbox,
 	Document,
-	Logger,
+	ILogger,
 	mat4,
 	Mesh,
 	Node,
@@ -303,7 +303,7 @@ function quantizeAttribute(attribute: Accessor, ctor: TypedArrayConstructor, bit
 function getQuantizationSettings(
 	semantic: string,
 	attribute: Accessor,
-	logger: Logger,
+	logger: ILogger,
 	options: Required<QuantizeOptions>
 ): { bits: number; ctor?: TypedArrayConstructor } {
 	const min = attribute.getMinNormalized([]);

--- a/packages/functions/src/unweld.ts
+++ b/packages/functions/src/unweld.ts
@@ -1,4 +1,4 @@
-import type { Accessor, Document, Logger, Transform, TypedArray } from '@gltf-transform/core';
+import type { Accessor, Document, ILogger, Transform, TypedArray } from '@gltf-transform/core';
 import { createTransform } from './utils';
 
 const NAME = 'unweld';
@@ -60,7 +60,7 @@ export function unweld(_options: UnweldOptions = UNWELD_DEFAULTS): Transform {
 function unweldAttribute(
 	srcAttribute: Accessor,
 	indices: Accessor,
-	logger: Logger,
+	logger: ILogger,
 	visited: Map<Accessor, Map<Accessor, Accessor>>
 ): Accessor {
 	if (visited.has(srcAttribute) && visited.get(srcAttribute)!.has(indices)) {


### PR DESCRIPTION
For methods like `document.setLogger` and `io.setLogger`, we should type the arguments as an ILogger interface rather than instances of the provided Logger class, so that users can provide their own logging.


- Fixes #651