### PR TITLE
Add transformMesh(), transformPrimitive()

### DIFF
--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -59,6 +59,7 @@ export * from './sort-primitive-weights';
 export * from './squoosh';
 export * from './tangents';
 export * from './texture-resize';
+export * from './transform-mesh';
 export * from './unlit';
 export * from './unpartition';
 export * from './unweld';

--- a/packages/functions/src/transform-mesh.ts
+++ b/packages/functions/src/transform-mesh.ts
@@ -1,0 +1,152 @@
+import { vec3, mat4, Accessor, Primitive, vec4, Mesh, PropertyType, Property } from '@gltf-transform/core';
+import { create as createMat3, fromMat4, invert, transpose } from 'gl-matrix/mat3';
+import { create as createVec3, normalize as normalizeVec3, transformMat3, transformMat4 } from 'gl-matrix/vec3';
+import { create as createVec4 } from 'gl-matrix/vec4';
+import { createIndices } from './utils';
+
+/**
+ * Applies transform matrix ({@link mat4}) to every {@link Primitive} in the given {@link Mesh}.
+ *
+ * Method:
+ * - If any primitives are shared by other meshes, they will be detached.
+ * - If any vertex streams are shared by primitives of other meshes, vertex data
+ * 		will be overwritten _unless_ `overwrite=false` or the indices are masked. If
+ * 		`overwrite=false`, a detached copy of the vertex stream is made before applying
+ * 		the transform.
+ * - Primitives within the mesh sharing vertex streams will continue to share those streams.
+ * - For indexed primitives, only indexed vertices are modified.
+ *
+ * @param mesh
+ * @param matrix
+ * @param overwrite Whether to overwrite vertex streams in place. If false,
+ * 		streams shared with other meshes will be detached.
+ * @param mask Masks vertices, specified by index, that will _not_ be transformed.
+ */
+export function transformMesh(mesh: Mesh, matrix: mat4, overwrite: boolean, mask?: Set<number>): void {
+	// (1) Detach shared prims.
+	for (const prim of mesh.listPrimitives()) {
+		const isShared = prim.listParents().some((p) => p.propertyType === PropertyType.MESH && p !== mesh);
+		if (isShared) mesh.swap(prim, prim.clone());
+	}
+
+	// (2) Detach shared vertex streams.
+	if (!overwrite) {
+		const prims = new Set<Property>(mesh.listPrimitives());
+		const attributes = new Map<Accessor, Accessor>();
+		for (const prim of mesh.listPrimitives()) {
+			for (const srcAttribute of prim.listAttributes()) {
+				const isShared = srcAttribute
+					.listParents()
+					.some((a) => a.propertyType === PropertyType.PRIMITIVE && !prims.has(a));
+				if (isShared) {
+					const dstAttribute = attributes.get(srcAttribute) || srcAttribute.clone();
+					prim.swap(srcAttribute, dstAttribute);
+					attributes.set(srcAttribute, dstAttribute);
+				}
+			}
+		}
+	}
+
+	// (3) Apply transform.
+	mask = mask || new Set<number>();
+	for (const prim of mesh.listPrimitives()) {
+		transformPrimitive(prim, matrix, mask);
+	}
+}
+
+/**
+ * Applies transform matrix ({@link mat4}) to a {@link Primitive}.
+ *
+ * When calling {@link transformPrimitive}, any un-masked vertices are overwritten
+ * directly in the underlying vertex streams. If streams should be detached instead,
+ * see {@link transformMesh}.
+ *
+ * @param prim
+ * @param matrix
+ * @param mask Masks vertices, specified by index, that will _not_ be transformed.
+ */
+export function transformPrimitive(prim: Primitive, matrix: mat4, mask = new Set<number>()): void {
+	const position = prim.getAttribute('POSITION')!;
+	const indices = (prim.getIndices()?.getArray() || createIndices(position!.getCount())) as Uint32Array;
+
+	// Apply transform.
+	if (position) {
+		applyMatrix(matrix, position, indices, new Set(mask));
+	}
+
+	const normal = prim.getAttribute('NORMAL');
+	if (normal) {
+		applyNormalMatrix(matrix, normal, indices, new Set(mask));
+	}
+
+	const tangent = prim.getAttribute('TANGENT');
+	if (tangent) {
+		applyTangentMatrix(matrix, tangent, indices, new Set(mask));
+	}
+
+	// Update mask.
+	for (let i = 0; i < indices.length; i++) mask.add(indices[i]);
+}
+
+function applyMatrix(matrix: mat4, attribute: Accessor, indices: Uint32Array, mask: Set<number>) {
+	const dstArray = new Float32Array(attribute.getCount() * 3);
+
+	const vector = createVec3() as vec3;
+	for (let i = 0; i < indices.length; i++) {
+		const index = indices[i];
+		if (mask.has(index)) continue;
+
+		attribute.getElement(index, vector);
+		transformMat4(vector, vector, matrix);
+		dstArray.set(vector, index * 3);
+
+		mask.add(index);
+	}
+
+	attribute.setArray(dstArray).setNormalized(false);
+}
+
+function applyNormalMatrix(matrix: mat4, attribute: Accessor, indices: Uint32Array, mask: Set<number>) {
+	const normalMatrix = createMat3();
+	fromMat4(normalMatrix, matrix);
+	invert(normalMatrix, normalMatrix);
+	transpose(normalMatrix, normalMatrix);
+
+	const vector = createVec3() as vec3;
+	for (let i = 0; i < indices.length; i++) {
+		const index = indices[i];
+		if (mask.has(index)) continue;
+
+		attribute.getElement(index, vector);
+		transformMat3(vector, vector, normalMatrix);
+		normalizeVec3(vector, vector);
+		attribute.setElement(index, vector);
+
+		mask.add(index);
+	}
+}
+
+function applyTangentMatrix(matrix: mat4, attribute: Accessor, indices: Uint32Array, mask: Set<number>) {
+	const v3 = createVec3() as vec3;
+	const v4 = createVec4() as vec4;
+	for (let i = 0; i < indices.length; i++) {
+		const index = indices[i];
+		if (mask.has(index)) continue;
+
+		attribute.getElement(index, v4);
+
+		// mat4 affine matrix applied to vector, vector interpreted as a direction.
+		// Reference: https://github.com/mrdoob/three.js/blob/9f4de99828c05e71c47e6de0beb4c6e7652e486a/src/math/Vector3.js#L286-L300
+		const [x, y, z] = v4;
+		v3[0] = matrix[0] * x + matrix[4] * y + matrix[8] * z;
+		v3[1] = matrix[1] * x + matrix[5] * y + matrix[9] * z;
+		v3[2] = matrix[2] * x + matrix[6] * y + matrix[10] * z;
+		normalizeVec3(v3, v3);
+
+		(v4[0] = v3[0]), (v4[1] = v3[1]), (v4[2] = v3[2]);
+
+		attribute.setElement(index, v4);
+
+		mask.add(index);
+	}
+}

