### PR TITLE
Add KHR and EXT prefixes to Extension subclasses

### DIFF
--- a/docs/EXTENSIONS.md
+++ b/docs/EXTENSIONS.md
@@ -21,29 +21,29 @@ as prescribed by the extension itself.
 
 > _**NOTICE:** Khronos extensions are widely supported and recommended for general use._
 
-- {@link DracoMeshCompression KHR_draco_mesh_compression}
-- {@link LightsPunctual KHR_lights_punctual}
-- {@link MaterialsClearcoat KHR_materials_clearcoat}
-- {@link MaterialsEmissiveStrength KHR_materials_emissive_strength}
-- {@link MaterialsIOR KHR_materials_ior}
-- {@link MaterialsIridescence KHR_materials_iridescence}
-- {@link MaterialsPBRSpecularGlossiness KHR_materials_pbrSpecularGlossiness}
-- {@link MaterialsSheen KHR_materials_sheen}
-- {@link MaterialsSpecular KHR_materials_specular}
-- {@link MaterialsTransmission KHR_materials_transmission}
-- {@link MaterialsUnlit KHR_materials_unlit}
-- {@link MaterialsVariants KHR_materials_variants}
-- {@link MaterialsVolume KHR_materials_volume}
-- {@link MeshQuantization KHR_mesh_quantization}
-- {@link TextureBasisu KHR_texture_basisu}
-- {@link TextureTransform KHR_texture_transform}
-- {@link XMP KHR_xmp_json_ld}
+- {@link KHRDracoMeshCompression KHR_draco_mesh_compression}
+- {@link KHRLightsPunctual KHR_lights_punctual}
+- {@link KHRMaterialsClearcoat KHR_materials_clearcoat}
+- {@link KHRMaterialsEmissiveStrength KHR_materials_emissive_strength}
+- {@link KHRMaterialsIOR KHR_materials_ior}
+- {@link KHRMaterialsIridescence KHR_materials_iridescence}
+- {@link KHRMaterialsPBRSpecularGlossiness KHR_materials_pbrSpecularGlossiness}
+- {@link KHRMaterialsSheen KHR_materials_sheen}
+- {@link KHRMaterialsSpecular KHR_materials_specular}
+- {@link KHRMaterialsTransmission KHR_materials_transmission}
+- {@link KHRMaterialsUnlit KHR_materials_unlit}
+- {@link KHRMaterialsVariants KHR_materials_variants}
+- {@link KHRMaterialsVolume KHR_materials_volume}
+- {@link KHRMeshQuantization KHR_mesh_quantization}
+- {@link KHRTextureBasisu KHR_texture_basisu}
+- {@link KHRTextureTransform KHR_texture_transform}
+- {@link KHRXMP KHR_xmp_json_ld}
 
 ## Vendor Extensions
 
-- {@link TextureWebP EXT_texture_webp}
-- {@link MeshGPUInstancing EXT_mesh_gpu_instancing}
-- {@link MeshoptCompression EXT_meshopt_compression}
+- {@link EXTTextureWebP EXT_texture_webp}
+- {@link EXTMeshGPUInstancing EXT_mesh_gpu_instancing}
+- {@link EXTMeshoptCompression EXT_meshopt_compression}
 
 ## Installation
 
@@ -64,8 +64,8 @@ const io = new WebIO().registerExtensions(KHRONOS_EXTENSIONS);
 
 // Register an individual extension.
 import { WebIO } from '@gltf-transform/core';
-import { MaterialsUnlit } from '@gltf-transform/extensions';
-const io = new WebIO().registerExtensions([MaterialsUnlit]);
+import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
+const io = new WebIO().registerExtensions([KHRMaterialsUnlit]);
 
 // Read a file that requires the KHR_materials_unlit extension.
 const document = await io.readGLB('unlit.glb');

--- a/docs/theme/layouts/default.hbs
+++ b/docs/theme/layouts/default.hbs
@@ -226,87 +226,87 @@
 	<ul>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.dracomeshcompression.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.dracomeshcompression.html'}} active{{/ifCond}}">
-				DracoMeshCompression
+				KHRDracoMeshCompression
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.lightspunctual.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.lightspunctual.html'}} active{{/ifCond}}">
-				LightsPunctual
+				KHRLightsPunctual
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsclearcoat.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsclearcoat.html'}} active{{/ifCond}}">
-				MaterialsClearcoat
+				KHRMaterialsClearcoat
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsemissivestrength.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsemissivestrength.html'}} active{{/ifCond}}">
-				MaterialsEmissiveStrength
+				KHRMaterialsEmissiveStrength
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsior.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsior.html'}} active{{/ifCond}}">
-				MaterialsIOR
+				KHRMaterialsIOR
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsiridescence.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsiridescence.html'}} active{{/ifCond}}">
-				MaterialsIridescence
+				KHRMaterialsIridescence
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialspbrspecularglossiness.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialspbrspecularglossiness.html'}} active{{/ifCond}}">
-				MaterialsPBRSpecularGlossiness
+				KHRMaterialsPBRSpecularGlossiness
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialssheen.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialssheen.html'}} active{{/ifCond}}">
-				MaterialsSheen
+				KHRMaterialsSheen
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsspecular.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsspecular.html'}} active{{/ifCond}}">
-				MaterialsSpecular
+				KHRMaterialsSpecular
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialstransmission.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialstransmission.html'}} active{{/ifCond}}">
-				MaterialsTransmission
+				KHRMaterialsTransmission
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsunlit.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsunlit.html'}} active{{/ifCond}}">
-				MaterialsUnlit
+				KHRMaterialsUnlit
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsvariants.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsvariants.html'}} active{{/ifCond}}">
-				MaterialsVariants
+				KHRMaterialsVariants
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.materialsvolume.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.materialsvolume.html'}} active{{/ifCond}}">
-				MaterialsVolume
+				KHRMaterialsVolume
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.meshquantization.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.meshquantization.html'}} active{{/ifCond}}">
-				MeshQuantization
+				KHRMeshQuantization
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.texturebasisu.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.texturebasisu.html'}} active{{/ifCond}}">
-				TextureBasisu
+				KHRTextureBasisu
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.texturetransform.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.texturetransform.html'}} active{{/ifCond}}">
-				TextureTransform
+				KHRTextureTransform
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.xmp.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.xmp.html'}} active{{/ifCond}}">
-				XMP
+				KHRXMP
 			</a>
 		</li>
 	</ul>
@@ -315,17 +315,17 @@
 	<ul>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.texturewebp.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.texturewebp.html'}} active{{/ifCond}}">
-				TextureWebP
+				EXTTextureWebP
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.meshgpuinstancing.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.meshgpuinstancing.html'}} active{{/ifCond}}">
-				MeshGPUInstancing
+				EXTMeshGPUInstancing
 			</a>
 		</li>
 		<li class="tsd-kind-class">
 			<a href="/classes/extensions.meshoptcompression.html" class="tsd-kind-icon{{#ifCond url '===' 'classes/extensions.meshoptcompression.html'}} active{{/ifCond}}">
-				MeshoptCompression
+				EXTMeshoptCompression
 			</a>
 		</li>
 	</ul>

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -1,5 +1,5 @@
 import { Document, NodeIO, Logger, FileUtils, Transform, Format, ILogger } from '@gltf-transform/core';
-import type { Packet, XMP } from '@gltf-transform/extensions';
+import type { Packet, KHRXMP } from '@gltf-transform/extensions';
 import { unpartition } from '@gltf-transform/functions';
 import { formatBytes, XMPContext } from './util';
 
