### PR TITLE
Reorder dedupe property types

### DIFF
--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -55,9 +55,9 @@ export const dedup = function (_options: DedupOptions = DEDUP_DEFAULTS): Transfo
 		const logger = doc.getLogger();
 
 		if (propertyTypes.has(PropertyType.ACCESSOR)) dedupAccessors(logger, doc);
-		if (propertyTypes.has(PropertyType.MESH)) dedupMeshes(logger, doc);
 		if (propertyTypes.has(PropertyType.TEXTURE)) dedupImages(logger, doc);
 		if (propertyTypes.has(PropertyType.MATERIAL)) dedupMaterials(logger, doc);
+		if (propertyTypes.has(PropertyType.MESH)) dedupMeshes(logger, doc);
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -92,6 +92,7 @@ test('@gltf-transform/functions::dedup | meshes', async (t) => {
 	// Put unique materials on two meshes to prevent merging.
 	root.listMeshes()[0].listPrimitives()[0].setMaterial(doc.createMaterial('A'));
 	root.listMeshes()[1].listPrimitives()[0].setMaterial(doc.createMaterial('B'));
+	root.listMeshes()[2].listPrimitives()[0].setMaterial(doc.createMaterial('C').setRoughnessFactor(0.5));
 
 	dedup()(doc);
 


### PR DESCRIPTION
By deduping meshes after textures and materials you're more likely to be able to deduplicate more meshes.