--- a/packages/functions/src/transform-mesh.ts
+++ b/packages/functions/src/transform-mesh.ts
@@ -89,7 +89,14 @@ export function transformPrimitive(prim: Primitive, matrix: mat4, mask = new Set
 }
 
 function applyMatrix(matrix: mat4, attribute: Accessor, indices: Uint32Array, mask: Set<number>) {
+	// An arbitrary transform may not keep vertex positions in the required
+	// range of a normalized attribute. Replace the array, instead.
 	const dstArray = new Float32Array(attribute.getCount() * 3);
+	const elementSize = attribute.getElementSize();
+
+	for (let i = 0, el: number[] = [], il = attribute.getCount(); i < il; i++) {
+		dstArray.set(attribute.getElement(i, el), i * elementSize);
+	}
 
 	const vector = createVec3() as vec3;
 	for (let i = 0; i < indices.length; i++) {

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -98,9 +98,11 @@ function weldOnly(doc: Document, prim: Primitive): void {
 	const attr = prim.listAttributes()[0];
 	const numVertices = attr.getCount();
 	const buffer = attr.getBuffer();
-	const indicesArray = numVertices <= 65534 ? new Uint16Array(numVertices) : new Uint32Array(numVertices);
-	const indices = doc.createAccessor().setBuffer(buffer).setType(Accessor.Type.SCALAR).setArray(indicesArray);
-	for (let i = 0; i < indices.getCount(); i++) indices.setScalar(i, i);
+	const indices = doc
+		.createAccessor()
+		.setBuffer(buffer)
+		.setType(Accessor.Type.SCALAR)
+		.setArray(createIndices(numVertices));
 	prim.setIndices(indices);
 }
 

--- a/packages/functions/test/transform-mesh.test.ts
+++ b/packages/functions/test/transform-mesh.test.ts
@@ -7,22 +7,8 @@ import { transformMesh, transformPrimitive } from '../';
 
 const logger = new Logger(Logger.Verbosity.SILENT);
 
-test.skip('@gltf-transform/functions::transformMesh', async (t) => {
+test('@gltf-transform/functions::transformPrimitive', async (t) => {
 	const document = new Document().setLogger(logger);
-
-	const prim1 = createPrimitive(document);
-	const prim2 = prim1.clone();
-
-	// (1) detach shared prims
-
-	// (2) detach shared vertex streams
-
-	// (3) vertex mask
-});
-
-test.only('@gltf-transform/functions::transformPrimitive', async (t) => {
-	const document = new Document().setLogger(logger);
-
 	const prim = createPrimitive(document);
 	const normal = prim.getAttribute('NORMAL')!;
 	const tangent = prim.getAttribute('TANGENT')!;
@@ -52,6 +38,65 @@ test.only('@gltf-transform/functions::transformPrimitive', async (t) => {
 	t.deepEquals(normal.getElement(0, []).map(round()), [0, 0, 1], 'rotate - normal');
 	t.deepEquals(tangent.getElement(0, []).map(round()), [1, 0, 0, 1], 'rotate - tangent');
 
+	t.end();
+});
+
+test('@gltf-transform/functions::transformMesh | detach shared prims', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createPrimitive(document);
+	const meshA = document.createMesh('A').addPrimitive(prim);
+	const meshB = document.createMesh('B').addPrimitive(prim);
+
+	t.equals(meshA.listPrimitives()[0], meshB.listPrimitives()[0], 'meshA = meshB, before');
+
+	transformMesh(meshA, fromScaling([], [2, 2, 2]), true);
+
+	t.notEquals(meshA.listPrimitives()[0], meshB.listPrimitives()[0], 'meshA ≠ meshB, after');
+	t.end();
+});
+
+test('@gltf-transform/functions::transformMesh | detach shared vertex streams', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createPrimitive(document);
+	const primA = prim.clone();
+	const primB = prim.clone();
+	const meshA = document.createMesh('A').addPrimitive(primA);
+	document.createMesh('B').addPrimitive(primB);
+
+	t.equals(primA.getAttribute('POSITION'), primB.getAttribute('POSITION'), 'primA = primB, before');
+
+	transformMesh(meshA, fromScaling([], [2, 2, 2]), true);
+
+	t.equals(primA.getAttribute('POSITION'), primB.getAttribute('POSITION'), 'primA = primB, after (overwrite=true)');
+
+	transformMesh(meshA, fromScaling([], [2, 2, 2]), false);
+
+	t.notEquals(
+		primA.getAttribute('POSITION'),
+		primB.getAttribute('POSITION'),
+		'primA ≠ primB, after (overwrite=false)'
+	);
+	t.end();
+});
+
+test('@gltf-transform/functions::transformMesh | skip indices', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createPrimitive(document);
+	const mesh = document.createMesh().addPrimitive(prim);
+
+	transformMesh(mesh, fromScaling([], [2, 2, 2]), false, new Set([0, 1]));
+
+	// prettier-ignore
+	t.deepEquals(
+		Array.from(mesh.listPrimitives()[0]!.getAttribute('POSITION')!.getArray()!),
+		[
+			0.5, 10, 0.5,
+			0.5, 10, -0.5,
+			-1, 20, -1,
+			-1, 20, 1,
+		],
+		'transform skips excluded indices'
+	);
 	t.end();
 });
 

--- a/packages/functions/test/transform-mesh.test.ts
+++ b/packages/functions/test/transform-mesh.test.ts
@@ -1,0 +1,108 @@
+require('source-map-support').install();
+
+import test from 'tape';
+import { bbox, Document, Logger, Primitive, PrimitiveTarget, vec3 } from '@gltf-transform/core';
+import { fromScaling, fromTranslation, fromRotation, identity } from 'gl-matrix/mat4';
+import { transformMesh, transformPrimitive } from '../';
+
+const logger = new Logger(Logger.Verbosity.SILENT);
+
+test.skip('@gltf-transform/functions::transformMesh', async (t) => {
+	// TODO(impl): todo - test primitive overwrite, cloning, ...
+});
+
+test('@gltf-transform/functions::transformMesh', async (t) => {
+	const document = new Document().setLogger(logger);
+
+	const prim = createPrimitive(document);
+
+	transformPrimitive(prim, identity([]));
+	t.deepEquals(primBounds(prim), { min: [-0.5, 10, -0.5], max: [0.5, 10, 0.5] }, 'identity');
+
+	transformPrimitive(prim, fromScaling([], [2, 1, 2]));
+	t.deepEquals(primBounds(prim), { min: [-1, 10, -1], max: [1, 10, 1] }, 'scale');
+
+	transformPrimitive(prim, fromTranslation([], [0, -10, 0]));
+	t.deepEquals(primBounds(prim), { min: [-1, 0, -1], max: [1, 0, 1] }, 'translate');
+
+	transformPrimitive(prim, fromRotation([], Math.PI / 2, [1, 0, 0]));
+	t.deepEquals(roundBbox(primBounds(prim)), { min: [-1, -1, 0], max: [1, 1, 0] }, 'rotate');
+
+	t.end();
+});
+
+/* UTILITIES */
+
+/** Creates a rounding function for given decimal precision. */
+function round(decimals = 4): (v: number) => number {
+	const f = Math.pow(10, decimals);
+	return (v: number) => {
+		v = Math.round(v * f) / f;
+		v = Object.is(v, -0) ? 0 : v;
+		return v;
+	};
+}
+
+function roundBbox(bbox: bbox, decimals = 4): bbox {
+	return {
+		min: bbox.min.map(round(decimals)) as vec3,
+		max: bbox.max.map(round(decimals)) as vec3,
+	};
+}
+
+function primBounds(prim: Primitive | PrimitiveTarget): bbox {
+	return {
+		min: prim.getAttribute('POSITION')!.getMinNormalized([]) as vec3,
+		max: prim.getAttribute('POSITION')!.getMaxNormalized([]) as vec3,
+	};
+}
+
+function createPrimitive(document: Document): Primitive {
+	const prim = document
+		.createPrimitive()
+		.setMode(Primitive.Mode.POINTS)
+		.setAttribute(
+			'POSITION',
+			// prettier-ignore
+			document
+				.createAccessor('POSITION')
+				.setType('VEC3')
+				.setArray(new Float32Array([
+					0.5, 10, 0.5,
+					0.5, 10, -0.5,
+					-0.5, 10, -0.5,
+					-0.5, 10, 0.5,
+				]))
+		)
+		.setAttribute(
+			'NORMAL',
+			// prettier-ignore
+			document
+				.createAccessor('NORMAL')
+				.setType('VEC3')
+				.setArray(
+					new Float32Array([
+						0, 1, 0,
+						0, 1, 0,
+						0, 1, 0,
+						0, 1, 0,
+					])
+				)
+		)
+		.setAttribute(
+			'TANGENT',
+			// prettier-ignore
+			document
+				.createAccessor('TANGENT')
+				.setType('VEC4')
+				.setArray(
+					new Float32Array([
+						1, 0, 0, 1,
+						1, 0, 0, 1,
+						1, 0, 0, 1,
+						1, 0, 0, 1,
+					])
+				)
+		);
+	return prim;
+}

--- a/packages/functions/test/transform-mesh.test.ts
+++ b/packages/functions/test/transform-mesh.test.ts
@@ -8,25 +8,49 @@ import { transformMesh, transformPrimitive } from '../';
 const logger = new Logger(Logger.Verbosity.SILENT);
 
 test.skip('@gltf-transform/functions::transformMesh', async (t) => {
-	// TODO(impl): todo - test primitive overwrite, cloning, ...
+	const document = new Document().setLogger(logger);
+
+	const prim1 = createPrimitive(document);
+	const prim2 = prim1.clone();
+
+	// (1) detach shared prims
+
+	// (2) detach shared vertex streams
+
+	// (3) vertex mask
 });
 
-test('@gltf-transform/functions::transformMesh', async (t) => {
+test.only('@gltf-transform/functions::transformPrimitive', async (t) => {
 	const document = new Document().setLogger(logger);
 
 	const prim = createPrimitive(document);
+	const normal = prim.getAttribute('NORMAL')!;
+	const tangent = prim.getAttribute('TANGENT')!;
 
 	transformPrimitive(prim, identity([]));
-	t.deepEquals(primBounds(prim), { min: [-0.5, 10, -0.5], max: [0.5, 10, 0.5] }, 'identity');
+	t.deepEquals(primBounds(prim), { min: [-0.5, 10, -0.5], max: [0.5, 10, 0.5] }, 'identity - position');
+	t.deepEquals(normal.getElement(0, []), [0, 1, 0], 'identity - normal');
+	t.deepEquals(tangent.getElement(0, []), [1, 0, 0, 1], 'identity - tangent');
+
+	transformPrimitive(prim, fromScaling([], [100, 100, 100]), new Set([0, 1, 2, 3]));
+	t.deepEquals(primBounds(prim), { min: [-0.5, 10, -0.5], max: [0.5, 10, 0.5] }, 'mask - position');
+	t.deepEquals(normal.getElement(0, []), [0, 1, 0], 'mask - normal');
+	t.deepEquals(tangent.getElement(0, []), [1, 0, 0, 1], 'mask - tangent');
 
 	transformPrimitive(prim, fromScaling([], [2, 1, 2]));
-	t.deepEquals(primBounds(prim), { min: [-1, 10, -1], max: [1, 10, 1] }, 'scale');
+	t.deepEquals(primBounds(prim), { min: [-1, 10, -1], max: [1, 10, 1] }, 'scale - position');
+	t.deepEquals(normal.getElement(0, []), [0, 1, 0], 'scale - normal');
+	t.deepEquals(tangent.getElement(0, []), [1, 0, 0, 1], 'scale - tangent');
 
 	transformPrimitive(prim, fromTranslation([], [0, -10, 0]));
-	t.deepEquals(primBounds(prim), { min: [-1, 0, -1], max: [1, 0, 1] }, 'translate');
+	t.deepEquals(primBounds(prim), { min: [-1, 0, -1], max: [1, 0, 1] }, 'translate - positino');
+	t.deepEquals(normal.getElement(0, []), [0, 1, 0], 'translate - normal');
+	t.deepEquals(tangent.getElement(0, []), [1, 0, 0, 1], 'translate - tangent');
 
 	transformPrimitive(prim, fromRotation([], Math.PI / 2, [1, 0, 0]));
-	t.deepEquals(roundBbox(primBounds(prim)), { min: [-1, -1, 0], max: [1, 1, 0] }, 'rotate');
+	t.deepEquals(roundBbox(primBounds(prim)), { min: [-1, -1, 0], max: [1, 1, 0] }, 'rotate - position');
+	t.deepEquals(normal.getElement(0, []).map(round()), [0, 0, 1], 'rotate - normal');
+	t.deepEquals(tangent.getElement(0, []).map(round()), [1, 0, 0, 1], 'rotate - tangent');
 
 	t.end();
 });


### PR DESCRIPTION
- Fixes #579

Adds two methods, `transformMesh()` and `transformPrimitive()`, for applying a 4x4 matrix transformation to a Mesh or Primitive instance.

Remaining:

- [x] unit tests

Example:

```js
import { fromScaling } from 'gl-matrix/mat4';
import { transformMesh } from '@gltf-transform/functions';

const matrix = fromScaling([], [5, 5, 5]);
transformMesh(mesh, matrix, /* overwrite = */ true);

```