### PR TITLE
Fix resampling of quaternion keyframe tracks

### DIFF
--- a/packages/core/src/utils/math-utils.ts
+++ b/packages/core/src/utils/math-utils.ts
@@ -9,12 +9,11 @@ export class MathUtils {
 		return v;
 	}
 
-	public static eq(a: number[], b: number[]): boolean {
+	public static eq(a: number[], b: number[], tolerance = 10e-6): boolean {
 		if (a.length !== b.length) return false;
 
-		const eps = 10e-6;
 		for (let i = 0; i < a.length; i++) {
-			if (Math.abs(a[i] - b[i]) > eps) return false;
+			if (Math.abs(a[i] - b[i]) > tolerance) return false;
 		}
 
 		return true;

--- a/packages/functions/src/resample.ts
+++ b/packages/functions/src/resample.ts
@@ -108,7 +108,7 @@ function optimize(sampler: AnimationSampler, path: GLTF.AnimationChannelTargetPa
 			if (interpolation === 'LINEAR' && path === 'rotation') {
 				// Prune keyframes colinear with prev/next keyframes.
 				const sample = slerp(tmp as quat, valuePrev as quat, valueNext as quat, t) as number[];
-				const angle = getAngle(valuePrev as quat, valueNext as quat);
+				const angle = getAngle(valuePrev as quat, value as quat) + getAngle(value as quat, valueNext as quat);
 				keep = !MathUtils.eq(value, sample, tolerance) || angle + Number.EPSILON >= Math.PI;
 			} else if (interpolation === 'LINEAR') {
 				// Prune keyframes colinear with prev/next keyframes.

--- a/packages/functions/test/resample.test.ts
+++ b/packages/functions/test/resample.test.ts
@@ -4,19 +4,19 @@ import test from 'tape';
 import { Accessor, Document, Logger } from '@gltf-transform/core';
 import { resample } from '../';
 
-test('@gltf-transform/functions::resample', async (t) => {
+test.only('@gltf-transform/functions::resample', async (t) => {
 	const doc = new Document().setLogger(new Logger(Logger.Verbosity.SILENT));
 
-	const inputArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
-	const outputArray = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5]);
-	const outputSplineArray = new Uint8Array([
+	const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
+	const outArray = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5]);
+	const outSplineArray = new Uint8Array([
 		0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 1, 4, 0, 0, 0,
 		0, 1, 5, 0, 0,
 	]);
 
-	const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inputArray);
-	const output = doc.createAccessor('output').setType(Accessor.Type.VEC2).setArray(outputArray);
-	const outputSpline = doc.createAccessor('outputSpline').setType(Accessor.Type.VEC2).setArray(outputSplineArray);
+	const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inArray);
+	const output = doc.createAccessor('output').setType(Accessor.Type.VEC2).setArray(outArray);
+	const outputSpline = doc.createAccessor('outputSpline').setType(Accessor.Type.VEC2).setArray(outSplineArray);
 
 	const samplerA = doc.createAnimationSampler().setInterpolation('STEP').setInput(input).setOutput(output);
 	const samplerB = samplerA.clone().setInterpolation('LINEAR');
@@ -29,15 +29,19 @@ test('@gltf-transform/functions::resample', async (t) => {
 	t.equals(doc.getRoot().listAccessors().length, 6, 'splits shared accessors');
 
 	// Merge duplicate keyframes.
-	t.deepEquals(samplerA.getInput().getArray(), new Uint8Array([0, 2, 3, 4, 5, 6]), 'STEP input');
-	t.deepEquals(samplerA.getOutput().getArray(), new Uint8Array([1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5]), 'STEP output');
+	t.deepEquals(toArray(samplerA.getInput()), [0, 2, 3, 4, 5, 6], 'STEP input');
+	t.deepEquals(toArray(samplerA.getOutput()), [1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5], 'STEP output');
 
 	// Merge colinear keyframes.
-	t.deepEquals(samplerB.getInput().getArray(), new Uint8Array([0, 2, 6]), 'LINEAR input');
-	t.deepEquals(samplerB.getOutput().getArray(), new Uint8Array([1, 1, 1, 1, 1, 5]), 'LINEAR output');
+	t.deepEquals(toArray(samplerB.getInput()), [0, 2, 6], 'LINEAR input');
+	t.deepEquals(toArray(samplerB.getOutput()), [1, 1, 1, 1, 1, 5], 'LINEAR output');
 
 	// No change.
-	t.deepEquals(samplerC.getInput().getArray(), inputArray, 'CUBICSPLINE input (unchanged)');
-	t.deepEquals(samplerC.getOutput().getArray(), outputSplineArray, 'CUBICSPLINE output (unchanged)');
+	t.deepEquals(toArray(samplerC.getInput()), Array.from(inArray), 'CUBICSPLINE input (unchanged)');
+	t.deepEquals(toArray(samplerC.getOutput()), Array.from(outSplineArray), 'CUBICSPLINE output (unchanged)');
 	t.end();
 });
+
+function toArray(accessor: Accessor): number[] {
+	return Array.from(accessor.getArray());
+}

--- a/packages/functions/test/resample.test.ts
+++ b/packages/functions/test/resample.test.ts
@@ -2,6 +2,7 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Accessor, Document, Logger } from '@gltf-transform/core';
+import { fromEuler } from 'gl-matrix/quat';
 import { resample } from '../';
 
 test('@gltf-transform/functions::resample', async (t) => {
@@ -39,6 +40,43 @@ test('@gltf-transform/functions::resample', async (t) => {
 	// No change.
 	t.deepEquals(toArray(samplerC.getInput()), Array.from(inArray), 'CUBICSPLINE input (unchanged)');
 	t.deepEquals(toArray(samplerC.getOutput()), Array.from(outSplineArray), 'CUBICSPLINE output (unchanged)');
+	t.end();
+});
+
+test('@gltf-transform/functions::resample | rotation', async (t) => {
+	const doc = new Document().setLogger(new Logger(Logger.Verbosity.SILENT));
+
+	const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
+	const outArray = new Float32Array([
+		...fromEuler([], 0, 0, 0),
+		...fromEuler([], 45, 0, 0),
+		...fromEuler([], 90, 0, 0),
+		...fromEuler([], 135, 0, 0),
+		...fromEuler([], 180, 0, 0), // resampling can't create ≥180º steps!
+		...fromEuler([], 225, 0, 0),
+		...fromEuler([], 270, 0, 0),
+	]);
+
+	const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inArray);
+	const output = doc.createAccessor('output').setType(Accessor.Type.VEC4).setArray(outArray);
+	const sampler = doc.createAnimationSampler().setInterpolation('LINEAR').setInput(input).setOutput(output);
+	const channel = doc.createAnimationChannel().setTargetPath('rotation').setSampler(sampler);
+	doc.createAnimation().addChannel(channel).addSampler(sampler);
+
+	await doc.transform(resample());
+
+	t.deepEquals(toArray(sampler.getInput()), [0, 3, 6], 'input');
+	t.deepEquals(
+		toArray(sampler.getOutput()),
+		// prettier-ignore
+		[
+			0, 0, 0, 1,
+			0.9238795042037964, 0, 0, 0.3826834261417389,
+			0.7071067690849304, 0, -0, -0.7071067690849304
+		],
+		'output'
+	);
+
 	t.end();
 });
 

--- a/packages/functions/test/resample.test.ts
+++ b/packages/functions/test/resample.test.ts
@@ -4,7 +4,7 @@ import test from 'tape';
 import { Accessor, Document, Logger } from '@gltf-transform/core';
 import { resample } from '../';
 
-test.only('@gltf-transform/functions::resample', async (t) => {
+test('@gltf-transform/functions::resample', async (t) => {
 	const doc = new Document().setLogger(new Logger(Logger.Verbosity.SILENT));
 
 	const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -36,6 +36,16 @@ declare module 'gl-matrix/mat3' {
 	export = mat3;
 }
 
+declare module 'gl-matrix/quat' {
+	import { quat } from 'gl-matrix';
+	export = quat;
+}
+
+declare module 'gl-matrix/quat2' {
+	import { quat2 } from 'gl-matrix';
+	export = quat2;
+}
+
 /** Deno */
 
 declare const Deno: {


### PR DESCRIPTION
Changes:

- Compare quaternion keyframes with slerp, not lerp
- Avoid creating ≥180º steps between quaternion keyframes 

***

- Fixes #501