### PR TITLE
move toktx tmp files into glTF-transform subdirectory, prefix with texture index, ensure input and output names are identical

### DIFF
--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -10,6 +10,7 @@ import { Document, FileUtils, ILogger, ImageUtils, TextureChannel, Transform, ve
 import { TextureBasisu } from '@gltf-transform/extensions';
 import { getTextureChannelMask, listTextureSlots } from '@gltf-transform/functions';
 import { spawn, commandExists, formatBytes, waitExit, MICROMATCH_OPTIONS } from '../util';
+import { existsSync, mkdirSync } from 'fs';
 
 tmp.setGracefulCleanup();
 
@@ -164,8 +165,13 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 				const extension = texture.getURI()
 					? FileUtils.extension(texture.getURI())
 					: ImageUtils.mimeTypeToExtension(texture.getMimeType());
-				const inPath = tmp.tmpNameSync({ postfix: '.' + extension });
-				const outPath = tmp.tmpNameSync({ postfix: '.ktx2' });
+
+				const dir = `${tmp.tmpdir}/glTF-transform`;
+				if(!existsSync(dir)) mkdirSync(dir);
+				const tmpPrefix = `${textureIndex}`;
+				const tmpName = tmp.tmpNameSync({ dir: dir, prefix: tmpPrefix });
+				const inPath = tmpName + '.' + extension;
+				const outPath = tmpName + '.ktx2';
 
 				const inBytes = image.byteLength;
 				await fs.writeFile(inPath, Buffer.from(image));

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -10,7 +10,7 @@ import { Document, FileUtils, ILogger, ImageUtils, TextureChannel, Transform, ve
 import { TextureBasisu } from '@gltf-transform/extensions';
 import { getTextureChannelMask, listTextureSlots } from '@gltf-transform/functions';
 import { spawn, commandExists, formatBytes, waitExit, MICROMATCH_OPTIONS } from '../util';
-import { exists, mkdir } from 'fs/promises';
+import { existsSync, mkdirSync } from 'fs';
 
 tmp.setGracefulCleanup();
 
@@ -120,7 +120,7 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 		
 		// Ensure the temp directory exists and create temp name for batch
 		const tmpDir = `${tmp.tmpdir}/gltf-transform`;
-		if(!(await exists(tmpDir))) await mkdir(tmpDir);
+		if(!(existsSync(tmpDir))) mkdirSync(tmpDir);
 		const tmpPathBase = tmpDir + "/" + uuid();
 
 		const basisuExtension = doc.createExtension(TextureBasisu).setRequired(true);


### PR DESCRIPTION
Hello Don,

I've modified the toktx path generation slightly:

- temporary files are generated in``<tmp_directory>/glTF-transform`` subdirectory
- files are prefixed with the texture index
- both input and output textures get same temp name + extension

e.g.
```
<temp>/glTF-transform/0-26512-mBTwWi5DfoJS.jpg
<temp>/glTF-transform/0-26512-mBTwWi5DfoJS.ktx2
```

instead of 
```
<temp>/26512-mBTwWi5DfoJS.jpg
<temp>/26512-DnLSUf3amI0h.ktx2
```

![image](https://user-images.githubusercontent.com/5083203/196656837-be9733cb-2619-4dc7-99ac-ef1e82c48226.png)
