### PR TITLE
Disable experimental TypeScript decorators

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "es6",
     "declaration": true,
     "stripInternal": true,
-    "experimentalDecorators": true,
     "typeRoots": ["node_modules/@types"],
 
     // Components of "strict" mode.


### PR DESCRIPTION
No longer needed in v2.

- #436
- #437