### PR TITLE
Add joinPrimitives()

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -45,6 +45,7 @@ export {
 export {
 	TypedArray,
 	TypedArrayConstructor,
+	ComponentTypeToTypedArray,
 	PropertyType,
 	Format,
 	Nullable,

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -61,6 +61,7 @@ export * from './flatten';
 export * from './get-node-scene';
 export * from './inspect';
 export * from './instance';
+export * from './join-primitives';
 export * from './meshopt';
 export * from './metal-rough';
 export * from './normals';

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -1,131 +1,123 @@
-import type { Accessor, Document, Material, Primitive } from '@gltf-transform/core';
+import { Accessor, Document, Primitive, ComponentTypeToTypedArray } from '@gltf-transform/core';
+import { createIndices, createPrimGroupKey, isUsed } from './utils';
 
 /**
- * Given a list of mesh {@link Primitive Primitives}, returns a new list of Primitives
- * in which all compatible Primitives have been joined. Compatibility is determined
- * based on {@link Material Materials}, vertex attributes, and morph targets. Resulting
- * Primitives use default accessor types (e.g. float32), and are not quantized.
+ * Given a list of compatible Mesh {@link Primitive Primitives}, returns new Primitive
+ * containing their vertex data. Compatibility requires that all Primitives share the
+ * same {@link Material Materials}, draw mode, and vertex attribute types. Primitives
+ * using morph targets cannot currently be joined.
  *
  * Example:
  *
  * ```javascript
  * import { joinPrimitives } from '@gltf-transform/functions';
  *
- * // Output will contain multiple primitives if not all inputs are compatible.
- * const [prim] = joinPrimitives(document, mesh.listPrimitives());
+ * // Succeeds if Primitives are compatible, or throws an error.
+ * const result = joinPrimitives(mesh.listPrimitives());
  *
  * for (const prim of mesh.listPrimitives()) {
- *  prim.dispose();
+ * 	prim.dispose();
  * }
  *
- * mesh.addPrimitive(prim);
+ * mesh.addPrimitive(result);
  * ```
  */
-export function joinPrimitives(document: Document, prims: Primitive[]): Primitive[] {
-	const result = [];
+export function joinPrimitives(
+	prims: Primitive[],
+	{ skipValidation = false, skipCleanup = false }: { skipValidation: boolean; skipCleanup: boolean }
+): Primitive {
+	const templatePrim = prims[0]!;
+	const document = Document.fromGraph(templatePrim.getGraph())!;
 
-	// TODO(🚩): Do I actually want this method identifying the groups? Or should that be
-	// configurable and passed in, bailing out if they're incompatible? Do we need to be
-	// able to return information about which primitive went where?
-
-	// Allocate groups.
-	const groups = new Map<Material | null, Map<string, Primitive[]>>();
-	for (const prim of prims) {
-		const material = prim.getMaterial();
-		if (!groups.has(material)) groups.set(material, new Map());
-	}
-
-	// Assign primitives to join-able groups.
-	for (const prim of prims) {
-		const primKey = _primKey(prim);
-		const materialGroup = groups.get(prim.getMaterial())!;
-
-		let group = materialGroup.get(primKey);
-		if (!group) {
-			group = [];
-			materialGroup.set(primKey, group);
-		}
-
-		group.push(prim);
-	}
-
-	// Execute join.
-	for (const [_, materialGroup] of groups) {
-		for (const [_, groupPrims] of materialGroup) {
-			result.push(_joinPrimitives(document, groupPrims));
-		}
-	}
-
-	return result;
-}
-
-function _joinPrimitives(document: Document, primitives: Primitive[]): Primitive {
-	const primTpl = primitives[0];
-	const result = document.createPrimitive().setMode(primTpl.getMode()).setMaterial(primTpl.getMaterial());
-	const count = primTpl.listAttributes()[0].getCount();
-
-	// TODO(🚩): Suppose one or more input primitives already share a vertex stream,
-	// and differ only in their indices. Don't just make N copies of the vertex stream.
-	// Suppose they share _part_ of a vertex stream, but also have unique attributes?
-	// Now we have a harder problem.
-
-	for (const semantic of primTpl.listSemantics()) {
-		const attributeTpl = primTpl.getAttribute(semantic)!;
-		const attribute = _fillAttribute(
-			_createAttribute(document, semantic, count, attributeTpl),
-			primitives.map((prim) => prim.getAttribute(semantic)!)
+	// (1) Validation.
+	if (!skipValidation && new Set(prims.map(createPrimGroupKey)).size > 1) {
+		throw new Error(
+			'' +
+				'Requires ≥2 Primitives, sharing the same Material ' +
+				'and Mode, with compatible vertex attributes and indices.'
 		);
-		result.setAttribute(semantic, attribute);
 	}
 
-	// TODO(🚩): Set indices.
+	const remapList = [] as Uint32Array[]; // remap[srcIndex] → dstIndex, by prim
+	const countList = [] as number[]; // vertex count, by prim
+	const indicesList = [] as (Uint32Array | Uint16Array)[]; // indices, by prim
 
-	return result;
-}
+	let totalCount = 0;
 
-// TODO(🚩): Method should be indices-aware.
-function _createAttribute(document: Document, semantic: string, count: number, tpl: Accessor): Accessor {
-	const array = semantic.startsWith('JOINTS_')
-		? new Uint16Array(count * tpl.getElementSize())
-		: new Float32Array(count * tpl.getElementSize());
-	return document.createAccessor().setArray(array).setType(tpl.getType()).setBuffer(tpl.getBuffer());
-}
+	// (2) Build remap lists.
+	for (const srcPrim of prims) {
+		const indices = _getOrCreateIndices(srcPrim);
+		const remap = [];
+		let count = 0;
+		for (let i = 0; i < indices.length; i++) {
+			const index = indices[i];
+			if (remap[index] === undefined) {
+				remap[index] = totalCount++;
+				count++;
+			}
+		}
+		remapList.push(new Uint32Array(remap));
+		countList.push(count);
+		indicesList.push(indices);
+	}
 
-function _fillAttribute(target: Accessor, sources: Accessor[]): Accessor {
-	const el: number[] = [];
-	let index = 0;
-	for (const source of sources) {
-		for (let i = 0, il = source.getCount(); i < il; i++) {
-			target.setElement(index++, source.getElement(i, el));
+	// (3) Allocate joined Primitive.
+	const dstPrim = document.createPrimitive().setMode(templatePrim.getMode()).setMaterial(templatePrim.getMaterial());
+	for (const semantic of templatePrim.listSemantics()) {
+		const tplAttribute = templatePrim.getAttribute(semantic)!;
+		const TemplateArray = ComponentTypeToTypedArray[tplAttribute.getComponentType()];
+		const dstAttribute = document
+			.createAccessor()
+			.setBuffer(tplAttribute.getBuffer())
+			.setNormalized(tplAttribute.getNormalized())
+			.setArray(new TemplateArray(totalCount));
+		dstPrim.setAttribute(semantic, dstAttribute);
+	}
+
+	// (4) Remap attributes into joined Primitive.
+	for (let primIndex = 0; primIndex < remapList.length; primIndex++) {
+		const srcPrim = prims[primIndex];
+		const remap = remapList[primIndex];
+		const indices = indicesList[primIndex];
+
+		for (const semantic of dstPrim.listSemantics()) {
+			const srcAttribute = srcPrim.getAttribute(semantic)!;
+			const dstAttribute = dstPrim.getAttribute(semantic)!;
+			const el = [] as number[];
+			for (let i = 0; i < indices.length; i++) {
+				const index = indices[i];
+				srcAttribute.getElement(index, el);
+				dstAttribute.setElement(remap[index], el);
+			}
 		}
 	}
-	return target;
+
+	// (5) Clean up.
+	if (!skipCleanup) {
+		const srcAccessors = new Set<Accessor>();
+		for (const srcPrim of prims) {
+			const indices = srcPrim.getIndices();
+			if (indices) {
+				srcAccessors.add(indices);
+			}
+			for (const attribute of srcPrim.listAttributes()) {
+				srcAccessors.add(attribute);
+			}
+			srcPrim.dispose();
+		}
+		for (const srcAccessor of srcAccessors) {
+			if (!srcAccessor.listParents().some(isUsed)) {
+				srcAccessor.dispose();
+			}
+		}
+	}
+
+	return dstPrim;
 }
 
-function _primKey(prim: Primitive): string {
-	const mode = prim.getMode();
-
-	const attributes = prim
-		.listSemantics()
-		.sort()
-		.map((semantic) => {
-			const attribute = prim.getAttribute(semantic)!;
-			const elementSize = attribute.getElementSize();
-			return `semantic:${elementSize}`;
-		})
-		.join('+');
-
-	const targets = prim.listTargets().map((target) => {
-		const targetAttributes = target
-			.listSemantics()
-			.sort()
-			.map((semantic) => {
-				const attribute = prim.getAttribute(semantic)!;
-				const elementSize = attribute.getElementSize();
-				return `semantic:${elementSize}`;
-			});
-		return targetAttributes.join('+');
-	});
-
-	return `${mode}|${attributes}|${targets}`;
+function _getOrCreateIndices(prim: Primitive): Uint16Array | Uint32Array {
+	const indices = prim.getIndices();
+	if (indices) return indices.getArray() as Uint32Array | Uint16Array;
+	const position = prim.getAttribute('POSITION')!;
+	return createIndices(position.getCount());
 }

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -24,6 +24,10 @@ import type { Accessor, Document, Material, Primitive } from '@gltf-transform/co
 export function joinPrimitives(document: Document, prims: Primitive[]): Primitive[] {
 	const result = [];
 
+	// TODO(🚩): Do I actually want this method identifying the groups? Or should that be
+	// configurable and passed in, bailing out if they're incompatible? Do we need to be
+	// able to return information about which primitive went where?
+
 	// Allocate groups.
 	const groups = new Map<Material | null, Map<string, Primitive[]>>();
 	for (const prim of prims) {

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -1,0 +1,127 @@
+import type { Accessor, Document, Material, Primitive } from '@gltf-transform/core';
+
+/**
+ * Given a list of mesh {@link Primitive Primitives}, returns a new list of Primitives
+ * in which all compatible Primitives have been joined. Compatibility is determined
+ * based on {@link Material Materials}, vertex attributes, and morph targets. Resulting
+ * Primitives use default accessor types (e.g. float32), and are not quantized.
+ *
+ * Example:
+ *
+ * ```javascript
+ * import { joinPrimitives } from '@gltf-transform/functions';
+ *
+ * // Output will contain multiple primitives if not all inputs are compatible.
+ * const [prim] = joinPrimitives(document, mesh.listPrimitives());
+ *
+ * for (const prim of mesh.listPrimitives()) {
+ *  prim.dispose();
+ * }
+ *
+ * mesh.addPrimitive(prim);
+ * ```
+ */
+export function joinPrimitives(document: Document, prims: Primitive[]): Primitive[] {
+	const result = [];
+
+	// Allocate groups.
+	const groups = new Map<Material | null, Map<string, Primitive[]>>();
+	for (const prim of prims) {
+		const material = prim.getMaterial();
+		if (!groups.has(material)) groups.set(material, new Map());
+	}
+
+	// Assign primitives to join-able groups.
+	for (const prim of prims) {
+		const primKey = _primKey(prim);
+		const materialGroup = groups.get(prim.getMaterial())!;
+
+		let group = materialGroup.get(primKey);
+		if (!group) {
+			group = [];
+			materialGroup.set(primKey, group);
+		}
+
+		group.push(prim);
+	}
+
+	// Execute join.
+	for (const [_, materialGroup] of groups) {
+		for (const [_, groupPrims] of materialGroup) {
+			result.push(_joinPrimitives(document, groupPrims));
+		}
+	}
+
+	return result;
+}
+
+function _joinPrimitives(document: Document, primitives: Primitive[]): Primitive {
+	const primTpl = primitives[0];
+	const result = document.createPrimitive().setMode(primTpl.getMode()).setMaterial(primTpl.getMaterial());
+	const count = primTpl.listAttributes()[0].getCount();
+
+	// TODO(🚩): Suppose one or more input primitives already share a vertex stream,
+	// and differ only in their indices. Don't just make N copies of the vertex stream.
+	// Suppose they share _part_ of a vertex stream, but also have unique attributes?
+	// Now we have a harder problem.
+
+	for (const semantic of primTpl.listSemantics()) {
+		const attributeTpl = primTpl.getAttribute(semantic)!;
+		const attribute = _fillAttribute(
+			_createAttribute(document, semantic, count, attributeTpl),
+			primitives.map((prim) => prim.getAttribute(semantic)!)
+		);
+		result.setAttribute(semantic, attribute);
+	}
+
+	// TODO(🚩): Set indices.
+
+	return result;
+}
+
+// TODO(🚩): Method should be indices-aware.
+function _createAttribute(document: Document, semantic: string, count: number, tpl: Accessor): Accessor {
+	const array = semantic.startsWith('JOINTS_')
+		? new Uint16Array(count * tpl.getElementSize())
+		: new Float32Array(count * tpl.getElementSize());
+	return document.createAccessor().setArray(array).setType(tpl.getType()).setBuffer(tpl.getBuffer());
+}
+
+function _fillAttribute(target: Accessor, sources: Accessor[]): Accessor {
+	const el: number[] = [];
+	let index = 0;
+	for (const source of sources) {
+		for (let i = 0, il = source.getCount(); i < il; i++) {
+			target.setElement(index++, source.getElement(i, el));
+		}
+	}
+	return target;
+}
+
+function _primKey(prim: Primitive): string {
+	const mode = prim.getMode();
+
+	const attributes = prim
+		.listSemantics()
+		.sort()
+		.map((semantic) => {
+			const attribute = prim.getAttribute(semantic)!;
+			const elementSize = attribute.getElementSize();
+			return `semantic:${elementSize}`;
+		})
+		.join('+');
+
+	const targets = prim.listTargets().map((target) => {
+		const targetAttributes = target
+			.listSemantics()
+			.sort()
+			.map((semantic) => {
+				const attribute = prim.getAttribute(semantic)!;
+				const elementSize = attribute.getElementSize();
+				return `semantic:${elementSize}`;
+			});
+		return targetAttributes.join('+');
+	});
+
+	return `${mode}|${attributes}|${targets}`;
+}

--- a/packages/functions/test/join-primitives.test.ts
+++ b/packages/functions/test/join-primitives.test.ts
@@ -49,6 +49,8 @@ test('@gltf-transform/functions::joinPrimitives', async (t) => {
 		0, 0, 0, 127,
 		0, 0, 0, 0,
 	], 'position data');
+
+	t.is(primAB.getIndices(), null, 'indices data');
 });
 
 test('@gltf-transform/functions::joinPrimitives | indexed', async (t) => {

--- a/packages/functions/test/join-primitives.test.ts
+++ b/packages/functions/test/join-primitives.test.ts
@@ -1,0 +1,162 @@
+import test from 'ava';
+import { Accessor, Document, Primitive } from '@gltf-transform/core';
+import { joinPrimitives } from '@gltf-transform/functions';
+import { logger } from '@gltf-transform/test-utils';
+
+test('@gltf-transform/functions::joinPrimitives', async (t) => {
+	const document = new Document().setLogger(logger);
+	const [primA, positionA, colorA] = createPrimA(document);
+	const [primB] = createPrimB(document);
+
+	const primAB = joinPrimitives([primA, primB]);
+
+	t.false(primA.isDisposed(), 'primA alive');
+	t.false(primB.isDisposed(), 'primB alive');
+
+	const positionAB = primAB.getAttribute('POSITION');
+	const colorAB = primAB.getAttribute('COLOR_0');
+
+	t.is(positionAB.getType(), positionA.getType(), 'position.type');
+	t.is(colorAB.getType(), colorA.getType(), 'color.type');
+	t.is(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
+	t.is(colorAB.getComponentType(), colorA.getComponentType(), 'color.componentType');
+
+	// prettier-ignore
+	t.deepEqual(Array.from(positionAB.getArray()), [
+		// primA
+		0, 0, 0,
+		0, 0, 1,
+		0, 1, 0,
+		1, 0, 0,
+		0, 1, 1,
+		1, 0, 1,
+		// primB
+		10, 10, 10,
+		10, 10, 12,
+		10, 12, 10,
+	], 'position data');
+	// prettier-ignore
+	t.deepEqual(Array.from(colorAB.getArray()), [
+		// primA
+		255, 0, 0, 255,
+		0, 255, 0, 255,
+		0, 0, 255, 255,
+		255, 0, 0, 255,
+		0, 255, 0, 255,
+		0, 0, 255, 255,
+		// primB
+		0, 0, 0, 255,
+		0, 0, 0, 127,
+		0, 0, 0, 0,
+	], 'position data');
+});
+
+test('@gltf-transform/functions::joinPrimitives | indexed', async (t) => {
+	const document = new Document().setLogger(logger);
+	const [primA, positionA, colorA] = createPrimA(document);
+	const [primB] = createPrimB(document);
+
+	const indicesA = document.createAccessor().setArray(new Uint16Array([0, 2, 4]));
+	const indicesB = document.createAccessor().setArray(new Uint16Array([0, 1, 2]));
+
+	primA.setIndices(indicesA);
+	primB.setIndices(indicesB);
+
+	const primAB = joinPrimitives([primA, primB]);
+
+	t.false(primA.isDisposed(), 'primA alive');
+	t.false(primB.isDisposed(), 'primB alive');
+
+	const positionAB = primAB.getAttribute('POSITION');
+	const colorAB = primAB.getAttribute('COLOR_0');
+
+	t.is(positionAB.getType(), positionA.getType(), 'position.type');
+	t.is(colorAB.getType(), colorA.getType(), 'color.type');
+	t.is(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
+	t.is(colorAB.getComponentType(), colorA.getComponentType(), 'color.componentType');
+
+	// prettier-ignore
+	t.deepEqual(Array.from(positionAB.getArray()), [
+		// primA
+		0, 0, 0,
+		// 0, 0, 1, ❌
+		0, 1, 0,
+		// 1, 0, 0, ❌
+		0, 1, 1,
+		// 1, 0, 1, ❌
+		// primB
+		10, 10, 10,
+		10, 10, 12,
+		10, 12, 10,
+	], 'position data');
+	// prettier-ignore
+	t.deepEqual(Array.from(colorAB.getArray()), [
+		// primA
+		255, 0, 0, 255,
+		// 0, 255, 0, 255, ❌
+		0, 0, 255, 255,
+		// 255, 0, 0, 255, ❌
+		0, 255, 0, 255,
+		// 0, 0, 255, 255, ❌
+		// primB
+		0, 0, 0, 255,
+		0, 0, 0, 127,
+		0, 0, 0, 0,
+	], 'position data');
+
+	t.is(primAB.getIndices().getCount(), 6, 'indices data');
+});
+
+function createPrimA(document: Document): [Primitive, Accessor, Accessor] {
+	// prettier-ignore
+	const positionA = document.createAccessor()
+		.setType('VEC3')
+		.setArray(new Uint16Array([
+			0, 0, 0,
+			0, 0, 1,
+			0, 1, 0,
+			1, 0, 0,
+			0, 1, 1,
+			1, 0, 1,
+		]));
+	// prettier-ignore
+	const colorA = document.createAccessor()
+		.setType('VEC4')
+		.setNormalized(true)
+		.setArray(new Uint8Array([
+			255, 0, 0, 255,
+			0, 255, 0, 255,
+			0, 0, 255, 255,
+			255, 0, 0, 255,
+			0, 255, 0, 255,
+			0, 0, 255, 255,
+		]));
+
+	const primA = document.createPrimitive().setAttribute('POSITION', positionA).setAttribute('COLOR_0', colorA);
+
+	return [primA, positionA, colorA];
+}
+
+function createPrimB(document: Document): [Primitive, Accessor, Accessor] {
+	// prettier-ignore
+	const positionB = document.createAccessor()
+		.setType('VEC3')
+		.setArray(new Uint16Array([
+			10, 10, 10,
+			10, 10, 12,
+			10, 12, 10,
+		]));
+	// prettier-ignore
+	const colorB = document.createAccessor()
+		.setType('VEC4')
+		.setNormalized(true)
+		.setArray(new Uint8Array([
+			0, 0, 0, 255,
+			0, 0, 0, 127,
+			0, 0, 0, 0,
+		]));
+
+	const primB = document.createPrimitive().setAttribute('POSITION', positionB).setAttribute('COLOR_0', colorB);
+
+	return [primB, positionB, colorB];
+}


### PR DESCRIPTION
Given a list of compatible Mesh Primitives, returns new Primitive containing their vertex data. Compatibility requires that all Primitives share the same Materials, draw mode, and vertex attribute types. Primitives using morph targets cannot currently be joined.

Related:

- #11 

To do:

- [x] Implementation
- [x] Unit tests

Example:

```javascript
import { joinPrimitives } from '@gltf-transform/functions';

// Succeeds if Primitives are compatible, or throws an error.
const result = joinPrimitives(mesh.listPrimitives());

for (const prim of mesh.listPrimitives()) {
    prim.dispose();
}

mesh.addPrimitive(result);
```