@@ -57,7 +57,9 @@ export class Session {
 
 function updateMetadata(document: Document): void {
 	const root = document.getRoot();
-	const xmpExtension = root.listExtensionsUsed().find((ext) => ext.extensionName === 'KHR_xmp_json_ld') as XMP | null;
+	const xmpExtension = root
+		.listExtensionsUsed()
+		.find((ext) => ext.extensionName === 'KHR_xmp_json_ld') as KHRXMP | null;
 
 	// Do not add KHR_xmp_json_ld to assets that don't already use it.
 	if (!xmpExtension) return;

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -9,7 +9,7 @@ const tmp = require('tmp');
 const pLimit = require('p-limit');
 
 import { Document, FileUtils, ILogger, ImageUtils, TextureChannel, Transform, vec2, uuid } from '@gltf-transform/core';
-import { TextureBasisu } from '@gltf-transform/extensions';
+import { KHRTextureBasisu } from '@gltf-transform/extensions';
 import { getTextureChannelMask, listTextureSlots } from '@gltf-transform/functions';
 import { spawn, commandExists, formatBytes, waitExit, MICROMATCH_OPTIONS } from '../util';
 
@@ -124,7 +124,7 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 		const batchDir = join(tmp.tmpdir, 'gltf-transform');
 		if (!existsSync(batchDir)) mkdirSync(batchDir);
 
-		const basisuExtension = doc.createExtension(TextureBasisu).setRequired(true);
+		const basisuExtension = doc.createExtension(KHRTextureBasisu).setRequired(true);
 
 		let numCompressed = 0;
 

--- a/packages/cli/src/transforms/xmp.ts
+++ b/packages/cli/src/transforms/xmp.ts
@@ -1,5 +1,5 @@
 import type { Document, ILogger, Transform } from '@gltf-transform/core';
-import { Packet, XMP } from '@gltf-transform/extensions';
+import { Packet, KHRXMP } from '@gltf-transform/extensions';
 import inquirer from 'inquirer';
 import { check as validateLanguage } from 'language-tags';
 import validateSPDX from 'spdx-correct';
@@ -254,7 +254,7 @@ export const xmp = (_options: XMPOptions = XMP_DEFAULTS): Transform => {
 	return async (document: Document): Promise<void> => {
 		const logger = document.getLogger();
 		const root = document.getRoot();
-		const xmpExtension = document.createExtension(XMP);
+		const xmpExtension = document.createExtension(KHRXMP);
 
 		if (options.reset) {
 			xmpExtension.dispose();

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import fs from 'fs/promises';
 import test from 'tape';
 import { Document, Logger, TextureChannel, vec2 } from '@gltf-transform/core';
-import { MaterialsClearcoat } from '@gltf-transform/extensions';
+import { KHRMaterialsClearcoat } from '@gltf-transform/extensions';
 import { Mode, mockCommandExists, mockSpawn, toktx, mockWaitExit } from '../';
 import type { ChildProcess } from 'child_process';
 
@@ -54,7 +54,7 @@ async function getParams(options: Record<string, unknown>, size: vec2, channels 
 	if (channels === R) {
 		doc.createMaterial().setOcclusionTexture(tex);
 	} else if (channels === G) {
-		const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
+		const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
 		const clearcoat = clearcoatExtension.createClearcoat().setClearcoatRoughnessTexture(tex);
 		doc.createMaterial().setExtension('KHR_materials_clearcoat', clearcoat);
 	} else if (channels !== 0x0000) {

--- a/packages/extensions/src/ext-mesh-gpu-instancing/instanced-mesh.ts
+++ b/packages/extensions/src/ext-mesh-gpu-instancing/instanced-mesh.ts
@@ -11,7 +11,7 @@ export const INSTANCE_ATTRIBUTE = 'INSTANCE_ATTRIBUTE';
 /**
  * # InstancedMesh
  *
- * Defines GPU instances of a {@link Mesh} under one {@link Node}. See {@link MeshGPUInstancing}.
+ * Defines GPU instances of a {@link Mesh} under one {@link Node}. See {@link EXTMeshGPUInstancing}.
  */
 export class InstancedMesh extends ExtensionProperty<IInstancedMesh> {
 	public static EXTENSION_NAME = EXT_MESH_GPU_INSTANCING;

--- a/packages/extensions/src/ext-mesh-gpu-instancing/mesh-gpu-instancing.ts
+++ b/packages/extensions/src/ext-mesh-gpu-instancing/mesh-gpu-instancing.ts
@@ -11,7 +11,7 @@ interface InstancedMeshDef {
 }
 
 /**
- * # MeshGPUInstancing
+ * # EXTMeshGPUInstancing
  *
  * [`EXT_mesh_gpu_instancing`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/)
  * prepares mesh data for efficient GPU instancing.
@@ -36,11 +36,11 @@ interface InstancedMeshDef {
  *
  * ### Example
  *
- * The `MeshGPUInstancing` class provides a single {@link ExtensionProperty} type, `InstancedMesh`,
+ * The `EXTMeshGPUInstancing` class provides a single {@link ExtensionProperty} type, `InstancedMesh`,
  * which may be attached to any {@link Node} instance. For example:
  *
  * ```typescript
- * import { MeshGPUInstancing } from '@gltf-transform/extensions';
+ * import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
  *
  * // Create standard mesh, node, and scene hierarchy.
  * // ...
@@ -62,7 +62,7 @@ interface InstancedMeshDef {
  * 	.setBuffer(buffer);
  *
  * // Create an Extension attached to the Document.
- * const batchExtension = document.createExtension(MeshGPUInstancing)
+ * const batchExtension = document.createExtension(EXTMeshGPUInstancing)
  * 	.setRequired(true);
  * const batch = batchExtension.createInstancedMesh()
  * 	.setAttribute('TRANSLATION', batchPositions)
@@ -77,7 +77,7 @@ interface InstancedMeshDef {
  * types allowed by the extension specification. Custom instance attributes are allowed, and should
  * be prefixed with an underscore (`_*`).
  */
-export class MeshGPUInstancing extends Extension {
+export class EXTMeshGPUInstancing extends Extension {
 	public readonly extensionName = NAME;
 	/** @hidden */
 	public readonly provideTypes = [PropertyType.NODE];

--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -29,7 +29,7 @@ type MeshoptBufferView = { extensions: { [NAME]: MeshoptBufferViewExtension } };
 type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
 
 /**
- * # MeshoptCompression
+ * # EXTMeshoptCompression
  *
  * [`EXT_meshopt_compression`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Vendor/EXT_meshopt_compression/)
  * provides compression and fast decoding for geometry, morph targets, and animations.
@@ -65,14 +65,14 @@ type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
  * ```typescript
  * import { NodeIO } from '@gltf-transform/core';
  * import { reorder, quantize } from '@gltf-transform/functions';
- * import { MeshoptCompression } from '@gltf-transform/extensions';
+ * import { EXTMeshoptCompression } from '@gltf-transform/extensions';
  * import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
  *
  * await MeshoptDecoder.ready;
  * await MeshoptEncoder.ready;
  *
  * const io = new NodeIO()
- *	.registerExtensions([MeshoptCompression])
+ *	.registerExtensions([EXTMeshoptCompression])
  *	.registerDependencies({
  *		'meshopt.decoder': MeshoptDecoder,
  *		'meshopt.encoder': MeshoptEncoder,
@@ -86,9 +86,9 @@ type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
  * 	reorder({encoder: MeshoptEncoder}),
  * 	quantize()
  * );
- * document.createExtension(MeshoptCompression)
+ * document.createExtension(EXTMeshoptCompression)
  * 	.setRequired(true)
- * 	.setEncoderOptions({ method: MeshoptCompression.EncoderMethod.QUANTIZE });
+ * 	.setEncoderOptions({ method: EXTMeshoptCompression.EncoderMethod.QUANTIZE });
  * await io.write('compressed-medium.glb', document);
  *
  * // Write and encode. (High, -cc)
@@ -96,13 +96,13 @@ type EncodedBufferView = GLTF.IBufferView & MeshoptBufferView;
  * 	reorder({encoder: MeshoptEncoder}),
  * 	quantize({pattern: /^(POSITION|TEXCOORD|JOINTS|WEIGHTS)(_\d+)?$/}),
  * );
- * document.createExtension(MeshoptCompression)
+ * document.createExtension(EXTMeshoptCompression)
  * 	.setRequired(true)
- * 	.setEncoderOptions({ method: MeshoptCompression.EncoderMethod.FILTER });
+ * 	.setEncoderOptions({ method: EXTMeshoptCompression.EncoderMethod.FILTER });
  * await io.write('compressed-high.glb', document);
  * ```
  */
-export class MeshoptCompression extends Extension {
+export class EXTMeshoptCompression extends Extension {
 	public readonly extensionName = NAME;
 	/** @hidden */
 	public readonly prereadTypes = [PropertyType.BUFFER, PropertyType.PRIMITIVE];
@@ -156,12 +156,12 @@ export class MeshoptCompression extends Extension {
 	 * Example:
 	 *
 	 * ```ts
-	 * import { MeshoptCompression } from '@gltf-transform/extensions';
+	 * import { EXTMeshoptCompression } from '@gltf-transform/extensions';
 	 *
-	 * doc.createExtension(MeshoptCompression)
+	 * doc.createExtension(EXTMeshoptCompression)
 	 * 	.setRequired(true)
 	 * 	.setEncoderOptions({
-	 * 		method: MeshoptCompression.EncoderMethod.QUANTIZE
+	 * 		method: EXTMeshoptCompression.EncoderMethod.QUANTIZE
 	 * 	});
 	 * ```
 	 */

--- a/packages/extensions/src/ext-texture-webp/texture-webp.ts
+++ b/packages/extensions/src/ext-texture-webp/texture-webp.ts
@@ -60,7 +60,7 @@ class WEBPImageUtils implements ImageUtilsFormat {
 }
 
 /**
- * # TextureWebP
+ * # EXTTextureWebP
  *
  * [`EXT_texture_webp`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_texture_webp/)
  * enables WebP images for any material texture.
@@ -85,10 +85,10 @@ class WEBPImageUtils implements ImageUtilsFormat {
  * ### Example
  *
  * ```typescript
- * import { TextureWebP } from '@gltf-transform/extensions';
+ * import { EXTTextureWebP } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const webpExtension = document.createExtension(TextureWebP)
+ * const webpExtension = document.createExtension(EXTTextureWebP)
  * 	.setRequired(true);
  * document.createTexture('MyWebPTexture')
  * 	.setMimeType('image/webp')
@@ -102,7 +102,7 @@ class WEBPImageUtils implements ImageUtilsFormat {
  * always be required. This tool does not support writing assets that "fall back" to optional PNG or
  * JPEG image data.
  */
-export class TextureWebP extends Extension {
+export class EXTTextureWebP extends Extension {
 	public readonly extensionName = NAME;
 	/** @hidden */
 	public readonly prereadTypes = [PropertyType.TEXTURE];

--- a/packages/extensions/src/extensions.ts
+++ b/packages/extensions/src/extensions.ts
@@ -1,47 +1,47 @@
 /** @module extensions */
 
-import { MeshGPUInstancing } from './ext-mesh-gpu-instancing';
-import { MeshoptCompression } from './ext-meshopt-compression';
-import { TextureWebP } from './ext-texture-webp';
-import { DracoMeshCompression } from './khr-draco-mesh-compression';
-import { LightsPunctual } from './khr-lights-punctual';
-import { MaterialsClearcoat } from './khr-materials-clearcoat';
-import { MaterialsEmissiveStrength } from './khr-materials-emissive-strength';
-import { MaterialsIOR } from './khr-materials-ior';
-import { MaterialsIridescence } from './khr-materials-iridescence';
-import { MaterialsPBRSpecularGlossiness } from './khr-materials-pbr-specular-glossiness';
-import { MaterialsSheen } from './khr-materials-sheen';
-import { MaterialsSpecular } from './khr-materials-specular';
-import { MaterialsTransmission } from './khr-materials-transmission';
-import { MaterialsUnlit } from './khr-materials-unlit';
-import { MaterialsVariants } from './khr-materials-variants';
-import { MaterialsVolume } from './khr-materials-volume';
-import { MeshQuantization } from './khr-mesh-quantization';
-import { TextureBasisu } from './khr-texture-basisu';
-import { TextureTransform } from './khr-texture-transform';
-import { XMP } from './khr-xmp-json-ld';
+import { EXTMeshGPUInstancing } from './ext-mesh-gpu-instancing';
+import { EXTMeshoptCompression } from './ext-meshopt-compression';
+import { EXTTextureWebP } from './ext-texture-webp';
+import { KHRDracoMeshCompression } from './khr-draco-mesh-compression';
+import { KHRLightsPunctual } from './khr-lights-punctual';
+import { KHRMaterialsClearcoat } from './khr-materials-clearcoat';
+import { KHRMaterialsEmissiveStrength } from './khr-materials-emissive-strength';
+import { KHRMaterialsIOR } from './khr-materials-ior';
+import { KHRMaterialsIridescence } from './khr-materials-iridescence';
+import { KHRMaterialsPBRSpecularGlossiness } from './khr-materials-pbr-specular-glossiness';
+import { KHRMaterialsSheen } from './khr-materials-sheen';
+import { KHRMaterialsSpecular } from './khr-materials-specular';
+import { KHRMaterialsTransmission } from './khr-materials-transmission';
+import { KHRMaterialsUnlit } from './khr-materials-unlit';
+import { KHRMaterialsVariants } from './khr-materials-variants';
+import { KHRMaterialsVolume } from './khr-materials-volume';
+import { KHRMeshQuantization } from './khr-mesh-quantization';
+import { KHRTextureBasisu } from './khr-texture-basisu';
+import { KHRTextureTransform } from './khr-texture-transform';
+import { KHRXMP } from './khr-xmp-json-ld';
 
 export const KHRONOS_EXTENSIONS = [
-	DracoMeshCompression,
-	LightsPunctual,
-	MaterialsClearcoat,
-	MaterialsEmissiveStrength,
-	MaterialsIOR,
-	MaterialsIridescence,
-	MaterialsPBRSpecularGlossiness,
-	MaterialsSpecular,
-	MaterialsSheen,
-	MaterialsTransmission,
-	MaterialsUnlit,
-	MaterialsVariants,
-	MaterialsVolume,
-	MeshQuantization,
-	TextureBasisu,
-	TextureTransform,
-	XMP,
+	KHRDracoMeshCompression,
+	KHRLightsPunctual,
+	KHRMaterialsClearcoat,
+	KHRMaterialsEmissiveStrength,
+	KHRMaterialsIOR,
+	KHRMaterialsIridescence,
+	KHRMaterialsPBRSpecularGlossiness,
+	KHRMaterialsSpecular,
+	KHRMaterialsSheen,
+	KHRMaterialsTransmission,
+	KHRMaterialsUnlit,
+	KHRMaterialsVariants,
+	KHRMaterialsVolume,
+	KHRMeshQuantization,
+	KHRTextureBasisu,
+	KHRTextureTransform,
+	KHRXMP,
 ];
 
-export const ALL_EXTENSIONS = [MeshGPUInstancing, MeshoptCompression, TextureWebP, ...KHRONOS_EXTENSIONS];
+export const ALL_EXTENSIONS = [EXTMeshGPUInstancing, EXTMeshoptCompression, EXTTextureWebP, ...KHRONOS_EXTENSIONS];
 
 export * from './ext-mesh-gpu-instancing';
 export * from './ext-meshopt-compression';

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -38,7 +38,7 @@ interface DracoWriterContext {
 }
 
 /**
- * # DracoMeshCompression
+ * # KHRDracoMeshCompression
  *
  * [`KHR_draco_mesh_compression`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_draco_mesh_compression/)
  * provides advanced compression for mesh geometry.
@@ -80,14 +80,14 @@ interface DracoWriterContext {
  *
  * ```typescript
  * import { NodeIO } from '@gltf-transform/core';
- * import { DracoMeshCompression } from '@gltf-transform/extensions';
+ * import { KHRDracoMeshCompression } from '@gltf-transform/extensions';
  *
  * import draco3d from 'draco3dgltf';
  *
  * // ...
  *
  * const io = new NodeIO()
- *	.registerExtensions([DracoMeshCompression])
+ *	.registerExtensions([KHRDracoMeshCompression])
  *	.registerDependencies({
  *		'draco3d.decoder': await draco3d.createDecoderModule(), // Optional.
  *		'draco3d.encoder': await draco3d.createEncoderModule(), // Optional.
@@ -97,17 +97,17 @@ interface DracoWriterContext {
  * const document = await io.read('compressed.glb');
  *
  * // Write and encode.
- * document.createExtension(DracoMeshCompression)
+ * document.createExtension(KHRDracoMeshCompression)
  * 	.setRequired(true)
  * 	.setEncoderOptions({
- * 		method: DracoMeshCompression.EncoderMethod.EDGEBREAKER,
+ * 		method: KHRDracoMeshCompression.EncoderMethod.EDGEBREAKER,
  * 		encodeSpeed: 5,
  * 		decodeSpeed: 5,
  * 	});
  * await io.write('compressed.glb', document);
  * ```
  */
-export class DracoMeshCompression extends Extension {
+export class KHRDracoMeshCompression extends Extension {
 	public readonly extensionName = NAME;
 	/** @hidden */
 	public readonly prereadTypes = [PropertyType.PRIMITIVE];

--- a/packages/extensions/src/khr-lights-punctual/light.ts
+++ b/packages/extensions/src/khr-lights-punctual/light.ts
@@ -16,7 +16,7 @@ type PunctualLightType = 'point' | 'spot' | 'directional';
 /**
  * # Light
  *
- * Defines a light attached to a {@link Node}. See {@link LightsPunctual}.
+ * Defines a light attached to a {@link Node}. See {@link KHRLightsPunctual}.
  */
 export class Light extends ExtensionProperty<ILight> {
 	public static EXTENSION_NAME = KHR_LIGHTS_PUNCTUAL;

--- a/packages/extensions/src/khr-lights-punctual/lights-punctual.ts
+++ b/packages/extensions/src/khr-lights-punctual/lights-punctual.ts
@@ -25,7 +25,7 @@ interface LightDef {
 }
 
 /**
- * # LightsPunctual
+ * # KHRLightsPunctual
  *
  * [`KHR_lights_punctual`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_lights_punctual/) defines three "punctual" light types: directional, point and
  * spot.
@@ -40,10 +40,10 @@ interface LightDef {
  * ### Example
  *
  * ```typescript
- * import { LightsPunctual, Light, LightType } from '@gltf-transform/extensions';
+ * import { KHRLightsPunctual, Light, LightType } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const lightsExtension = document.createExtension(LightsPunctual);
+ * const lightsExtension = document.createExtension(KHRLightsPunctual);
  *
  * // Create a Light property.
  * const light = lightsExtension.createLight()
@@ -55,7 +55,7 @@ interface LightDef {
  * node.setExtension('KHR_lights_punctual', light);
  * ```
  */
-export class LightsPunctual extends Extension {
+export class KHRLightsPunctual extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/clearcoat.ts
@@ -28,7 +28,7 @@ const { R, G, B } = TextureChannel;
 /**
  * # Clearcoat
  *
- * Defines clear coat for a PBR material. See {@link MaterialsClearcoat}.
+ * Defines clear coat for a PBR material. See {@link KHRMaterialsClearcoat}.
  */
 export class Clearcoat extends ExtensionProperty<IClearcoat> {
 	public static EXTENSION_NAME = KHR_MATERIALS_CLEARCOAT;

--- a/packages/extensions/src/khr-materials-clearcoat/materials-clearcoat.ts
+++ b/packages/extensions/src/khr-materials-clearcoat/materials-clearcoat.ts
@@ -13,7 +13,7 @@ interface ClearcoatDef {
 }
 
 /**
- * # MaterialsClearcoat
+ * # KHRMaterialsClearcoat
  *
  * [KHR_materials_clearcoat](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_clearcoat/)
  * defines a clear coating on a glTF PBR material.
@@ -33,10 +33,10 @@ interface ClearcoatDef {
  * ### Example
  *
  * ```typescript
- * import { MaterialsClearcoat, Clearcoat } from '@gltf-transform/extensions';
+ * import { KHRMaterialsClearcoat, Clearcoat } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const clearcoatExtension = document.createExtension(MaterialsClearcoat);
+ * const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
  *
  * // Create Clearcoat property.
  * const clearcoat = clearcoatExtension.createClearcoat()
@@ -46,7 +46,7 @@ interface ClearcoatDef {
  * material.setExtension('KHR_materials_clearcoat', clearcoat);
  * ```
  */
-export class MaterialsClearcoat extends Extension {
+export class KHRMaterialsClearcoat extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-emissive-strength/emissive-strength.ts
+++ b/packages/extensions/src/khr-materials-emissive-strength/emissive-strength.ts
@@ -9,7 +9,7 @@ interface IEmissiveStrength extends IProperty {
  * # EmissiveStrength
  *
  * Defines emissive strength for a PBR {@link Material}, allowing high-dynamic-range
- * (HDR) emissive materials. See {@link MaterialsEmissiveStrength}.
+ * (HDR) emissive materials. See {@link KHRMaterialsEmissiveStrength}.
  */
 export class EmissiveStrength extends ExtensionProperty<IEmissiveStrength> {
 	public static EXTENSION_NAME = KHR_MATERIALS_EMISSIVE_STRENGTH;

--- a/packages/extensions/src/khr-materials-emissive-strength/materials-emissive-strength.ts
+++ b/packages/extensions/src/khr-materials-emissive-strength/materials-emissive-strength.ts
@@ -9,7 +9,7 @@ interface EmissiveStrengthDef {
 }
 
 /**
- * # MaterialsEmissiveStrength
+ * # KHRMaterialsEmissiveStrength
  *
  * [KHR_materials_emissive_strength](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength/)
  * defines emissive strength and enables high-dynamic-range (HDR) emissive materials.
@@ -34,10 +34,10 @@ interface EmissiveStrengthDef {
  * ### Example
  *
  * ```typescript
- * import { MaterialsEmissiveStrength, EmissiveStrength } from '@gltf-transform/extensions';
+ * import { KHRMaterialsEmissiveStrength, EmissiveStrength } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const emissiveStrengthExtension = document.createExtension(MaterialsEmissiveStrength);
+ * const emissiveStrengthExtension = document.createExtension(KHRMaterialsEmissiveStrength);
  *
  * // Create EmissiveStrength property.
  * const emissiveStrength = emissiveStrengthExtension
@@ -47,7 +47,7 @@ interface EmissiveStrengthDef {
  * material.setExtension('KHR_materials_emissive_strength', emissiveStrength);
  * ```
  */
-export class MaterialsEmissiveStrength extends Extension {
+export class KHRMaterialsEmissiveStrength extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-ior/ior.ts
+++ b/packages/extensions/src/khr-materials-ior/ior.ts
@@ -8,7 +8,7 @@ interface IIOR extends IProperty {
 /**
  * # IOR
  *
- * Defines index of refraction for a PBR {@link Material}. See {@link MaterialsIOR}.
+ * Defines index of refraction for a PBR {@link Material}. See {@link KHRMaterialsIOR}.
  */
 export class IOR extends ExtensionProperty<IIOR> {
 	public static EXTENSION_NAME = KHR_MATERIALS_IOR;

--- a/packages/extensions/src/khr-materials-ior/materials-ior.ts
+++ b/packages/extensions/src/khr-materials-ior/materials-ior.ts
@@ -9,7 +9,7 @@ interface IORDef {
 }
 
 /**
- * # MaterialsIOR
+ * # KHRMaterialsIOR
  *
  * [KHR_materials_ior](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_ior/)
  * defines index of refraction on a glTF PBR material.
@@ -25,10 +25,10 @@ interface IORDef {
  * ### Example
  *
  * ```typescript
- * import { MaterialsIOR, IOR } from '@gltf-transform/extensions';
+ * import { KHRMaterialsIOR, IOR } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const iorExtension = document.createExtension(MaterialsIOR);
+ * const iorExtension = document.createExtension(KHRMaterialsIOR);
  *
  * // Create IOR property.
  * const ior = iorExtension.createIOR().setIOR(1.0);
@@ -37,7 +37,7 @@ interface IORDef {
  * material.setExtension('KHR_materials_ior', ior);
  * ```
  */
-export class MaterialsIOR extends Extension {
+export class KHRMaterialsIOR extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-iridescence/iridescence.ts
+++ b/packages/extensions/src/khr-materials-iridescence/iridescence.ts
@@ -25,7 +25,7 @@ const { R, G } = TextureChannel;
 /**
  * # Iridescence
  *
- * Defines iridescence (thin film interference) on a PBR {@link Material}. See {@link MaterialsIridescence}.
+ * Defines iridescence (thin film interference) on a PBR {@link Material}. See {@link KHRMaterialsIridescence}.
  */
 export class Iridescence extends ExtensionProperty<IIridescence> {
 	public static EXTENSION_NAME = KHR_MATERIALS_IRIDESCENCE;

--- a/packages/extensions/src/khr-materials-iridescence/materials-iridescence.ts
+++ b/packages/extensions/src/khr-materials-iridescence/materials-iridescence.ts
@@ -14,7 +14,7 @@ interface IridescenceDef {
 }
 
 /**
- * # MaterialsIridescence
+ * # KHRMaterialsIridescence
  *
  * [`KHR_materials_iridescence`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_iridescence/)
  * defines iridescence (thin film interference) on a PBR material.
@@ -32,14 +32,14 @@ interface IridescenceDef {
  *
  * ### Example
  *
- * The `MaterialsIridescence` class provides a single {@link ExtensionProperty} type, `Iridescence`,
+ * The `KHRMaterialsIridescence` class provides a single {@link ExtensionProperty} type, `Iridescence`,
  * which may be attached to any {@link Material} instance. For example:
  *
  * ```typescript
- * import { MaterialsIridescence, Iridescence } from '@gltf-transform/extensions';
+ * import { KHRMaterialsIridescence, Iridescence } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const iridescenceExtension = document.createExtension(MaterialsIridescence);
+ * const iridescenceExtension = document.createExtension(KHRMaterialsIridescence);
  *
  * // Create an Iridescence property.
  * const iridescence = iridescenceExtension.createIridescence()
@@ -50,7 +50,7 @@ interface IridescenceDef {
  * material.setExtension('KHR_materials_iridescence', iridescence);
  * ```
  */
-export class MaterialsIridescence extends Extension {
+export class KHRMaterialsIridescence extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/materials-pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/materials-pbr-specular-glossiness.ts
@@ -13,14 +13,14 @@ interface SpecularGlossinessDef {
 }
 
 /**
- * # MaterialsPBRSpecularGlossiness
+ * # KHRMaterialsPBRSpecularGlossiness
  *
  * [`KHR_materials_pbrSpecularGlossiness`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_pbrSpecularGlossiness/)
  * converts a PBR material from the default metal/rough workflow to a spec/gloss workflow.
  *
  * > _**NOTICE:** The spec/gloss workflow does _not_ support other PBR extensions such as clearcoat,
  * > transmission, IOR, etc. For the complete PBR feature set and specular data, use the
- * > {@link MaterialsSpecular} extension instead, which provides specular data within a metal/rough
+ * > {@link KHRMaterialsSpecular} extension instead, which provides specular data within a metal/rough
  * > workflow._
  *
  * ![Illustration](/media/extensions/khr-material-pbr-specular-glossiness.png)
@@ -33,10 +33,10 @@ interface SpecularGlossinessDef {
  * ### Example
  *
  * ```typescript
- * import { MaterialsPBRSpecularGlossiness } from '@gltf-transform/extensions';
+ * import { KHRMaterialsPBRSpecularGlossiness } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const specGlossExtension = document.createExtension(MaterialsPBRSpecularGlossiness);
+ * const specGlossExtension = document.createExtension(KHRMaterialsPBRSpecularGlossiness);
  *
  * // Create a PBRSpecularGlossiness property.
  * const specGloss = specGlossExtension.createPBRSpecularGlossiness()
@@ -46,7 +46,7 @@ interface SpecularGlossinessDef {
  * material.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
  * ```
  */
-export class MaterialsPBRSpecularGlossiness extends Extension {
+export class KHRMaterialsPBRSpecularGlossiness extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -27,7 +27,7 @@ const { R, G, B, A } = TextureChannel;
 /**
  * # PBRSpecularGlossiness
  *
- * Converts a {@link Material} to a spec/gloss workflow. See {@link MaterialsPBRSpecularGlossiness}.
+ * Converts a {@link Material} to a spec/gloss workflow. See {@link KHRMaterialsPBRSpecularGlossiness}.
  */
 export class PBRSpecularGlossiness extends ExtensionProperty<IPBRSpecularGlossiness> {
 	public static EXTENSION_NAME = KHR_MATERIALS_PBR_SPECULAR_GLOSSINESS;

--- a/packages/extensions/src/khr-materials-sheen/materials-sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/materials-sheen.ts
@@ -12,7 +12,7 @@ interface SheenDef {
 }
 
 /**
- * # MaterialsSheen
+ * # KHRMaterialsSheen
  *
  * [`KHR_materials_sheen`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_sheen/)
  * defines a velvet-like sheen layered on a glTF PBR material.
@@ -31,14 +31,14 @@ interface SheenDef {
  *
  * ### Example
  *
- * The `MaterialsSheen` class provides a single {@link ExtensionProperty} type, `Sheen`,
+ * The `KHRMaterialsSheen` class provides a single {@link ExtensionProperty} type, `Sheen`,
  * which may be attached to any {@link Material} instance. For example:
  *
  * ```typescript
- * import { MaterialsSheen, Sheen } from '@gltf-transform/extensions';
+ * import { KHRMaterialsSheen, Sheen } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const sheenExtension = document.createExtension(MaterialsSheen);
+ * const sheenExtension = document.createExtension(KHRMaterialsSheen);
  *
  * // Create a Sheen property.
  * const sheen = sheenExtension.createSheen()
@@ -48,7 +48,7 @@ interface SheenDef {
  * material.setExtension('KHR_materials_sheen', sheen);
  * ```
  */
-export class MaterialsSheen extends Extension {
+export class KHRMaterialsSheen extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-sheen/sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/sheen.ts
@@ -25,7 +25,7 @@ const { R, G, B, A } = TextureChannel;
 /**
  * # Sheen
  *
- * Defines sheen on a PBR {@link Material}. See {@link MaterialsSheen}.
+ * Defines sheen on a PBR {@link Material}. See {@link KHRMaterialsSheen}.
  */
 export class Sheen extends ExtensionProperty<ISheen> {
 	public static EXTENSION_NAME = KHR_MATERIALS_SHEEN;

--- a/packages/extensions/src/khr-materials-specular/materials-specular.ts
+++ b/packages/extensions/src/khr-materials-specular/materials-specular.ts
@@ -12,13 +12,13 @@ interface SpecularDef {
 }
 
 /**
- * # MaterialsSpecular
+ * # KHRMaterialsSpecular
  *
  * [`KHR_materials_specular`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_specular/)
  * adjusts the strength of the specular reflection in the dielectric BRDF.
  *
- * MaterialsSpecular is a better alternative to the older
- * {@link MaterialsPBRSpecularGlossiness KHR_materials_pbrSpecularGlossiness} extension, and
+ * KHRMaterialsSpecular is a better alternative to the older
+ * {@link KHRMaterialsPBRSpecularGlossiness KHR_materials_pbrSpecularGlossiness} extension, and
  * provides specular information while remaining within a metal/rough PBR workflow. A
  * value of zero disables the specular reflection, resulting in a pure diffuse material.
  *
@@ -27,14 +27,14 @@ interface SpecularDef {
  *
  * ### Example
  *
- * The `MaterialsSpecular` class provides a single {@link ExtensionProperty} type, `Specular`,
+ * The `KHRMaterialsSpecular` class provides a single {@link ExtensionProperty} type, `Specular`,
  * which may be attached to any {@link Material} instance. For example:
  *
  * ```typescript
- * import { MaterialsSpecular, Specular } from '@gltf-transform/extensions';
+ * import { KHRMaterialsSpecular, Specular } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const specularExtension = document.createExtension(MaterialsSpecular);
+ * const specularExtension = document.createExtension(KHRMaterialsSpecular);
  *
  * // Create a Specular property.
  * const specular = specularExtension.createSpecular()
@@ -44,7 +44,7 @@ interface SpecularDef {
  * material.setExtension('KHR_materials_specular', specular);
  * ```
  */
-export class MaterialsSpecular extends Extension {
+export class KHRMaterialsSpecular extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -25,7 +25,7 @@ const { R, G, B, A } = TextureChannel;
 /**
  * # Specular
  *
- * Defines specular reflectivity on a PBR {@link Material}. See {@link MaterialsSpecular}.
+ * Defines specular reflectivity on a PBR {@link Material}. See {@link KHRMaterialsSpecular}.
  */
 export class Specular extends ExtensionProperty<ISpecular> {
 	public static EXTENSION_NAME = KHR_MATERIALS_SPECULAR;

--- a/packages/extensions/src/khr-materials-transmission/materials-transmission.ts
+++ b/packages/extensions/src/khr-materials-transmission/materials-transmission.ts
@@ -10,7 +10,7 @@ interface TransmissionDef {
 }
 
 /**
- * # MaterialsTransmission
+ * # KHRMaterialsTransmission
  *
  * [`KHR_materials_transmission`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_transmission/)
  * provides a common type of optical transparency: infinitely-thin materials with no refraction,
@@ -18,7 +18,7 @@ interface TransmissionDef {
  *
  * While default PBR materials using alpha blending become invisible as their opacity approaches
  * zero, a transmissive material continues to reflect light in a glass-like manner, even at low
- * transmission values. When combined with {@link MaterialsVolume}, transmission may be used for
+ * transmission values. When combined with {@link KHRMaterialsVolume}, transmission may be used for
  * thicker materials and refractive effects.
  *
  * Properties:
@@ -26,14 +26,14 @@ interface TransmissionDef {
  *
  * ### Example
  *
- * The `MaterialsTransmission` class provides a single {@link ExtensionProperty} type,
+ * The `KHRMaterialsTransmission` class provides a single {@link ExtensionProperty} type,
  * `Transmission`, which may be attached to any {@link Material} instance. For example:
  *
  * ```typescript
- * import { MaterialsTransmission, Transmission } from '@gltf-transform/extensions';
+ * import { KHRMaterialsTransmission, Transmission } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const transmissionExtension = document.createExtension(MaterialsTransmission);
+ * const transmissionExtension = document.createExtension(KHRMaterialsTransmission);
  *
  * // Create a Transmission property.
  * const transmission = transmissionExtension.createTransmission()
@@ -43,7 +43,7 @@ interface TransmissionDef {
  * material.setExtension('KHR_materials_transmission', transmission);
  * ```
  */
-export class MaterialsTransmission extends Extension {
+export class KHRMaterialsTransmission extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-transmission/transmission.ts
+++ b/packages/extensions/src/khr-materials-transmission/transmission.ts
@@ -20,7 +20,7 @@ const { R } = TextureChannel;
 /**
  * # Transmission
  *
- * Defines optical transmission on a PBR {@link Material}. See {@link MaterialsTransmission}.
+ * Defines optical transmission on a PBR {@link Material}. See {@link KHRMaterialsTransmission}.
  */
 export class Transmission extends ExtensionProperty<ITransmission> {
 	public static EXTENSION_NAME = KHR_MATERIALS_TRANSMISSION;

--- a/packages/extensions/src/khr-materials-unlit/materials-unlit.ts
+++ b/packages/extensions/src/khr-materials-unlit/materials-unlit.ts
@@ -5,7 +5,7 @@ import { Unlit } from './unlit';
 const NAME = KHR_MATERIALS_UNLIT;
 
 /**
- * # MaterialsUnlit
+ * # KHRMaterialsUnlit
  *
  * [`KHR_materials_unlit`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_unlit/)
  * defines an unlit shading model for use in glTF 2.0 materials.
@@ -26,14 +26,14 @@ const NAME = KHR_MATERIALS_UNLIT;
  *
  * ### Example
  *
- * The `MaterialsUnlit` class provides a single {@link ExtensionProperty} type, `Unlit`, which may
+ * The `KHRMaterialsUnlit` class provides a single {@link ExtensionProperty} type, `Unlit`, which may
  * be attached to any {@link Material} instance. For example:
  *
  * ```typescript
- * import { MaterialsUnlit, Unlit } from '@gltf-transform/extensions';
+ * import { KHRMaterialsUnlit, Unlit } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const unlitExtension = document.createExtension(MaterialsUnlit);
+ * const unlitExtension = document.createExtension(KHRMaterialsUnlit);
  *
  * // Create an Unlit property.
  * const unlit = unlitExtension.createUnlit();
@@ -42,7 +42,7 @@ const NAME = KHR_MATERIALS_UNLIT;
  * material.setExtension('KHR_materials_unlit', unlit);
  * ```
  */
-export class MaterialsUnlit extends Extension {
+export class KHRMaterialsUnlit extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-unlit/unlit.ts
+++ b/packages/extensions/src/khr-materials-unlit/unlit.ts
@@ -5,7 +5,7 @@ import { KHR_MATERIALS_UNLIT } from '../constants';
 /**
  * # Unlit
  *
- * Converts a PBR {@link Material} to an unlit shading model. See {@link MaterialsUnlit}.
+ * Converts a PBR {@link Material} to an unlit shading model. See {@link KHRMaterialsUnlit}.
  */
 export class Unlit extends ExtensionProperty {
 	public static EXTENSION_NAME = KHR_MATERIALS_UNLIT;

--- a/packages/extensions/src/khr-materials-variants/mapping-list.ts
+++ b/packages/extensions/src/khr-materials-variants/mapping-list.ts
@@ -9,7 +9,7 @@ interface IMappingList extends IProperty {
 /**
  * # MappingList
  *
- * List of material variant {@link Mapping}s. See {@link MaterialsVariants}.
+ * List of material variant {@link Mapping}s. See {@link KHRMaterialsVariants}.
  */
 export class MappingList extends ExtensionProperty<IMappingList> {
 	public static EXTENSION_NAME = KHR_MATERIALS_VARIANTS;

--- a/packages/extensions/src/khr-materials-variants/mapping.ts
+++ b/packages/extensions/src/khr-materials-variants/mapping.ts
@@ -10,7 +10,7 @@ interface IMapping extends IProperty {
 /**
  * # Mapping
  *
- * Maps {@link Variant}s to {@link Material}s. See {@link MaterialsVariants}.
+ * Maps {@link Variant}s to {@link Material}s. See {@link KHRMaterialsVariants}.
  */
 export class Mapping extends ExtensionProperty<IMapping> {
 	public static EXTENSION_NAME = KHR_MATERIALS_VARIANTS;

--- a/packages/extensions/src/khr-materials-variants/materials-variants.ts
+++ b/packages/extensions/src/khr-materials-variants/materials-variants.ts
@@ -24,7 +24,7 @@ interface VariantMappingDef {
 }
 
 /**
- * # MaterialsVariants
+ * # KHRMaterialsVariants
  *
  * [`KHR_materials_variants`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_variants/)
  * defines alternate {@link Material} states for any {@link Primitive} in the scene.
@@ -34,7 +34,7 @@ interface VariantMappingDef {
  * > _**Figure:** A sneaker, in three material variants. Source: Khronos Group._
  *
  * Uses include product configurators, night/day states, healthy/damaged states, etc. The
- * `MaterialsVariants` class provides three {@link ExtensionProperty} types: `Variant`, `Mapping`,
+ * `KHRMaterialsVariants` class provides three {@link ExtensionProperty} types: `Variant`, `Mapping`,
  * and `MappingList`. When attached to {@link Primitive} properties, these offer flexible ways of
  * defining the variants available to an application. Triggering a variant is out of scope of this
  * extension, but could be handled in the application with a UI dropdown, particular game states,
@@ -51,10 +51,10 @@ interface VariantMappingDef {
  * ### Example
  *
  * ```typescript
- * import { MaterialsVariants } from '@gltf-transform/extensions';
+ * import { KHRMaterialsVariants } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const variantExtension = document.createExtension(MaterialsVariants);
+ * const variantExtension = document.createExtension(KHRMaterialsVariants);
  *
  * // Create some Variant states.
  * const healthyVariant = variantExtension.createVariant('Healthy');
@@ -89,7 +89,7 @@ interface VariantMappingDef {
  * 	 the option of downloading only textures associated with the default state, and lazy-loading
  * 	 any textures for inactive Variants only when they are needed.
  */
-export class MaterialsVariants extends Extension {
+export class KHRMaterialsVariants extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-variants/variant.ts
+++ b/packages/extensions/src/khr-materials-variants/variant.ts
@@ -4,7 +4,7 @@ import { KHR_MATERIALS_VARIANTS } from '../constants';
 /**
  * # Variant
  *
- * Defines a variant of a {@link Material}. See {@link MaterialsVariants}.
+ * Defines a variant of a {@link Material}. See {@link KHRMaterialsVariants}.
  */
 export class Variant extends ExtensionProperty {
 	public static EXTENSION_NAME = KHR_MATERIALS_VARIANTS;

--- a/packages/extensions/src/khr-materials-volume/materials-volume.ts
+++ b/packages/extensions/src/khr-materials-volume/materials-volume.ts
@@ -12,7 +12,7 @@ interface VolumeDef {
 }
 
 /**
- * # MaterialsVolume
+ * # KHRMaterialsVolume
  *
  * [KHR_materials_volume](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_materials_volume/)
  * adds refraction, absorption, or scattering to a glTF PBR material already using transmission or
@@ -34,7 +34,7 @@ interface VolumeDef {
  * be manifold. Volumes provide effects like refraction, absorption and scattering. Scattering
  * effects will require future (TBD) extensions.
  *
- * The volume extension must be combined with {@link MaterialsTransmission} or
+ * The volume extension must be combined with {@link KHRMaterialsTransmission} or
  * `KHR_materials_translucency` in order to define entry of light into the volume.
  *
  * Properties:
@@ -42,14 +42,14 @@ interface VolumeDef {
  *
  * ### Example
  *
- * The `MaterialsVolume` class provides a single {@link ExtensionProperty} type, `Volume`, which
+ * The `KHRMaterialsVolume` class provides a single {@link ExtensionProperty} type, `Volume`, which
  * may be attached to any {@link Material} instance. For example:
  *
  * ```typescript
- * import { MaterialsVolume, Volume } from '@gltf-transform/extensions';
+ * import { KHRMaterialsVolume, Volume } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const volumeExtension = document.createExtension(MaterialsVolume);
+ * const volumeExtension = document.createExtension(KHRMaterialsVolume);
  *
  * // Create a Volume property.
  * const volume = volumeExtension.createVolume()
@@ -65,7 +65,7 @@ interface VolumeDef {
  * A thickness texture is required in most realtime renderers, and can be baked in software such as
  * Blender or Substance Painter. When `thicknessFactor = 0`, all volumetric effects are disabled.
  */
-export class MaterialsVolume extends Extension {
+export class KHRMaterialsVolume extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-materials-volume/volume.ts
+++ b/packages/extensions/src/khr-materials-volume/volume.ts
@@ -24,7 +24,7 @@ const { G } = TextureChannel;
 /**
  * # Volume
  *
- * Defines volume on a PBR {@link Material}. See {@link MaterialsVolume}.
+ * Defines volume on a PBR {@link Material}. See {@link KHRMaterialsVolume}.
  */
 export class Volume extends ExtensionProperty<IVolume> {
 	public static EXTENSION_NAME = KHR_MATERIALS_VOLUME;

--- a/packages/extensions/src/khr-mesh-quantization/mesh-quantization.ts
+++ b/packages/extensions/src/khr-mesh-quantization/mesh-quantization.ts
@@ -4,7 +4,7 @@ import { KHR_MESH_QUANTIZATION } from '../constants';
 const NAME = KHR_MESH_QUANTIZATION;
 
 /**
- * # MeshQuantization
+ * # KHRMeshQuantization
  *
  * [`KHR_mesh_quantization`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_mesh_quantization/)
  * expands allowed component types for vertex attributes to include 16- and 8-bit storage.
@@ -27,11 +27,11 @@ const NAME = KHR_MESH_QUANTIZATION;
  * ### Example
  *
  * ```typescript
- * import { MeshQuantization } from '@gltf-transform/extensions';
+ * import { KHRMeshQuantization } from '@gltf-transform/extensions';
  * import { quantize } from '@gltf-transform/functions';
  *
  * // Create an Extension attached to the Document.
- * const quantizationExtension = document.createExtension(MeshQuantization).setRequired(true);
+ * const quantizationExtension = document.createExtension(KHRMeshQuantization).setRequired(true);
  *
  * // Use Uint16Array, Uint8Array, Int16Array, and Int8Array in vertex accessors manually,
  * // or apply the provided quantize() function to compute quantized accessors automatically:
@@ -44,7 +44,7 @@ const NAME = KHR_MESH_QUANTIZATION;
  *
  * For more documentation about automatic quantization, see the {@link quantize} function.
  */
-export class MeshQuantization extends Extension {
+export class KHRMeshQuantization extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
+++ b/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
@@ -71,7 +71,7 @@ class KTX2ImageUtils implements ImageUtilsFormat {
 }
 
 /**
- * # TextureBasisu
+ * # KHRTextureBasisu
  *
  * [`KHR_texture_basisu`](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_texture_basisu)
  * enables KTX2 GPU textures with Basis Universal supercompression for any material texture.
@@ -95,10 +95,10 @@ class KTX2ImageUtils implements ImageUtilsFormat {
  * ### Example
  *
  * ```typescript
- * import { TextureBasisu } from '@gltf-transform/extensions';
+ * import { KHRTextureBasisu } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const basisuExtension = document.createExtension(TextureBasisu)
+ * const basisuExtension = document.createExtension(KHRTextureBasisu)
  * 	.setRequired(true);
  * document.createTexture('MyCompressedTexture')
  * 	.setMimeType('image/ktx2')
@@ -123,7 +123,7 @@ class KTX2ImageUtils implements ImageUtilsFormat {
  * > [texture dilation](https://docs.substance3d.com/spdoc/padding-134643719.html) and minimize
  * > prominent UV seams._
  */
-export class TextureBasisu extends Extension {
+export class KHRTextureBasisu extends Extension {
 	public readonly extensionName = NAME;
 	/** @hidden */
 	public readonly prereadTypes = [PropertyType.TEXTURE];

--- a/packages/extensions/src/khr-texture-transform/texture-transform.ts
+++ b/packages/extensions/src/khr-texture-transform/texture-transform.ts
@@ -12,7 +12,7 @@ interface TransformDef {
 }
 
 /**
- * # TextureTransform
+ * # KHRTextureTransform
  *
  * [`KHR_texture_transform`](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_texture_transform/)
  * adds offset, rotation, and scale to {@link TextureInfo} properties.
@@ -26,14 +26,14 @@ interface TransformDef {
  *
  * ### Example
  *
- * The `TextureTransform` class provides a single {@link ExtensionProperty} type, `Transform`, which
+ * The `KHRTextureTransform` class provides a single {@link ExtensionProperty} type, `Transform`, which
  * may be attached to any {@link TextureInfo} instance. For example:
  *
  * ```typescript
- * import { TextureTransform } from '@gltf-transform/extensions';
+ * import { KHRTextureTransform } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const transformExtension = document.createExtension(TextureTransform)
+ * const transformExtension = document.createExtension(KHRTextureTransform)
  * 	.setRequired(true);
  *
  * // Create a reusable Transform.
@@ -47,7 +47,7 @@ interface TransformDef {
  * 	.setExtension('KHR_texture_transform', transform);
  * ```
  */
-export class TextureTransform extends Extension {
+export class KHRTextureTransform extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/src/khr-texture-transform/transform.ts
+++ b/packages/extensions/src/khr-texture-transform/transform.ts
@@ -12,7 +12,7 @@ interface ITransform extends IProperty {
 /**
  * # Transform
  *
- * Defines UV transform for a {@link TextureInfo}. See {@link TextureTransform}.
+ * Defines UV transform for a {@link TextureInfo}. See {@link KHRTextureTransform}.
  */
 export class Transform extends ExtensionProperty<ITransform> {
 	public static EXTENSION_NAME = KHR_TEXTURE_TRANSFORM;

--- a/packages/extensions/src/khr-xmp-json-ld/packet.ts
+++ b/packages/extensions/src/khr-xmp-json-ld/packet.ts
@@ -25,7 +25,7 @@ interface IPacket extends IProperty {
 /**
  * # Packet
  *
- * Defines an XMP packet associated with a Document or Property. See {@link XMP}.
+ * Defines an XMP packet associated with a Document or Property. See {@link KHRXMP}.
  */
 export class Packet extends ExtensionProperty<IPacket> {
 	public declare propertyType: 'Packet';

--- a/packages/extensions/src/khr-xmp-json-ld/xmp.ts
+++ b/packages/extensions/src/khr-xmp-json-ld/xmp.ts
@@ -36,7 +36,7 @@ interface XMPRootDef {
 }
 
 /**
- * # XMP
+ * # KHRXMP
  *
  * [KHR_xmp_json_ld](https://github.com/KhronosGroup/gltf/blob/main/extensions/2.0/Khronos/KHR_xmp_json_ld/)
  * defines XMP metadata associated with a glTF asset.
@@ -71,7 +71,7 @@ interface XMPRootDef {
  * | `xmpRights` | http://ns.adobe.com/xap/1.0/rights/         | XMP Rights Management          |
  *
  * Only the XMP contexts required for a packet should be assigned, and different packets
- * in the same asset may use different contexts. For greater detail on available XMP 
+ * in the same asset may use different contexts. For greater detail on available XMP
  * contexts and how to use them in glTF assets, see the
  * [3DC Metadata Recommendations](https://github.com/KhronosGroup/3DC-Metadata-Recommendations/blob/main/model3d.md).
  *
@@ -81,10 +81,10 @@ interface XMPRootDef {
  * ### Example
  *
  * ```typescript
- * import { XMP, Packet } from '@gltf-transform/extensions';
+ * import { KHRXMP, Packet } from '@gltf-transform/extensions';
  *
  * // Create an Extension attached to the Document.
- * const xmpExtension = document.createExtension(XMP);
+ * const xmpExtension = document.createExtension(KHRXMP);
  *
  * // Create Packet property.
  * const packet = xmpExtension.createPacket()
@@ -100,7 +100,7 @@ interface XMPRootDef {
  * texture.setExtension('KHR_xmp_json_ld', packet);
  * ```
  */
-export class XMP extends Extension {
+export class KHRXMP extends Extension {
 	public readonly extensionName = NAME;
 	public static readonly EXTENSION_NAME = NAME;
 

--- a/packages/extensions/test/draco-mesh-compression.test.ts
+++ b/packages/extensions/test/draco-mesh-compression.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { createDecoderModule, createEncoderModule } from 'draco3dgltf';
 import test from 'tape';
 import { Accessor, Buffer, Document, Format, NodeIO, Primitive, getBounds } from '@gltf-transform/core';
-import { DracoMeshCompression } from '../';
+import { KHRDracoMeshCompression } from '../';
 
 const throwsAsync = async (t: test.Test, fn: () => Promise<unknown>, re: RegExp, msg: string): Promise<void> => {
 	try {
@@ -38,7 +38,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding complete', a
 	// (2) All primitive accessors reused (share compressed buffer views).
 
 	const doc = new Document();
-	doc.createExtension(DracoMeshCompression).setRequired(true);
+	doc.createExtension(KHRDracoMeshCompression).setRequired(true);
 
 	const buffer = doc.createBuffer();
 	const prim1 = createMeshPrimitive(doc, buffer);
@@ -142,7 +142,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding skipped', as
 	// (2) Non-TRIANGLES.
 
 	const doc = new Document();
-	doc.createExtension(DracoMeshCompression).setRequired(true);
+	doc.createExtension(KHRDracoMeshCompression).setRequired(true);
 
 	const buffer = doc.createBuffer();
 	const prim1 = createMeshPrimitive(doc, buffer);
@@ -181,7 +181,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | encoding skipped', as
 
 test('@gltf-transform/extensions::draco-mesh-compression | mixed indices', async (t) => {
 	const doc = new Document();
-	doc.createExtension(DracoMeshCompression).setRequired(true);
+	doc.createExtension(KHRDracoMeshCompression).setRequired(true);
 
 	const buffer = doc.createBuffer();
 	const prim1 = createMeshPrimitive(doc, buffer);
@@ -237,7 +237,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | mixed indices', async
 
 test('@gltf-transform/extensions::draco-mesh-compression | mixed attributes', async (t) => {
 	const doc = new Document();
-	doc.createExtension(DracoMeshCompression).setRequired(true);
+	doc.createExtension(KHRDracoMeshCompression).setRequired(true);
 
 	const buffer = doc.createBuffer();
 	const prim1 = createMeshPrimitive(doc, buffer);
@@ -300,7 +300,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | mixed attributes', as
 
 test('@gltf-transform/extensions::draco-mesh-compression | non-primitive parent', async (t) => {
 	const doc = new Document();
-	doc.createExtension(DracoMeshCompression).setRequired(true);
+	doc.createExtension(KHRDracoMeshCompression).setRequired(true);
 
 	const prim = createMeshPrimitive(doc, doc.createBuffer());
 	prim.addTarget(doc.createPrimitiveTarget().setAttribute('POSITION', prim.getAttribute('POSITION')));
@@ -342,7 +342,7 @@ async function createDecoderIO(): Promise<NodeIO> {
 
 	decoderIO = createDecoderModule().then((decoder) => {
 		return new NodeIO()
-			.registerExtensions([DracoMeshCompression])
+			.registerExtensions([KHRDracoMeshCompression])
 			.registerDependencies({ 'draco3d.decoder': decoder });
 	});
 
@@ -354,7 +354,7 @@ async function createEncoderIO(): Promise<NodeIO> {
 
 	encoderIO = createEncoderModule().then((encoder) => {
 		return new NodeIO()
-			.registerExtensions([DracoMeshCompression])
+			.registerExtensions([KHRDracoMeshCompression])
 			.registerDependencies({ 'draco3d.encoder': encoder });
 	});
 

--- a/packages/extensions/test/lights-punctual.test.ts
+++ b/packages/extensions/test/lights-punctual.test.ts
@@ -2,13 +2,13 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { Light, LightsPunctual } from '../';
+import { Light, KHRLightsPunctual } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::lights-punctual', async (t) => {
 	const doc = new Document();
-	const lightsExtension = doc.createExtension(LightsPunctual);
+	const lightsExtension = doc.createExtension(KHRLightsPunctual);
 	const light = lightsExtension
 		.createLight()
 		.setType(Light.Type.SPOT)
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::lights-punctual', async (t) => {
 
 	t.equal(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
@@ -46,7 +46,7 @@ test('@gltf-transform/extensions::lights-punctual', async (t) => {
 	lightsExtension.dispose();
 	t.equal(node.getExtension('KHR_lights_punctual'), null, 'light is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([LightsPunctual]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).readJSON(jsonDoc);
 	const roundtripNode = roundtripDoc.getRoot().listNodes().pop();
 	const light2 = roundtripNode.getExtension<Light>('KHR_lights_punctual');
 
@@ -61,7 +61,7 @@ test('@gltf-transform/extensions::lights-punctual', async (t) => {
 
 test('@gltf-transform/extensions::lights-punctual | copy', (t) => {
 	const doc = new Document();
-	const lightsExtension = doc.createExtension(LightsPunctual);
+	const lightsExtension = doc.createExtension(KHRLightsPunctual);
 	const light = lightsExtension
 		.createLight()
 		.setType(Light.Type.SPOT)
@@ -74,7 +74,7 @@ test('@gltf-transform/extensions::lights-punctual | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const light2 = doc2.getRoot().listNodes()[0].getExtension<Light>('KHR_lights_punctual');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy LightsPunctual');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRLightsPunctual');
 	t.ok(light2, 'copy light');
 	t.equal(light2.getType(), Light.Type.SPOT, 'copy type');
 	t.equal(light2.getIntensity(), 2, 'copy intensity');
@@ -87,7 +87,7 @@ test('@gltf-transform/extensions::lights-punctual | copy', (t) => {
 
 test('@gltf-transform/extensions::lights-punctual | hex', (t) => {
 	const doc = new Document();
-	const lightsExtension = doc.createExtension(LightsPunctual);
+	const lightsExtension = doc.createExtension(KHRLightsPunctual);
 	const light = lightsExtension.createLight().setColorHex(0x111111);
 	t.equals(light.getColorHex(), 0x111111, 'colorHex');
 	t.end();
@@ -95,14 +95,14 @@ test('@gltf-transform/extensions::lights-punctual | hex', (t) => {
 
 test('@gltf-transform/extensions::lights-punctual | i/o', async (t) => {
 	const doc = new Document();
-	const lightsExtension = doc.createExtension(LightsPunctual);
+	const lightsExtension = doc.createExtension(KHRLightsPunctual);
 	const light = lightsExtension.createLight().setType(Light.Type.POINT).setIntensity(2.0);
 
 	const node = doc.createNode().setExtension('KHR_lights_punctual', light);
 
 	t.equal(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([LightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).writeJSON(doc, WRITER_OPTIONS);
 	const nodeDef = jsonDoc.json.nodes[0];
 
 	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -2,20 +2,20 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { Clearcoat, MaterialsClearcoat } from '../';
+import { Clearcoat, KHRMaterialsClearcoat } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-clearcoat | factors', async (t) => {
 	const doc = new Document();
-	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
+	const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
 	const clearcoat = clearcoatExtension.createClearcoat().setClearcoatFactor(0.9).setClearcoatRoughnessFactor(0.1);
 
 	doc.createMaterial('MyClearcoatMaterial')
 		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
 		.setExtension('KHR_materials_clearcoat', clearcoat);
 
-	const io = new NodeIO().registerExtensions([MaterialsClearcoat]);
+	const io = new NodeIO().registerExtensions([KHRMaterialsClearcoat]);
 	const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
@@ -28,7 +28,7 @@ test('@gltf-transform/extensions::materials-clearcoat | factors', async (t) => {
 test('@gltf-transform/extensions::materials-clearcoat | textures', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
+	const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
 	const clearcoat = clearcoatExtension
 		.createClearcoat()
 		.setClearcoatFactor(0.9)
@@ -45,7 +45,7 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', async (t) => 
 
 	t.equal(mat.getExtension('KHR_materials_clearcoat'), clearcoat, 'clearcoat is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -62,12 +62,12 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', async (t) => 
 		},
 		'writes clearcoat extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsClearcoat.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsClearcoat.EXTENSION_NAME], 'writes extensionsUsed');
 
 	clearcoatExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_clearcoat'), null, 'clearcoat is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsClearcoat]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsClearcoat]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
 
@@ -82,10 +82,10 @@ test('@gltf-transform/extensions::materials-clearcoat | textures', async (t) => 
 
 test('@gltf-transform/extensions::materials-clearcoat | disabled', async (t) => {
 	const doc = new Document();
-	doc.createExtension(MaterialsClearcoat);
+	doc.createExtension(KHRMaterialsClearcoat);
 	doc.createMaterial();
 
-	const io = new NodeIO().registerExtensions([MaterialsClearcoat]);
+	const io = new NodeIO().registerExtensions([KHRMaterialsClearcoat]);
 	const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	t.equals(roundtripMat.getExtension('KHR_materials_clearcoat'), null, 'no effect when not attached');
@@ -94,7 +94,7 @@ test('@gltf-transform/extensions::materials-clearcoat | disabled', async (t) => 
 
 test('@gltf-transform/extensions::materials-clearcoat | copy', (t) => {
 	const doc = new Document();
-	const clearcoatExtension = doc.createExtension(MaterialsClearcoat);
+	const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
 	const clearcoat = clearcoatExtension
 		.createClearcoat()
 		.setClearcoatFactor(0.9)
@@ -107,7 +107,7 @@ test('@gltf-transform/extensions::materials-clearcoat | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const clearcoat2 = doc2.getRoot().listMaterials()[0].getExtension<Clearcoat>('KHR_materials_clearcoat');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsClearcoat');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsClearcoat');
 	t.ok(clearcoat2, 'copy Clearcoat');
 	t.equals(clearcoat2.getClearcoatFactor(), 0.9, 'copy clearcoatFactor');
 	t.equals(clearcoat2.getClearcoatRoughnessFactor(), 0.1, 'copy clearcoatFactor');

--- a/packages/extensions/test/materials-emissive-strength.test.ts
+++ b/packages/extensions/test/materials-emissive-strength.test.ts
@@ -2,13 +2,13 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { EmissiveStrength, MaterialsEmissiveStrength } from '../';
+import { EmissiveStrength, KHRMaterialsEmissiveStrength } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-emissive-strength', async (t) => {
 	const doc = new Document();
-	const emissiveStrengthExtension = doc.createExtension(MaterialsEmissiveStrength);
+	const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);
 	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
 
 	const mat = doc
@@ -18,7 +18,9 @@ test('@gltf-transform/extensions::materials-emissive-strength', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_emissive_strength'), emissiveStrength, 'emissive strength is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsEmissiveStrength]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO()
+		.registerExtensions([KHRMaterialsEmissiveStrength])
+		.writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -27,12 +29,12 @@ test('@gltf-transform/extensions::materials-emissive-strength', async (t) => {
 		{ KHR_materials_emissive_strength: { emissiveStrength: 5.0 } },
 		'writes emissive strength extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsEmissiveStrength.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsEmissiveStrength.EXTENSION_NAME], 'writes extensionsUsed');
 
 	emissiveStrengthExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_emissive_strength'), null, 'emissive strength is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsEmissiveStrength]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsEmissiveStrength]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
 	t.equal(
@@ -45,7 +47,7 @@ test('@gltf-transform/extensions::materials-emissive-strength', async (t) => {
 
 test('@gltf-transform/extensions::materials-emissive-strength | copy', (t) => {
 	const doc = new Document();
-	const emissiveStrengthExtension = doc.createExtension(MaterialsEmissiveStrength);
+	const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);
 	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
 	doc.createMaterial().setExtension('KHR_materials_emissive_strength', emissiveStrength);
 
@@ -54,7 +56,7 @@ test('@gltf-transform/extensions::materials-emissive-strength | copy', (t) => {
 		.getRoot()
 		.listMaterials()[0]
 		.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsEmissiveStrength');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsEmissiveStrength');
 	t.ok(emissiveStrength2, 'copy EmissiveStrength');
 	t.equals(emissiveStrength2.getEmissiveStrength(), 5.0, 'copy emissive strength');
 	t.end();

--- a/packages/extensions/test/materials-ior.test.ts
+++ b/packages/extensions/test/materials-ior.test.ts
@@ -2,13 +2,13 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { IOR, MaterialsIOR } from '../';
+import { IOR, KHRMaterialsIOR } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-ior', async (t) => {
 	const doc = new Document();
-	const iorExtension = doc.createExtension(MaterialsIOR);
+	const iorExtension = doc.createExtension(KHRMaterialsIOR);
 	const ior = iorExtension.createIOR().setIOR(1.2);
 
 	const mat = doc
@@ -18,17 +18,17 @@ test('@gltf-transform/extensions::materials-ior', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_ior'), ior, 'ior is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
 	t.deepEqual(materialDef.extensions, { KHR_materials_ior: { ior: 1.2 } }, 'writes ior extension');
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsIOR.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsIOR.EXTENSION_NAME], 'writes extensionsUsed');
 
 	iorExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_ior'), null, 'ior is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsIOR]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsIOR]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
 	t.equal(roundtripMat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1.2, 'reads ior');
@@ -37,13 +37,13 @@ test('@gltf-transform/extensions::materials-ior', async (t) => {
 
 test('@gltf-transform/extensions::materials-ior | copy', (t) => {
 	const doc = new Document();
-	const iorExtension = doc.createExtension(MaterialsIOR);
+	const iorExtension = doc.createExtension(KHRMaterialsIOR);
 	const ior = iorExtension.createIOR().setIOR(1.2);
 	doc.createMaterial().setExtension('KHR_materials_ior', ior);
 
 	const doc2 = doc.clone();
 	const ior2 = doc2.getRoot().listMaterials()[0].getExtension<IOR>('KHR_materials_ior');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsIOR');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIOR');
 	t.ok(ior2, 'copy IOR');
 	t.equals(ior2.getIOR(), 1.2, 'copy ior');
 	t.end();

--- a/packages/extensions/test/materials-iridescence.test.ts
+++ b/packages/extensions/test/materials-iridescence.test.ts
@@ -2,14 +2,14 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsIridescence, Iridescence } from '../';
+import { KHRMaterialsIridescence, Iridescence } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-iridescence', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const iridescenceExtension = doc.createExtension(MaterialsIridescence);
+	const iridescenceExtension = doc.createExtension(KHRMaterialsIridescence);
 	const iridescence = iridescenceExtension
 		.createIridescence()
 		.setIridescenceFactor(0.9)
@@ -26,7 +26,7 @@ test('@gltf-transform/extensions::materials-iridescence', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_iridescence'), iridescence, 'iridescence is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsIridescence]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsIridescence]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -44,12 +44,12 @@ test('@gltf-transform/extensions::materials-iridescence', async (t) => {
 		},
 		'writes iridescence extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsIridescence.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsIridescence.EXTENSION_NAME], 'writes extensionsUsed');
 
 	iridescenceExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_iridescence'), null, 'iridescence is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsIridescence]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsIridescence]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Iridescence>('KHR_materials_iridescence');
 
@@ -64,7 +64,7 @@ test('@gltf-transform/extensions::materials-iridescence', async (t) => {
 
 test('@gltf-transform/extensions::materials-iridescence | copy', (t) => {
 	const doc = new Document();
-	const iridescenceExtension = doc.createExtension(MaterialsIridescence);
+	const iridescenceExtension = doc.createExtension(KHRMaterialsIridescence);
 	const iridescence = iridescenceExtension
 		.createIridescence()
 		.setIridescenceFactor(0.9)
@@ -77,7 +77,7 @@ test('@gltf-transform/extensions::materials-iridescence | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const iridescence2 = doc2.getRoot().listMaterials()[0].getExtension<Iridescence>('KHR_materials_iridescence');
-	t.equal(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsIridescence');
+	t.equal(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIridescence');
 	t.ok(iridescence2, 'copy Iridescence');
 	t.equal(iridescence2.getIridescenceFactor(), 0.9, 'copy iridescenceFactor');
 	t.equal(iridescence2.getIridescenceIOR(), 1.5, 'copy iridescenceIOR');

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -2,14 +2,14 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsPBRSpecularGlossiness, PBRSpecularGlossiness } from '../';
+import { KHRMaterialsPBRSpecularGlossiness, PBRSpecularGlossiness } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-pbr-specular-glossiness', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
 	const specGloss = specGlossExtension
 		.createPBRSpecularGlossiness()
 		.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', async (t) 
 	t.equal(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), specGloss, 'specGloss is attached');
 
 	const jsonDoc = await new NodeIO()
-		.registerExtensions([MaterialsPBRSpecularGlossiness])
+		.registerExtensions([KHRMaterialsPBRSpecularGlossiness])
 		.writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
@@ -38,12 +38,16 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', async (t) 
 		},
 		'writes specGloss extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsPBRSpecularGlossiness.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(
+		jsonDoc.json.extensionsUsed,
+		[KHRMaterialsPBRSpecularGlossiness.EXTENSION_NAME],
+		'writes extensionsUsed'
+	);
 
 	specGlossExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), null, 'specGloss is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsPBRSpecularGlossiness]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsPBRSpecularGlossiness]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
 
@@ -56,7 +60,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness', async (t) 
 
 test('@gltf-transform/extensions::materials-pbr-specular-glossiness | copy', (t) => {
 	const doc = new Document();
-	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
 	const specGloss = specGlossExtension
 		.createPBRSpecularGlossiness()
 		.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
@@ -70,7 +74,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness | copy', (t)
 		.getRoot()
 		.listMaterials()[0]
 		.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsPBRSpecularGlossiness');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsPBRSpecularGlossiness');
 	t.ok(specGloss2, 'copy PBRSpecularGlossiness');
 	t.deepEqual(specGloss2.getDiffuseFactor(), [0.5, 0.5, 0.5, 0.9], 'copy diffuseFactor');
 	t.deepEqual(specGloss2.getSpecularFactor(), [0.9, 0.5, 0.8], 'copy specularFactor');
@@ -81,7 +85,7 @@ test('@gltf-transform/extensions::materials-pbr-specular-glossiness | copy', (t)
 
 test('@gltf-transform/extensions::materials-pbr-specular-glossiness | hex', (t) => {
 	const doc = new Document();
-	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
 	const specGloss = specGlossExtension.createPBRSpecularGlossiness().setDiffuseHex(0x0000ff);
 	t.equals(specGloss.getDiffuseHex(), 254, 'diffuseHex');
 	t.end();

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -2,14 +2,14 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsSheen, Sheen } from '../';
+import { KHRMaterialsSheen, Sheen } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-sheen', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const sheenExtension = doc.createExtension(MaterialsSheen);
+	const sheenExtension = doc.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension
 		.createSheen()
 		.setSheenColorFactor([0.9, 0.5, 0.8])
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-sheen', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_sheen'), sheen, 'sheen is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -37,12 +37,12 @@ test('@gltf-transform/extensions::materials-sheen', async (t) => {
 		},
 		'writes sheen extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsSheen.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsSheen.EXTENSION_NAME], 'writes extensionsUsed');
 
 	sheenExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_sheen'), null, 'sheen is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsSheen]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsSheen]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Sheen>('KHR_materials_sheen');
 
@@ -53,7 +53,7 @@ test('@gltf-transform/extensions::materials-sheen', async (t) => {
 
 test('@gltf-transform/extensions::materials-sheen | copy', (t) => {
 	const doc = new Document();
-	const sheenExtension = doc.createExtension(MaterialsSheen);
+	const sheenExtension = doc.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension
 		.createSheen()
 		.setSheenColorFactor([0.9, 0.5, 0.8])
@@ -62,7 +62,7 @@ test('@gltf-transform/extensions::materials-sheen | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const sheen2 = doc2.getRoot().listMaterials()[0].getExtension<Sheen>('KHR_materials_sheen');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsSheen');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSheen');
 	t.ok(sheen2, 'copy Sheen');
 	t.deepEquals(sheen2.getSheenColorFactor(), [0.9, 0.5, 0.8], 'copy sheenColorFactor');
 	t.equals(sheen2.getSheenColorTexture().getName(), 'sheen', 'copy sheenColorTexture');
@@ -71,7 +71,7 @@ test('@gltf-transform/extensions::materials-sheen | copy', (t) => {
 
 test('@gltf-transform/extensions::materials-sheen | hex', (t) => {
 	const doc = new Document();
-	const sheenExtension = doc.createExtension(MaterialsSheen);
+	const sheenExtension = doc.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension.createSheen().setSheenColorHex(0x252525);
 	t.equals(sheen.getSheenColorHex(), 0x252525, 'sheenColorHex');
 	t.end();

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -2,14 +2,14 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsSpecular, Specular } from '../';
+import { KHRMaterialsSpecular, Specular } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-specular', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const specularExtension = doc.createExtension(MaterialsSpecular);
+	const specularExtension = doc.createExtension(KHRMaterialsSpecular);
 	const specular = specularExtension
 		.createSpecular()
 		.setSpecularFactor(0.9)
@@ -24,7 +24,7 @@ test('@gltf-transform/extensions::materials-specular', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_specular'), specular, 'specular is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -40,12 +40,12 @@ test('@gltf-transform/extensions::materials-specular', async (t) => {
 		},
 		'writes specular extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsSpecular.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsSpecular.EXTENSION_NAME], 'writes extensionsUsed');
 
 	specularExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_specular'), null, 'specular is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsSpecular]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsSpecular]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Specular>('KHR_materials_specular');
 
@@ -57,7 +57,7 @@ test('@gltf-transform/extensions::materials-specular', async (t) => {
 
 test('@gltf-transform/extensions::materials-specular | copy', (t) => {
 	const doc = new Document();
-	const specularExtension = doc.createExtension(MaterialsSpecular);
+	const specularExtension = doc.createExtension(KHRMaterialsSpecular);
 	const specular = specularExtension
 		.createSpecular()
 		.setSpecularFactor(0.9)
@@ -68,7 +68,7 @@ test('@gltf-transform/extensions::materials-specular | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const specular2 = doc2.getRoot().listMaterials()[0].getExtension<Specular>('KHR_materials_specular');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsSpecular');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSpecular');
 	t.ok(specular2, 'copy Specular');
 	t.equals(specular2.getSpecularFactor(), 0.9, 'copy specularFactor');
 	t.deepEquals(specular2.getSpecularColorFactor(), [0.9, 0.5, 0.8], 'copy specularColorFactor');
@@ -79,7 +79,7 @@ test('@gltf-transform/extensions::materials-specular | copy', (t) => {
 
 test('@gltf-transform/extensions::materials-specular | hex', (t) => {
 	const doc = new Document();
-	const specularExtension = doc.createExtension(MaterialsSpecular);
+	const specularExtension = doc.createExtension(KHRMaterialsSpecular);
 	const specular = specularExtension.createSpecular().setSpecularColorHex(0x252525);
 	t.equals(specular.getSpecularColorHex(), 0x252525, 'specularColorHex');
 	t.end();

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -2,14 +2,14 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsTransmission, Transmission } from '../';
+import { KHRMaterialsTransmission, Transmission } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-transmission', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const transmissionExtension = doc.createExtension(MaterialsTransmission);
+	const transmissionExtension = doc.createExtension(KHRMaterialsTransmission);
 	const transmission = transmissionExtension
 		.createTransmission()
 		.setTransmissionFactor(0.9)
@@ -22,7 +22,7 @@ test('@gltf-transform/extensions::materials-transmission', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_transmission'), transmission, 'transmission is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsTransmission]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsTransmission]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -36,12 +36,12 @@ test('@gltf-transform/extensions::materials-transmission', async (t) => {
 		},
 		'writes transmission extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsTransmission.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsTransmission.EXTENSION_NAME], 'writes extensionsUsed');
 
 	transmissionExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_transmission'), null, 'transmission is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsTransmission]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsTransmission]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Transmission>('KHR_materials_transmission');
 
@@ -52,7 +52,7 @@ test('@gltf-transform/extensions::materials-transmission', async (t) => {
 
 test('@gltf-transform/extensions::materials-transmission | copy', (t) => {
 	const doc = new Document();
-	const transmissionExtension = doc.createExtension(MaterialsTransmission);
+	const transmissionExtension = doc.createExtension(KHRMaterialsTransmission);
 	const transmission = transmissionExtension
 		.createTransmission()
 		.setTransmissionFactor(0.9)
@@ -61,7 +61,7 @@ test('@gltf-transform/extensions::materials-transmission | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const transmission2 = doc2.getRoot().listMaterials()[0].getExtension<Transmission>('KHR_materials_transmission');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsTransmission');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsTransmission');
 	t.ok(transmission2, 'copy Transmission');
 	t.equals(transmission2.getTransmissionFactor(), 0.9, 'copy transmissionFactor');
 	t.equals(transmission2.getTransmissionTexture().getName(), 'trns', 'copy transmissionTexture');

--- a/packages/extensions/test/materials-unlit.test.ts
+++ b/packages/extensions/test/materials-unlit.test.ts
@@ -2,13 +2,13 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsUnlit } from '../';
+import { KHRMaterialsUnlit } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-unlit', async (t) => {
 	const doc = new Document();
-	const unlitExtension = doc.createExtension(MaterialsUnlit);
+	const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
 	const unlit = unlitExtension.createUnlit();
 
 	const mat = doc
@@ -20,14 +20,14 @@ test('@gltf-transform/extensions::materials-unlit', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_unlit'), unlit, 'unlit is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
 	t.deepEqual(materialDef.extensions, { KHR_materials_unlit: {} }, 'writes unlit extension');
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsUnlit.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsUnlit.EXTENSION_NAME], 'writes extensionsUsed');
 
-	const rtDoc = await new NodeIO().registerExtensions([MaterialsUnlit]).readJSON(jsonDoc);
+	const rtDoc = await new NodeIO().registerExtensions([KHRMaterialsUnlit]).readJSON(jsonDoc);
 	const rtMat = rtDoc.getRoot().listMaterials()[0];
 	t.ok(rtMat.getExtension('KHR_materials_unlit'), 'unlit is round tripped');
 
@@ -39,11 +39,11 @@ test('@gltf-transform/extensions::materials-unlit', async (t) => {
 
 test('@gltf-transform/extensions::materials-unlit | copy', (t) => {
 	const doc = new Document();
-	const unlitExtension = doc.createExtension(MaterialsUnlit);
+	const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
 	doc.createMaterial().setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
 
 	const doc2 = doc.clone();
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsUnlit');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsUnlit');
 	t.ok(doc2.getRoot().listMaterials()[0].getExtension('KHR_materials_unlit'), 'copy Unlit');
 	t.end();
 });

--- a/packages/extensions/test/materials-variants.test.ts
+++ b/packages/extensions/test/materials-variants.test.ts
@@ -2,11 +2,11 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MappingList, MaterialsVariants } from '../';
+import { MappingList, KHRMaterialsVariants } from '../';
 
 test('@gltf-transform/extensions::materials-variants', async (t) => {
 	const doc = new Document();
-	const variantsExtension = doc.createExtension(MaterialsVariants);
+	const variantsExtension = doc.createExtension(KHRMaterialsVariants);
 	const var2 = variantsExtension.createVariant('Damaged1');
 	const var3 = variantsExtension.createVariant('Damaged2');
 
@@ -26,7 +26,7 @@ test('@gltf-transform/extensions::materials-variants', async (t) => {
 
 	//
 
-	const io = new NodeIO().registerExtensions([MaterialsVariants]);
+	const io = new NodeIO().registerExtensions([KHRMaterialsVariants]);
 	const rtDoc = await io.readJSON(await io.writeJSON(doc, {}));
 	const rtPrim1 = rtDoc.getRoot().listMeshes()[0].listPrimitives()[0];
 	const rtPrim2 = rtDoc.getRoot().listMeshes()[1].listPrimitives()[0];
@@ -68,7 +68,7 @@ test('@gltf-transform/extensions::materials-variants', async (t) => {
 
 test('@gltf-transform/extensions::materials-variants | copy', (t) => {
 	const doc = new Document();
-	const variantsExtension = doc.createExtension(MaterialsVariants);
+	const variantsExtension = doc.createExtension(KHRMaterialsVariants);
 	const var1 = variantsExtension.createVariant('Dry');
 	const var2 = variantsExtension.createVariant('Wet');
 

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -2,14 +2,14 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { MaterialsVolume, Volume } from '../';
+import { KHRMaterialsVolume, Volume } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::materials-volume', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const volumeExtension = doc.createExtension(MaterialsVolume);
+	const volumeExtension = doc.createExtension(KHRMaterialsVolume);
 	const volume = volumeExtension
 		.createVolume()
 		.setThicknessFactor(0.9)
@@ -24,7 +24,7 @@ test('@gltf-transform/extensions::materials-volume', async (t) => {
 
 	t.equal(mat.getExtension('KHR_materials_volume'), volume, 'volume is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([MaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
+	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
 	const materialDef = jsonDoc.json.materials[0];
 
 	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
@@ -40,12 +40,12 @@ test('@gltf-transform/extensions::materials-volume', async (t) => {
 		},
 		'writes volume extension'
 	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MaterialsVolume.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsVolume.EXTENSION_NAME], 'writes extensionsUsed');
 
 	volumeExtension.dispose();
 	t.equal(mat.getExtension('KHR_materials_volume'), null, 'volume is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([MaterialsVolume]).readJSON(jsonDoc);
+	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsVolume]).readJSON(jsonDoc);
 	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 	const roundtripExt = roundtripMat.getExtension<Volume>('KHR_materials_volume');
 
@@ -61,7 +61,7 @@ test('@gltf-transform/extensions::materials-volume', async (t) => {
 
 test('@gltf-transform/extensions::materials-transmission | copy', (t) => {
 	const doc = new Document();
-	const volumeExtension = doc.createExtension(MaterialsVolume);
+	const volumeExtension = doc.createExtension(KHRMaterialsVolume);
 	const volume = volumeExtension
 		.createVolume()
 		.setThicknessFactor(0.9)
@@ -72,7 +72,7 @@ test('@gltf-transform/extensions::materials-transmission | copy', (t) => {
 
 	const doc2 = doc.clone();
 	const volume2 = doc2.getRoot().listMaterials()[0].getExtension<Volume>('KHR_materials_volume');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MaterialsVolume');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsVolume');
 	t.ok(volume2, 'copy Volume');
 	t.equals(volume2.getThicknessFactor(), 0.9, 'copy thicknessFactor');
 	t.equals(volume2.getThicknessTexture().getName(), 'trns', 'copy thicknessTexture');

--- a/packages/extensions/test/mesh-gpu-instancing.test.ts
+++ b/packages/extensions/test/mesh-gpu-instancing.test.ts
@@ -2,11 +2,11 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Accessor, Document, NodeIO } from '@gltf-transform/core';
-import { InstancedMesh, MeshGPUInstancing } from '../';
+import { InstancedMesh, EXTMeshGPUInstancing } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-const io = new NodeIO().registerExtensions([MeshGPUInstancing]);
+const io = new NodeIO().registerExtensions([EXTMeshGPUInstancing]);
 
 test('@gltf-transform/extensions::mesh-gpu-instancing', async (t) => {
 	const doc = new Document();
@@ -21,7 +21,7 @@ test('@gltf-transform/extensions::mesh-gpu-instancing', async (t) => {
 	const prim = doc.createPrimitive().setAttribute('POSITION', data.clone().setName('prim_pos'));
 	const mesh = doc.createMesh().addPrimitive(prim);
 
-	const batchExtension = doc.createExtension(MeshGPUInstancing);
+	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
 	const batch = batchExtension
 		.createInstancedMesh()
 		.setAttribute('TRANSLATION', data.clone().setName('inst_pos'))
@@ -67,14 +67,14 @@ test('@gltf-transform/extensions::mesh-gpu-instancing | copy', (t) => {
 		.setArray(new Float32Array(12))
 		.setType(Accessor.Type.VEC3)
 		.setBuffer(doc.createBuffer());
-	const batchExtension = doc.createExtension(MeshGPUInstancing);
+	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
 	const batch = batchExtension.createInstancedMesh().setAttribute('TRANSLATION', data).setAttribute('_ID', data);
 
 	doc.createNode().setExtension('EXT_mesh_gpu_instancing', batch);
 
 	const doc2 = doc.clone();
 	const batch2 = doc2.getRoot().listNodes()[0].getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
-	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy MeshGPUInstancing');
+	t.equals(doc2.getRoot().listExtensionsUsed().length, 1, 'copy EXTMeshGPUInstancing');
 	t.ok(batch2, 'copy batch');
 	t.deepEqual(batch.listSemantics(), batch2.listSemantics(), 'matching semantics');
 	t.deepEqual(batch.getAttribute('_ID').getArray(), new Float32Array(12), 'matching data');

--- a/packages/extensions/test/mesh-quantization.test.ts
+++ b/packages/extensions/test/mesh-quantization.test.ts
@@ -2,17 +2,17 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, JSONDocument, NodeIO } from '@gltf-transform/core';
-import { MeshQuantization } from '../';
+import { KHRMeshQuantization } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 test('@gltf-transform/extensions::mesh-quantization', async (t) => {
 	const doc = new Document();
-	const quantizationExtension = doc.createExtension(MeshQuantization);
+	const quantizationExtension = doc.createExtension(KHRMeshQuantization);
 	let jsonDoc: JSONDocument;
 
-	jsonDoc = await new NodeIO().registerExtensions([MeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [MeshQuantization.EXTENSION_NAME], 'writes extensionsUsed');
+	jsonDoc = await new NodeIO().registerExtensions([KHRMeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMeshQuantization.EXTENSION_NAME], 'writes extensionsUsed');
 
 	quantizationExtension.dispose();
 
@@ -23,8 +23,8 @@ test('@gltf-transform/extensions::mesh-quantization', async (t) => {
 
 test('@gltf-transform/extensions::mesh-quantization | copy', (t) => {
 	const doc = new Document();
-	doc.createExtension(MeshQuantization);
+	doc.createExtension(KHRMeshQuantization);
 
-	t.equals(doc.clone().getRoot().listExtensionsUsed().length, 1, 'copy MeshQuantization');
+	t.equals(doc.clone().getRoot().listExtensionsUsed().length, 1, 'copy KHRMeshQuantization');
 	t.end();
 });

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import path from 'path';
 import test from 'tape';
 import { NodeIO, getBounds } from '@gltf-transform/core';
-import { MeshoptCompression, MeshQuantization } from '../';
+import { EXTMeshoptCompression, KHRMeshQuantization } from '../';
 import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
 
 const INPUTS = ['BoxMeshopt.glb', 'BoxMeshopt.gltf'];
@@ -12,7 +12,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | decoding', async (t) 
 	await MeshoptDecoder.ready;
 
 	const io = new NodeIO()
-		.registerExtensions([MeshoptCompression, MeshQuantization])
+		.registerExtensions([EXTMeshoptCompression, KHRMeshQuantization])
 		.registerDependencies({ 'meshopt.decoder': MeshoptDecoder });
 
 	for (const input of INPUTS) {
@@ -36,7 +36,7 @@ test('@gltf-transform/extensions::draco-mesh-compression | decoding', async (t) 
 test('@gltf-transform/extensions::draco-mesh-compression | encoding', async (t) => {
 	await Promise.all([MeshoptDecoder.ready, MeshoptEncoder.ready]);
 
-	const io = new NodeIO().registerExtensions([MeshoptCompression, MeshQuantization]).registerDependencies({
+	const io = new NodeIO().registerExtensions([EXTMeshoptCompression, KHRMeshQuantization]).registerDependencies({
 		'meshopt.decoder': MeshoptDecoder,
 		'meshopt.encoder': MeshoptEncoder,
 	});

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -2,7 +2,7 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, GLTF, ImageUtils, JSONDocument, NodeIO } from '@gltf-transform/core';
-import { TextureBasisu } from '../';
+import { KHRTextureBasisu } from '../';
 
 const IS_NODEJS = typeof window === 'undefined';
 
@@ -14,12 +14,12 @@ if (IS_NODEJS) {
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-const io = new NodeIO().registerExtensions([TextureBasisu]);
+const io = new NodeIO().registerExtensions([KHRTextureBasisu]);
 
 test('@gltf-transform/extensions::texture-basisu', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const basisuExtension = doc.createExtension(TextureBasisu);
+	const basisuExtension = doc.createExtension(KHRTextureBasisu);
 	const tex1 = doc.createTexture('BasisTexture').setMimeType('image/ktx2').setImage(new Uint8Array(10));
 	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
 	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
@@ -29,7 +29,7 @@ test('@gltf-transform/extensions::texture-basisu', async (t) => {
 	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 
 	// Writing to file.
-	t.deepEqual(jsonDoc.json.extensionsUsed, [TextureBasisu.EXTENSION_NAME], 'writes extensionsUsed');
+	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRTextureBasisu.EXTENSION_NAME], 'writes extensionsUsed');
 	t.equal(jsonDoc.json.textures[0].source, undefined, 'omits .source on KTX2 texture');
 	t.equal(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
 	t.equal(

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -2,16 +2,16 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { TextureTransform, Transform } from '../';
+import { KHRTextureTransform, Transform } from '../';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-const io = new NodeIO().registerExtensions([TextureTransform]);
+const io = new NodeIO().registerExtensions([KHRTextureTransform]);
 
 test('@gltf-transform/extensions::texture-transform', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const transformExtension = doc.createExtension(TextureTransform);
+	const transformExtension = doc.createExtension(KHRTextureTransform);
 	const tex1 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(10));
 	const tex2 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(15));
 	const tex3 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(20));
@@ -64,7 +64,7 @@ test('@gltf-transform/extensions::texture-transform', async (t) => {
 
 test('@gltf-transform/extensions::texture-transform | clone', (t) => {
 	const srcDoc = new Document();
-	const transformExtension = srcDoc.createExtension(TextureTransform);
+	const transformExtension = srcDoc.createExtension(KHRTextureTransform);
 	const tex1 = srcDoc.createTexture();
 	const tex2 = srcDoc.createTexture();
 	const tex3 = srcDoc.createTexture();
@@ -125,7 +125,7 @@ test('@gltf-transform/extensions::texture-transform | clone', (t) => {
 test('@gltf-transform/extensions::texture-transform | i/o', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const transformExtension = doc.createExtension(TextureTransform);
+	const transformExtension = doc.createExtension(KHRTextureTransform);
 	const tex1 = doc.createTexture();
 
 	const mat = doc.createMaterial();

--- a/packages/extensions/test/texture-webp.test.ts
+++ b/packages/extensions/test/texture-webp.test.ts
@@ -2,7 +2,7 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { BufferUtils, Document, GLTF, ImageUtils, JSONDocument, NodeIO } from '@gltf-transform/core';
-import { TextureWebP } from '../';
+import { EXTTextureWebP } from '../';
 
 const IS_NODEJS = typeof window === 'undefined';
 
@@ -14,12 +14,12 @@ if (IS_NODEJS) {
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-const io = new NodeIO().registerExtensions([TextureWebP]);
+const io = new NodeIO().registerExtensions([EXTTextureWebP]);
 
 test('@gltf-transform/extensions::texture-webp', async (t) => {
 	const doc = new Document();
 	doc.createBuffer();
-	const webpExtension = doc.createExtension(TextureWebP);
+	const webpExtension = doc.createExtension(EXTTextureWebP);
 	const tex1 = doc.createTexture('WebPTexture').setMimeType('image/webp').setImage(new Uint8Array(10));
 	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
 	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);

--- a/packages/extensions/test/xmp.test.ts
+++ b/packages/extensions/test/xmp.test.ts
@@ -2,7 +2,7 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, NodeIO } from '@gltf-transform/core';
-import { Packet, XMP } from '../';
+import { Packet, KHRXMP } from '../';
 
 const MOCK_CONTEXT_URL = 'https://test.example/1.0/';
 
@@ -24,7 +24,7 @@ const MOCK_JSONLD_PACKET = {
 
 test('@gltf-transform/extensions::xmp', async (t) => {
 	const document = new Document();
-	const xmpExtension = document.createExtension(XMP);
+	const xmpExtension = document.createExtension(KHRXMP);
 	const packet = xmpExtension.createPacket();
 
 	// Context.
@@ -115,7 +115,7 @@ test('@gltf-transform/extensions::xmp', async (t) => {
 
 test('@gltf-transform/extensions::xmp | i/o', async (t) => {
 	const document = new Document();
-	const xmpExtension = document.createExtension(XMP);
+	const xmpExtension = document.createExtension(KHRXMP);
 	const packet = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
 	const packet2 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
 
@@ -134,7 +134,7 @@ test('@gltf-transform/extensions::xmp | i/o', async (t) => {
 
 	document.createBuffer();
 
-	const io = new NodeIO().registerExtensions([XMP]);
+	const io = new NodeIO().registerExtensions([KHRXMP]);
 	const jsonDocument = await io.writeJSON(document);
 
 	// Serialize.
@@ -215,7 +215,7 @@ test('@gltf-transform/extensions::xmp | i/o', async (t) => {
 
 test('@gltf-transform/extensions::xmp | clone', async (t) => {
 	const document1 = new Document();
-	const xmpExtension = document1.createExtension(XMP);
+	const xmpExtension = document1.createExtension(KHRXMP);
 	const packet1 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
 	document1.getRoot().setExtension('KHR_xmp_json_ld', packet1);
 	t.equals(document1.getRoot().getExtension('KHR_xmp_json_ld'), packet1, 'sets packet');

--- a/packages/functions/src/dequantize.ts
+++ b/packages/functions/src/dequantize.ts
@@ -1,5 +1,5 @@
 import type { Accessor, Document, Primitive, Transform } from '@gltf-transform/core';
-import { MeshQuantization } from '@gltf-transform/extensions';
+import { KHRMeshQuantization } from '@gltf-transform/extensions';
 import { createTransform } from './utils';
 
 const NAME = 'dequantize';
@@ -18,7 +18,7 @@ const DEQUANTIZE_DEFAULTS: DequantizeOptions = {
 };
 
 /**
- * Dequantize {@link Primitive Primitives}, removing {@link MeshQuantization `KHR_mesh_quantization`}
+ * Dequantize {@link Primitive Primitives}, removing {@link KHRMeshQuantization `KHR_mesh_quantization`}
  * if present. Dequantization will increase the size of the mesh on disk and in memory, but may be
  * necessary for compatibility with applications that don't support quantization.
  */
@@ -32,7 +32,7 @@ export function dequantize(_options: DequantizeOptions = DEQUANTIZE_DEFAULTS): T
 				dequantizePrimitive(prim, options);
 			}
 		}
-		doc.createExtension(MeshQuantization).dispose();
+		doc.createExtension(KHRMeshQuantization).dispose();
 		logger.debug(`${NAME}: Complete.`);
 	});
 }

--- a/packages/functions/src/draco.ts
+++ b/packages/functions/src/draco.ts
@@ -1,5 +1,5 @@
 import type { Document, Transform } from '@gltf-transform/core';
-import { DracoMeshCompression } from '@gltf-transform/extensions';
+import { KHRDracoMeshCompression } from '@gltf-transform/extensions';
 
 export interface DracoOptions {
 	method?: 'edgebreaker' | 'sequential';
@@ -26,21 +26,21 @@ export const DRACO_DEFAULTS: DracoOptions = {
 };
 
 /**
- * Applies Draco compression using {@link DracoMeshCompression KHR_draco_mesh_compression}.
+ * Applies Draco compression using {@link KHRDracoMeshCompression KHR_draco_mesh_compression}.
  * This type of compression can reduce the size of triangle geometry.
  *
- * This function is a thin wrapper around the {@link DracoMeshCompression} extension itself.
+ * This function is a thin wrapper around the {@link KHRDracoMeshCompression} extension itself.
  */
 export const draco = (_options: DracoOptions): Transform => {
 	const options = { ...DRACO_DEFAULTS, ..._options } as Required<DracoOptions>;
 	return (doc: Document): void => {
-		doc.createExtension(DracoMeshCompression)
+		doc.createExtension(KHRDracoMeshCompression)
 			.setRequired(true)
 			.setEncoderOptions({
 				method:
 					options.method === 'edgebreaker'
-						? DracoMeshCompression.EncoderMethod.EDGEBREAKER
-						: DracoMeshCompression.EncoderMethod.SEQUENTIAL,
+						? KHRDracoMeshCompression.EncoderMethod.EDGEBREAKER
+						: KHRDracoMeshCompression.EncoderMethod.SEQUENTIAL,
 				encodeSpeed: options.encodeSpeed,
 				decodeSpeed: options.decodeSpeed,
 				quantizationBits: {

--- a/packages/functions/src/instance.ts
+++ b/packages/functions/src/instance.ts
@@ -1,5 +1,5 @@
 import { Document, ILogger, MathUtils, Mesh, Node, Transform, vec3, vec4 } from '@gltf-transform/core';
-import { InstancedMesh, MeshGPUInstancing } from '@gltf-transform/extensions';
+import { InstancedMesh, EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import { createTransform } from './utils';
 
 const NAME = 'instance';
@@ -20,7 +20,7 @@ export function instance(_options: InstanceOptions = INSTANCE_DEFAULTS): Transfo
 	return createTransform(NAME, (doc: Document): void => {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
-		const batchExtension = doc.createExtension(MeshGPUInstancing);
+		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
 
 		if (root.listAnimations().length) {
 			logger.warn(`${NAME}: Instancing is not currently supported for animated models.`);
@@ -126,7 +126,7 @@ function pruneUnusedNodes(nodes: Node[], logger: ILogger): void {
 	logger.debug(`${NAME}: Removed ${unusedNodes} unused nodes.`);
 }
 
-function createBatch(doc: Document, batchExtension: MeshGPUInstancing, mesh: Mesh, count: number): InstancedMesh {
+function createBatch(doc: Document, batchExtension: EXTMeshGPUInstancing, mesh: Mesh, count: number): InstancedMesh {
 	const buffer = mesh.listPrimitives()[0].getAttribute('POSITION')!.getBuffer();
 
 	const batchTranslation = doc

--- a/packages/functions/src/meshopt.ts
+++ b/packages/functions/src/meshopt.ts
@@ -1,5 +1,5 @@
 import type { Document, Transform } from '@gltf-transform/core';
-import { MeshoptCompression } from '@gltf-transform/extensions';
+import { EXTMeshoptCompression } from '@gltf-transform/extensions';
 import type { MeshoptEncoder } from 'meshoptimizer';
 import { reorder } from './reorder';
 import { quantize } from './quantize';
@@ -14,12 +14,12 @@ export const MESHOPT_DEFAULTS: Required<Omit<MeshoptOptions, 'encoder'>> = { lev
 const NAME = 'meshopt';
 
 /**
- * Applies Meshopt compression using {@link MeshoptCompression EXT_meshopt_compression}.
+ * Applies Meshopt compression using {@link EXTMeshoptCompression EXT_meshopt_compression}.
  * This type of compression can reduce the size of point, line, and triangle geometry,
  * morph targets, and animation data.
  *
  * This function is a thin wrapper around {@link reorder}, {@link quantize}, and
- * {@link MeshoptCompression}, and exposes relatively few configuration options.
+ * {@link EXTMeshoptCompression}, and exposes relatively few configuration options.
  * To access more options (like quantization bits) direct use of the underlying
  * functions is recommended.
  *
@@ -62,13 +62,13 @@ export const meshopt = (_options: MeshoptOptions): Transform => {
 		);
 
 		document
-			.createExtension(MeshoptCompression)
+			.createExtension(EXTMeshoptCompression)
 			.setRequired(true)
 			.setEncoderOptions({
 				method:
 					options.level === 'medium'
-						? MeshoptCompression.EncoderMethod.QUANTIZE
-						: MeshoptCompression.EncoderMethod.FILTER,
+						? EXTMeshoptCompression.EncoderMethod.QUANTIZE
+						: EXTMeshoptCompression.EncoderMethod.FILTER,
 			});
 	};
 };

--- a/packages/functions/src/metal-rough.ts
+++ b/packages/functions/src/metal-rough.ts
@@ -1,8 +1,8 @@
 import type { Document, Texture, Transform } from '@gltf-transform/core';
 import {
-	MaterialsIOR,
-	MaterialsPBRSpecularGlossiness,
-	MaterialsSpecular,
+	KHRMaterialsIOR,
+	KHRMaterialsPBRSpecularGlossiness,
+	KHRMaterialsSpecular,
 	PBRSpecularGlossiness,
 } from '@gltf-transform/extensions';
 import { createTransform, rewriteTexture } from './utils';
@@ -38,9 +38,9 @@ export function metalRough(_options: MetalRoughOptions = METALROUGH_DEFAULTS): T
 			return;
 		}
 
-		const iorExtension = doc.createExtension(MaterialsIOR);
-		const specExtension = doc.createExtension(MaterialsSpecular);
-		const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+		const iorExtension = doc.createExtension(KHRMaterialsIOR);
+		const specExtension = doc.createExtension(KHRMaterialsSpecular);
+		const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
 
 		const inputTextures = new Set<Texture | null>();
 

--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -19,7 +19,7 @@ import {
 import { dedup } from './dedup';
 import { fromRotationTranslationScale, fromScaling, invert, multiply as multiplyMat4 } from 'gl-matrix/mat4';
 import { max, min, scale, transformMat4 } from 'gl-matrix/vec3';
-import { MeshQuantization } from '@gltf-transform/extensions';
+import { KHRMeshQuantization } from '@gltf-transform/extensions';
 import type { Volume } from '@gltf-transform/extensions';
 import { prune } from './prune';
 import { createTransform } from './utils';
@@ -90,7 +90,7 @@ const quantize = (_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transform => {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
 
-		doc.createExtension(MeshQuantization).setRequired(true);
+		doc.createExtension(KHRMeshQuantization).setRequired(true);
 
 		// Compute vertex position quantization volume.
 		let nodeTransform: VectorTransform<vec3> | undefined = undefined;

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -1,5 +1,5 @@
 import { BufferUtils, Document, ImageUtils, Texture, TextureChannel, Transform, vec2 } from '@gltf-transform/core';
-import { TextureWebP } from '@gltf-transform/extensions';
+import { EXTTextureWebP } from '@gltf-transform/extensions';
 import { getTextureChannelMask } from './list-texture-channels';
 import { listTextureSlots } from './list-texture-slots';
 import type sharp from 'sharp';
@@ -165,7 +165,7 @@ export const textureCompress = function (_options: TextureCompressOptions): Tran
 
 		// Attach EXT_texture_web if needed.
 		if (textures.some((texture) => texture.getMimeType() === 'image/webp')) {
-			document.createExtension(TextureWebP).setRequired(true);
+			document.createExtension(EXTTextureWebP).setRequired(true);
 		}
 
 		logger.debug(`${NAME}: Complete.`);

--- a/packages/functions/src/unlit.ts
+++ b/packages/functions/src/unlit.ts
@@ -1,9 +1,9 @@
 import type { Document, Transform } from '@gltf-transform/core';
-import { MaterialsUnlit } from '@gltf-transform/extensions';
+import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
 
 export const unlit = (): Transform => {
 	return (doc: Document): void => {
-		const unlitExtension = doc.createExtension(MaterialsUnlit) as MaterialsUnlit;
+		const unlitExtension = doc.createExtension(KHRMaterialsUnlit) as KHRMaterialsUnlit;
 		const unlit = unlitExtension.createUnlit();
 		doc.getRoot()
 			.listMaterials()

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -5,7 +5,7 @@ import { createCanvas } from 'canvas';
 import test from 'tape';
 import { Document, NodeIO, PropertyType } from '@gltf-transform/core';
 import { dedup } from '../';
-import { MaterialsTransmission } from '@gltf-transform/extensions';
+import { KHRMaterialsTransmission } from '@gltf-transform/extensions';
 
 test('@gltf-transform/functions::dedup | accessors', async (t) => {
 	const io = new NodeIO();
@@ -102,7 +102,7 @@ test('@gltf-transform/functions::dedup | meshes', async (t) => {
 
 test('@gltf-transform/functions::dedup | textures', (t) => {
 	const doc = new Document();
-	const transmissionExt = doc.createExtension(MaterialsTransmission);
+	const transmissionExt = doc.createExtension(KHRMaterialsTransmission);
 
 	const canvas = createCanvas(100, 50);
 	const ctx = canvas.getContext('2d');

--- a/packages/functions/test/instance.test.ts
+++ b/packages/functions/test/instance.test.ts
@@ -2,7 +2,7 @@ require('source-map-support').install();
 
 import test from 'tape';
 import { Document, Logger } from '@gltf-transform/core';
-import { InstancedMesh, MeshGPUInstancing } from '@gltf-transform/extensions';
+import { InstancedMesh, EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import { instance } from '../';
 
 test('@gltf-transform/functions::instance | translation', async (t) => {
@@ -140,7 +140,7 @@ test('@gltf-transform/functions::instance | idempotence', async (t) => {
 
 	t.equals(doc.getRoot().listExtensionsUsed().length, 0, 'does not add EXT_mesh_gpu_instancing');
 
-	const batchExtension = doc.createExtension(MeshGPUInstancing);
+	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
 	const batch = batchExtension.createInstancedMesh();
 	const node = doc.createNode();
 	node.setExtension('EXT_mesh_gpu_instancing', batch);

--- a/packages/functions/test/list-texture-channels.test.ts
+++ b/packages/functions/test/list-texture-channels.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import { Document, TextureChannel } from '@gltf-transform/core';
 import { listTextureChannels, getTextureChannelMask } from '@gltf-transform/functions';
-import { MaterialsSheen } from '@gltf-transform/extensions';
+import { KHRMaterialsSheen } from '@gltf-transform/extensions';
 
 const { R, G, B, A } = TextureChannel;
 
@@ -11,7 +11,7 @@ test('@gltf-transform/functions::listTextureChannels', (t) => {
 	const document = new Document();
 	const textureA = document.createTexture();
 	const textureB = document.createTexture();
-	const sheenExtension = document.createExtension(MaterialsSheen);
+	const sheenExtension = document.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureB);
 	const material = document
 		.createMaterial()
@@ -34,7 +34,7 @@ test('@gltf-transform/functions::getTextureChannelMask', (t) => {
 	const document = new Document();
 	const textureA = document.createTexture();
 	const textureB = document.createTexture();
-	const sheenExtension = document.createExtension(MaterialsSheen);
+	const sheenExtension = document.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureB);
 	const material = document
 		.createMaterial()

--- a/packages/functions/test/list-texture-info.test.ts
+++ b/packages/functions/test/list-texture-info.test.ts
@@ -3,14 +3,14 @@ require('source-map-support').install();
 import test from 'tape';
 import { Document } from '@gltf-transform/core';
 import { listTextureInfo } from '@gltf-transform/functions';
-import { MaterialsSheen } from '@gltf-transform/extensions';
+import { KHRMaterialsSheen } from '@gltf-transform/extensions';
 
 test('@gltf-transform/functions::listTextureInfo', (t) => {
 	const document = new Document();
 	const textureA = document.createTexture();
 	const textureB = document.createTexture();
 
-	const sheenExtension = document.createExtension(MaterialsSheen);
+	const sheenExtension = document.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureA);
 
 	document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);

--- a/packages/functions/test/list-texture-slots.test.ts
+++ b/packages/functions/test/list-texture-slots.test.ts
@@ -3,13 +3,13 @@ require('source-map-support').install();
 import test from 'tape';
 import { Document } from '@gltf-transform/core';
 import { listTextureSlots } from '@gltf-transform/functions';
-import { MaterialsSheen } from '@gltf-transform/extensions';
+import { KHRMaterialsSheen } from '@gltf-transform/extensions';
 
 test('@gltf-transform/functions::listTextureSlots', (t) => {
 	const document = new Document();
 	const textureA = document.createTexture();
 	const textureB = document.createTexture();
-	const sheenExtension = document.createExtension(MaterialsSheen);
+	const sheenExtension = document.createExtension(KHRMaterialsSheen);
 	const sheen = sheenExtension.createSheen().setSheenColorTexture(textureB);
 	document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);
 	t.deepEquals(listTextureSlots(document, textureA), ['baseColorTexture'], 'baseColorTexture');

--- a/packages/functions/test/metal-rough.test.ts
+++ b/packages/functions/test/metal-rough.test.ts
@@ -6,9 +6,9 @@ import test from 'tape';
 import { Document } from '@gltf-transform/core';
 import {
 	IOR,
-	MaterialsIOR,
-	MaterialsPBRSpecularGlossiness,
-	MaterialsSpecular,
+	KHRMaterialsIOR,
+	KHRMaterialsPBRSpecularGlossiness,
+	KHRMaterialsSpecular,
 	Specular,
 } from '@gltf-transform/extensions';
 import { metalRough } from '../';
@@ -42,7 +42,7 @@ test('@gltf-transform/functions::metalRough | textures', async (t) => {
 		.createTexture()
 		.setImage(await savePixels(SPEC_GLOSS, 'image/png'))
 		.setMimeType('image/png');
-	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
 	const specGloss = specGlossExtension
 		.createPBRSpecularGlossiness()
 		.setDiffuseTexture(diffuseTex)
@@ -65,7 +65,7 @@ test('@gltf-transform/functions::metalRough | textures', async (t) => {
 
 	t.deepEqual(
 		extensionsUsed,
-		[MaterialsIOR.EXTENSION_NAME, MaterialsSpecular.EXTENSION_NAME],
+		[KHRMaterialsIOR.EXTENSION_NAME, KHRMaterialsSpecular.EXTENSION_NAME],
 		'uses KHR_materials_ior and KHR_materials_specular'
 	);
 	t.ok(specGloss.isDisposed(), 'disposes PBRSpecularGlossiness');
@@ -97,7 +97,7 @@ test('@gltf-transform/functions::metalRough | textures', async (t) => {
 
 test('@gltf-transform/functions::metalRough | factors', async (t) => {
 	const doc = new Document();
-	const specGlossExtension = doc.createExtension(MaterialsPBRSpecularGlossiness);
+	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
 	const specGloss = specGlossExtension
 		.createPBRSpecularGlossiness()
 		.setDiffuseFactor([0, 1, 0, 0.5])
@@ -120,7 +120,7 @@ test('@gltf-transform/functions::metalRough | factors', async (t) => {
 
 	t.deepEqual(
 		extensionsUsed,
-		[MaterialsIOR.EXTENSION_NAME, MaterialsSpecular.EXTENSION_NAME],
+		[KHRMaterialsIOR.EXTENSION_NAME, KHRMaterialsSpecular.EXTENSION_NAME],
 		'uses KHR_materials_ior and KHR_materials_specular'
 	);
 	t.deepEqual(mat.getBaseColorFactor(), [0, 1, 0, 0.5], 'baseColorFactor = diffuseFactor');

--- a/packages/functions/test/quantize.test.ts
+++ b/packages/functions/test/quantize.test.ts
@@ -15,7 +15,7 @@ import {
 	Scene,
 	vec3,
 } from '@gltf-transform/core';
-import { MaterialsVolume, Volume } from '@gltf-transform/extensions';
+import { KHRMaterialsVolume, Volume } from '@gltf-transform/extensions';
 import { quantize } from '../';
 
 const logger = new Logger(Logger.Verbosity.WARN);
@@ -364,7 +364,7 @@ test('@gltf-transform/functions::quantize | volumetric materials', async (t) => 
 	const primB = doc.getRoot().listNodes()[1].getMesh().listPrimitives()[0];
 
 	// Add volumetric material (thickness is in local units).
-	const volumeExtension = doc.createExtension(MaterialsVolume);
+	const volumeExtension = doc.createExtension(KHRMaterialsVolume);
 	const volume = volumeExtension.createVolume().setThicknessFactor(1.0);
 	const material = doc.createMaterial().setExtension('KHR_materials_volume', volume);
 	primA.setMaterial(material);

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -3,7 +3,7 @@ require('source-map-support').install();
 import test from 'tape';
 import path from 'path';
 import { bbox, getBounds, Document, Logger, NodeIO, Primitive, vec3 } from '@gltf-transform/core';
-import { DracoMeshCompression, MeshQuantization } from '@gltf-transform/extensions';
+import { KHRDracoMeshCompression, KHRMeshQuantization } from '@gltf-transform/extensions';
 import { weld, unweld, simplify } from '../';
 import { MeshoptSimplifier } from 'meshoptimizer';
 import draco3d from 'draco3dgltf';
@@ -11,7 +11,7 @@ import draco3d from 'draco3dgltf';
 async function createIO(): Promise<NodeIO> {
 	const io = new NodeIO()
 		.setLogger(new Logger(Logger.Verbosity.SILENT))
-		.registerExtensions([DracoMeshCompression, MeshQuantization])
+		.registerExtensions([KHRDracoMeshCompression, KHRMeshQuantization])
 		.registerDependencies({
 			'draco3d.decoder': await draco3d.createDecoderModule(),
 		});


### PR DESCRIPTION
- Fixes https://github.com/donmccurdy/glTF-Transform/issues/715

Before:

```javascript
import { TextureTransform, Transform } from '@gltf-transform/extensions';

const transformExtension = document.createExtension(TextureTransform);
const transform: Transform = transformExtension.createTransform();
```

After:

```javascript
import { KHRTextureTransform, Transform } from '@gltf-transform/extensions';

const transformExtension = document.createExtension(KHRTextureTransform);
const transform: Transform = transformExtension.createTransform();
```