### PR TITLE
Rename MathUtils norm/denorm methods

### DIFF
--- a/packages/core/src/properties/accessor.ts
+++ b/packages/core/src/properties/accessor.ts
@@ -360,8 +360,8 @@ export class Accessor extends ExtensibleProperty<IAccessor> {
 		this.set('normalized', normalized);
 
 		if (normalized) {
-			this._out = (c: number): number => MathUtils.denormalize(c, this.get('componentType'));
-			this._in = (f: number): number => MathUtils.normalize(f, this.get('componentType'));
+			this._out = (c: number): number => MathUtils.decodeNormalizedInt(c, this.get('componentType'));
+			this._in = (f: number): number => MathUtils.encodeNormalizedInt(f, this.get('componentType'));
 		} else {
 			this._out = MathUtils.identity;
 			this._in = MathUtils.identity;

--- a/packages/core/src/utils/math-utils.ts
+++ b/packages/core/src/utils/math-utils.ts
@@ -19,7 +19,7 @@ export class MathUtils {
 		return true;
 	}
 
-	public static denormalize(c: number, componentType: GLTF.AccessorComponentType): number {
+	public static decodeNormalizedInt(c: number, componentType: GLTF.AccessorComponentType): number {
 		// Hardcode enums from accessor.ts to avoid a circular dependency.
 		switch (componentType) {
 			case 5126:
@@ -37,7 +37,12 @@ export class MathUtils {
 		}
 	}
 
-	public static normalize(f: number, componentType: GLTF.AccessorComponentType): number {
+	/** @deprecated Renamed to {@link MathUtils.decodeNormalizedInt}. */
+	public static denormalize(c: number, componentType: GLTF.AccessorComponentType): number {
+		return MathUtils.decodeNormalizedInt(c, componentType);
+	}
+
+	public static encodeNormalizedInt(f: number, componentType: GLTF.AccessorComponentType): number {
 		// Hardcode enums from accessor.ts to avoid a circular dependency.
 		switch (componentType) {
 			case 5126:
@@ -53,6 +58,11 @@ export class MathUtils {
 			default:
 				throw new Error('Invalid component type.');
 		}
+	}
+
+	/** @deprecated Renamed to {@link MathUtils.encodeNormalizedInt}. */
+	public static normalize(f: number, componentType: GLTF.AccessorComponentType): number {
+		return MathUtils.encodeNormalizedInt(f, componentType);
 	}
 
 	/**

--- a/packages/core/test/utils/math-utils.test.ts
+++ b/packages/core/test/utils/math-utils.test.ts
@@ -6,20 +6,20 @@ test('@gltf-transform/core::math-utils | identity', (t) => {
 	t.end();
 });
 
-test('@gltf-transform/core::math-utils | denormalize', (t) => {
-	t.equals(MathUtils.denormalize(25, 5126), 25, 'float');
-	t.equals(MathUtils.denormalize(13107, 5123), 0.2, 'ushort');
-	t.equals(MathUtils.denormalize(51, 5121), 0.2, 'ubyte');
-	t.equals(MathUtils.denormalize(1000, 5122).toFixed(4), '0.0305', 'short');
-	t.equals(MathUtils.denormalize(3, 5120).toFixed(4), '0.0236', 'byte');
+test('@gltf-transform/core::math-utils | decodeNormalizedInt', (t) => {
+	t.equals(MathUtils.decodeNormalizedInt(25, 5126), 25, 'float');
+	t.equals(MathUtils.decodeNormalizedInt(13107, 5123), 0.2, 'ushort');
+	t.equals(MathUtils.decodeNormalizedInt(51, 5121), 0.2, 'ubyte');
+	t.equals(MathUtils.decodeNormalizedInt(1000, 5122).toFixed(4), '0.0305', 'short');
+	t.equals(MathUtils.decodeNormalizedInt(3, 5120).toFixed(4), '0.0236', 'byte');
 	t.end();
 });
 
-test('@gltf-transform/core::math-utils | normalize', (t) => {
-	t.equals(MathUtils.normalize(25, 5126), 25, 'float');
-	t.equals(MathUtils.normalize(0.2, 5123), 13107, 'ushort');
-	t.equals(MathUtils.normalize(0.2, 5121), 51, 'ubyte');
-	t.equals(MathUtils.normalize(0.03053, 5122), 1000, 'short');
-	t.equals(MathUtils.normalize(0.0236, 5120), 3, 'byte');
+test('@gltf-transform/core::math-utils | encodeNormalizedInt', (t) => {
+	t.equals(MathUtils.encodeNormalizedInt(25, 5126), 25, 'float');
+	t.equals(MathUtils.encodeNormalizedInt(0.2, 5123), 13107, 'ushort');
+	t.equals(MathUtils.encodeNormalizedInt(0.2, 5121), 51, 'ubyte');
+	t.equals(MathUtils.encodeNormalizedInt(0.03053, 5122), 1000, 'short');
+	t.equals(MathUtils.encodeNormalizedInt(0.0236, 5120), 3, 'byte');
 	t.end();
 });

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -16,7 +16,7 @@ import {
 import type { MeshoptEncoder } from 'meshoptimizer';
 
 const { BYTE, SHORT, FLOAT } = Accessor.ComponentType;
-const { normalize, denormalize } = MathUtils;
+const { encodeNormalizedInt, decodeNormalizedInt } = MathUtils;
 
 /** Pre-processes array with required filters or padding. */
 export function prepareAccessor(
@@ -68,12 +68,12 @@ export function prepareAccessor(
 		result.min = accessor.getMin([]);
 		result.max = accessor.getMax([]);
 		if (accessor.getNormalized()) {
-			result.min = result.min.map((v) => denormalize(v, accessor.getComponentType()));
-			result.max = result.max.map((v) => denormalize(v, accessor.getComponentType()));
+			result.min = result.min.map((v) => decodeNormalizedInt(v, accessor.getComponentType()));
+			result.max = result.max.map((v) => decodeNormalizedInt(v, accessor.getComponentType()));
 		}
 		if (result.normalized) {
-			result.min = result.min.map((v) => normalize(v, result.componentType));
-			result.max = result.max.map((v) => normalize(v, result.componentType));
+			result.min = result.min.map((v) => encodeNormalizedInt(v, result.componentType));
+			result.max = result.max.map((v) => encodeNormalizedInt(v, result.componentType));
 		}
 	} else if (result.byteStride % 4) {
 		result.array = padArrayElements(result.array, accessor.getElementSize());
@@ -88,7 +88,7 @@ function denormalizeArray(attribute: Accessor): Float32Array {
 	const srcArray = attribute.getArray()!;
 	const dstArray = new Float32Array(srcArray.length);
 	for (let i = 0; i < srcArray.length; i++) {
-		dstArray[i] = denormalize(srcArray[i], componentType);
+		dstArray[i] = decodeNormalizedInt(srcArray[i], componentType);
 	}
 	return dstArray;
 }

--- a/packages/functions/src/sort-primitive-weights.ts
+++ b/packages/functions/src/sort-primitive-weights.ts
@@ -91,7 +91,7 @@ function normalizePrimitiveWeights(prim: PrimLike): void {
 	const componentType = templateAttribute.getComponentType();
 	const normalized = templateAttribute.getNormalized();
 	const normalizedComponentType = normalized ? componentType : undefined;
-	const delta = normalized ? MathUtils.denormalize(1, componentType) : Number.EPSILON;
+	const delta = normalized ? MathUtils.decodeNormalizedInt(1, componentType) : Number.EPSILON;
 	const joints = new Uint32Array(setCount * 4).fill(0);
 	const weights = templateArray.slice(0, setCount * 4).fill(0);
 
@@ -106,8 +106,8 @@ function normalizePrimitiveWeights(prim: PrimLike): void {
 		if (Math.abs(1 - weightsSum) > delta) {
 			for (let j = 0; j < weights.length; j++) {
 				if (normalized) {
-					const intValue = MathUtils.normalize(weights[j] / weightsSum, componentType);
-					weights[j] = MathUtils.denormalize(intValue, componentType);
+					const intValue = MathUtils.encodeNormalizedInt(weights[j] / weightsSum, componentType);
+					weights[j] = MathUtils.decodeNormalizedInt(intValue, componentType);
 				} else {
 					weights[j] /= weightsSum;
 				}
@@ -121,7 +121,7 @@ function normalizePrimitiveWeights(prim: PrimLike): void {
 		if (normalized && weightsSum !== 1) {
 			for (let j = weights.length - 1; j >= 0; j--) {
 				if (weights[j] > 0) {
-					weights[j] += MathUtils.normalize(1 - weightsSum, componentType);
+					weights[j] += MathUtils.encodeNormalizedInt(1 - weightsSum, componentType);
 					break;
 				}
 			}
@@ -153,7 +153,7 @@ function getVertexArray(
 		weights.getElement(vertexIndex, el);
 		for (let j = 0; j < 4; j++) {
 			if (normalizedComponentType) {
-				target[i * 4 + j] = MathUtils.normalize(el[j], normalizedComponentType);
+				target[i * 4 + j] = MathUtils.encodeNormalizedInt(el[j], normalizedComponentType);
 			} else {
 				target[i * 4 + j] = el[j];
 			}
@@ -175,7 +175,7 @@ function setVertexArray(
 	for (let i = 0; (weights = prim.getAttribute(`${prefix}_${i}`)); i++) {
 		for (let j = 0; j < 4; j++) {
 			if (normalizedComponentType) {
-				el[j] = MathUtils.denormalize(values[i * 4 + j], normalizedComponentType);
+				el[j] = MathUtils.decodeNormalizedInt(values[i * 4 + j], normalizedComponentType);
 			} else {
 				el[j] = values[i * 4 + j];
 			}
@@ -189,7 +189,7 @@ function sum(values: TypedArray, normalizedComponentType?: GLTF.AccessorComponen
 	let sum = 0;
 	for (let i = 0; i < values.length; i++) {
 		if (normalizedComponentType) {
-			sum += MathUtils.denormalize(values[i], normalizedComponentType);
+			sum += MathUtils.decodeNormalizedInt(values[i], normalizedComponentType);
 		} else {
 			sum += values[i];
 		}


### PR DESCRIPTION
I think I prefer this naming, but will wait for feedback in https://github.com/mrdoob/three.js/pull/24512.

- denormalize → decodeNormalizedInt
- normalize → encodeNormalizedInt

***

- Fixes #672 