### PR TITLE
Add listTextureInfo()

### DIFF
--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -64,4 +64,5 @@ export * from './unpartition';
 export * from './unweld';
 export * from './weld';
 export * from './list-texture-channels';
+export * from './list-texture-info';
 export * from './list-texture-slots';

--- a/packages/functions/src/list-texture-info.ts
+++ b/packages/functions/src/list-texture-info.ts
@@ -1,0 +1,34 @@
+import { Document, Texture, TextureInfo } from '@gltf-transform/core';
+
+/**
+ * Lists all {@link TextureInfo} definitions associated with a given {@link Texture}.
+ *
+ * Example:
+ *
+ * ```js
+ * // Find TextureInfo instances associated with the texture.
+ * const results = listTextureInfo(document, texture);
+ *
+ * // Find which UV sets (TEXCOORD_0, TEXCOORD_1, ...) are required.
+ * const texCoords = results.map((info) => info.getTexCoord());
+ * // → [0, 0, 1]
+ * ```
+ */
+export function listTextureInfo(document: Document, texture: Texture): TextureInfo[] {
+	const graph = document.getGraph();
+	const results: TextureInfo[] = [];
+
+	for (const textureEdge of graph.listParentEdges(texture)) {
+		const parent = textureEdge.getParent();
+		const name = textureEdge.getName() + 'Info';
+
+		for (const edge of graph.listChildEdges(parent)) {
+			const child = edge.getChild();
+			if (child instanceof TextureInfo && edge.getName() === name) {
+				results.push(child);
+			}
+		}
+	}
+
+	return results;
+}

--- a/packages/functions/test/list-texture-info.test.ts
+++ b/packages/functions/test/list-texture-info.test.ts
@@ -1,0 +1,34 @@
+require('source-map-support').install();
+
+import test from 'tape';
+import { Document } from '@gltf-transform/core';
+import { listTextureInfo } from '@gltf-transform/functions';
+import { MaterialsSheen } from '@gltf-transform/extensions';
+
+test('@gltf-transform/functions::listTextureInfo', (t) => {
+	const document = new Document();
+	const textureA = document.createTexture();
+	const textureB = document.createTexture();
+
+	const sheenExtension = document.createExtension(MaterialsSheen);
+	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureA);
+
+	document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);
+	document.createMaterial().setOcclusionTexture(textureB).setMetallicRoughnessTexture(textureB);
+
+	t.deepEquals(
+		listTextureInfo(document, textureA)
+			.map((info) => info.getName())
+			.sort(),
+		['baseColorTextureInfo', 'sheenRoughnessTextureInfo'],
+		'texture A'
+	);
+	t.deepEquals(
+		listTextureInfo(document, textureB)
+			.map((info) => info.getName())
+			.sort(),
+		['metallicRoughnessTextureInfo', 'occlusionTextureInfo'],
+		'texture B'
+	);
+	t.end();
+});


### PR DESCRIPTION
Lists all TextureInfo definitions associated with a given Texture.

Example:

```js
// Find TextureInfo instances associated with the texture.
const results = listTextureInfo(document, texture);

// Find which UV sets (TEXCOORD_0, TEXCOORD_1, ...) are required.
const texCoords = results.map((info) => info.getTexCoord());
// → [0, 0, 1]
```

- Fixes #689 