### PR TITLE
Add Sharp-based resize option to textureCompress

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
 import { Logger, NodeIO, PropertyType, VertexLayout, vec2 } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
-import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, textureResize, unweld, weld, reorder, dequantize, unlit, meshopt, DRACO_DEFAULTS, draco, DracoOptions, simplify, SIMPLIFY_DEFAULTS, WELD_DEFAULTS, textureCompress, TEXTURE_COMPRESS_DEFAULTS } from '@gltf-transform/functions';
+import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, unweld, weld, reorder, dequantize, unlit, meshopt, DRACO_DEFAULTS, draco, DracoOptions, simplify, SIMPLIFY_DEFAULTS, WELD_DEFAULTS, textureCompress } from '@gltf-transform/functions';
 import { InspectFormat, inspect } from './inspect';
 import { ETC1S_DEFAULTS, Filter, Mode, UASTC_DEFAULTS, ktxfix, merge, toktx, XMPOptions, xmp } from './transforms';
 import { formatBytes, MICROMATCH_OPTIONS, underline } from './util';
@@ -758,9 +758,10 @@ preserving original aspect ratio. Texture dimensions are never increased.
 			? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS)
 			: null;
 		return Session.create(io, logger, args.input, args.output)
-			.transform(textureResize({
-				size: [options.width, options.height] as vec2,
-				filter: options.filter as TextureResizeFilter,
+			.transform(textureCompress({
+				encoder: sharp,
+				resize: [options.width, options.height] as vec2,
+				resizeFilter: options.filter as TextureResizeFilter,
 				pattern,
 			}));
 	});

--- a/packages/functions/src/texture-resize.ts
+++ b/packages/functions/src/texture-resize.ts
@@ -40,7 +40,10 @@ export const TEXTURE_RESIZE_DEFAULTS: TextureResizeOptions = {
 
 /**
  * Resize PNG or JPEG {@link Texture Textures}, with {@link https://en.wikipedia.org/wiki/Lanczos_algorithm Lanczos filtering}.
- * Implementation provided by {@link https://github.com/donmccurdy/ndarray-lanczos ndarray-lanczos} package.
+ *
+ * Implementation provided by {@link https://github.com/donmccurdy/ndarray-lanczos ndarray-lanczos}
+ * package, which works in Web and Node.js environments. For a faster and more robust implementation
+ * based on Sharp (available only in Node.js), use {@link textureCompress} with the 'resize' option.
  */
 export function textureResize(_options: TextureResizeOptions = TEXTURE_RESIZE_DEFAULTS): Transform {
 	const options = { ...TEXTURE_RESIZE_DEFAULTS, ..._options } as Required<TextureResizeOptions>;


### PR DESCRIPTION
Example:

```javascript
import sharp from 'sharp';
import { textureCompress } from '@gltf-transform/functions';

await document.transform(
  textureCompress({ encoder: sharp, resize: [1024, 1024] })
);
```

- Fixes https://github.com/donmccurdy/glTF-Transform/issues/647
- Fixes https://github.com/donmccurdy/glTF-Transform/issues/562