### PR TITLE
Export weldOnly and weldAndMerge

### DIFF
--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -85,8 +85,10 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 }
 
 export function weldPrimitive(doc: Document, prim: Primitive, options: Required<WeldOptions>): void {
-	if (prim.getIndices() && !options.overwrite) return;
-	if (prim.getMode() === Primitive.Mode.POINTS) return;
+	if (prim.getIndices() && !options.overwrite) 
+		return;
+	if (prim.getMode() === Primitive.Mode.POINTS) 
+		return;
 	if (options.tolerance === 0) {
 		weldOnly(doc, prim);
 	} else {

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -70,15 +70,7 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 
 		for (const mesh of doc.getRoot().listMeshes()) {
 			for (const prim of mesh.listPrimitives()) {
-				if (prim.getIndices() && !options.overwrite) {
-					continue;
-				} else if (prim.getMode() === Primitive.Mode.POINTS) {
-					continue;
-				} else if (options.tolerance === 0) {
-					weldOnly(doc, prim);
-				} else {
-					weldAndMerge(doc, prim, options);
-				}
+				weldPrimitive(doc, prim, options);
 			}
 		}
 
@@ -92,8 +84,18 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 	});
 }
 
+export function weldPrimitive(doc: Document, prim: Primitive, options: Required<WeldOptions>): void {
+	if (prim.getIndices() && !options.overwrite) return;
+	if (prim.getMode() === Primitive.Mode.POINTS) return;
+	if (options.tolerance === 0) {
+		weldOnly(doc, prim);
+	} else {
+		weldAndMerge(doc, prim, options);
+	}
+}
+
 /**  In-place weld, adds indices without changing number of vertices. */
-export function weldOnly(doc: Document, prim: Primitive): void {
+function weldOnly(doc: Document, prim: Primitive): void {
 	if (prim.getIndices()) return;
 	const attr = prim.listAttributes()[0];
 	const numVertices = attr.getCount();
@@ -107,7 +109,7 @@ export function weldOnly(doc: Document, prim: Primitive): void {
 }
 
 /** Weld and merge, combining vertices that are similar on all vertex attributes. */
-export function weldAndMerge(doc: Document, prim: Primitive, options: Required<WeldOptions>): void {
+function weldAndMerge(doc: Document, prim: Primitive, options: Required<WeldOptions>): void {
 	const logger = doc.getLogger();
 
 	const srcPosition = prim.getAttribute('POSITION')!;

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -93,7 +93,7 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 }
 
 /**  In-place weld, adds indices without changing number of vertices. */
-function weldOnly(doc: Document, prim: Primitive): void {
+export function weldOnly(doc: Document, prim: Primitive): void {
 	if (prim.getIndices()) return;
 	const attr = prim.listAttributes()[0];
 	const numVertices = attr.getCount();
@@ -107,7 +107,7 @@ function weldOnly(doc: Document, prim: Primitive): void {
 }
 
 /** Weld and merge, combining vertices that are similar on all vertex attributes. */
-function weldAndMerge(doc: Document, prim: Primitive, options: Required<WeldOptions>): void {
+export function weldAndMerge(doc: Document, prim: Primitive, options: Required<WeldOptions>): void {
 	const logger = doc.getLogger();
 
 	const srcPosition = prim.getAttribute('POSITION')!;


### PR DESCRIPTION
It would be nice to be able to re-use the weld and weldOnly methods for individual primitives without having to copy the code in our own extension/plugin.

I'm not sure if you'd want to export those methods and increasing the API surface. I would like to make a similar PR for the squoosh and/or toktx methods if you're generally open for that