### PR TITLE
Fix weld() handling of morph targets.

### DIFF
--- a/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
@@ -105,7 +105,7 @@ export function encodeGeometry(prim: Primitive, _options: EncoderOptions = DEFAU
 	}
 
 	const indices = prim.getIndices();
-	if (!indices) throw new Error('Primitive must have indices.');
+	if (!indices) throw new EncodingError('Primitive must have indices.');
 
 	builder.AddFacesToMesh(mesh, indices.getCount() / 3, indices.getArray() as unknown as Uint32Array);
 
@@ -120,7 +120,7 @@ export function encodeGeometry(prim: Primitive, _options: EncoderOptions = DEFAU
 	}
 
 	const byteLength = encoder.EncodeMeshToDracoBuffer(mesh, dracoBuffer);
-	if (byteLength <= 0) throw new Error('Error applying Draco compression.');
+	if (byteLength <= 0) throw new EncodingError('Error applying Draco compression.');
 
 	const data = new Uint8Array(byteLength);
 	for (let i = 0; i < byteLength; ++i) {
@@ -132,7 +132,7 @@ export function encodeGeometry(prim: Primitive, _options: EncoderOptions = DEFAU
 	const numIndices = encoder.GetNumberOfEncodedFaces() * 3;
 
 	if (prim.listTargets().length > 0 && numVertices !== prevNumVertices) {
-		throw new Error(
+		throw new EncodingError(
 			'Compression reduced vertex count unexpectedly, corrupting morph targets.' +
 				' Applying the "weld" function before compression may resolve the issue.'
 		);
@@ -185,3 +185,5 @@ function addAttribute(
 			throw new Error(`Unexpected component type, "${componentType}".`);
 	}
 }
+
+export class EncodingError extends Error {}

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -165,7 +165,7 @@ function weldAndMerge(doc: Document, prim: Primitive, options: Required<WeldOpti
 			});
 			const isTargetMatch = prim.listTargets().every((target) => {
 				return target.listSemantics().every((semantic) => {
-					const attribute = prim.getAttribute(semantic)!;
+					const attribute = target.getAttribute(semantic)!;
 					const tolerance = attributeTolerance[semantic];
 					return compareAttributes(attribute, a, b, tolerance, semantic);
 				});

--- a/packages/functions/test/weld.test.ts
+++ b/packages/functions/test/weld.test.ts
@@ -50,18 +50,8 @@ test('@gltf-transform/functions::weld | tolerance>0', async (t) => {
 		0, 0.5, 0.50001, // should still be welded
 		0.5, 0.5, 0
 	]);
-	// prettier-ignore
-	const positionTargetArray = new Float32Array([
-		0, 10, 0,
-		0, 10, 1,
-		0, 10, -1,
-		0, 15, 0,
-		0, 15, 1,
-		0, 15, -1
-	]);
 	const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
 	const normal = doc.createAccessor().setType('VEC3').setArray(normalArray);
-	const positionTarget = doc.createAccessor().setType('VEC3').setArray(positionTargetArray);
 
 	const prim1 = doc
 		.createPrimitive()
@@ -70,14 +60,12 @@ test('@gltf-transform/functions::weld | tolerance>0', async (t) => {
 		.setAttribute('NORMAL', normal);
 
 	const prim2Indices = doc.createAccessor().setArray(new Uint32Array([3, 4, 5, 0, 1, 2]));
-	const prim2Target = doc.createPrimitiveTarget().setAttribute('POSITION', positionTarget);
 	const prim2 = doc
 		.createPrimitive()
 		.setMode(Primitive.Mode.TRIANGLES)
 		.setIndices(prim2Indices)
 		.setAttribute('POSITION', position)
-		.setAttribute('NORMAL', normal)
-		.addTarget(prim2Target);
+		.setAttribute('NORMAL', normal);
 	doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
 	await doc.transform(weld());
@@ -86,12 +74,7 @@ test('@gltf-transform/functions::weld | tolerance>0', async (t) => {
 	t.deepEquals(prim2.getIndices().getArray(), new Uint16Array([0, 1, 2, 0, 1, 2]), 'indices on prim2');
 	t.deepEquals(prim1.getAttribute('POSITION').getArray(), positionArray.slice(0, 9), 'vertices on prim1');
 	t.deepEquals(prim2.getAttribute('POSITION').getArray(), positionArray.slice(0, 9), 'vertices on prim2');
-	t.deepEquals(
-		prim2.listTargets()[0].getAttribute('POSITION').getArray(),
-		positionTargetArray.slice(0, 9), // Uses later targets, because of index order.
-		'morph targets on prim2'
-	);
-	t.equals(doc.getRoot().listAccessors().length, 4, 'keeps only needed accessors');
+	t.equals(doc.getRoot().listAccessors().length, 3, 'accessor count');
 	t.end();
 });
 


### PR DESCRIPTION
Fixes a bug in `weld()` implementation, which caused it to not correctly consider morph targets when welding vertices.

Additionally, changes the Draco compression implementation so that if Draco encoding fails for a primitive, the encoder skips compressing that primitive and keeps writing the rest of the file.

- Fixes #693 

/cc @hybridherbst