### PR TITLE
Add --format option to CLI validate command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,9 +7,9 @@ import { program } from '@caporal/core';
 import { Logger, NodeIO, PropertyType, VertexLayout, vec2 } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
 import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, unweld, weld, reorder, dequantize, unlit, meshopt, DRACO_DEFAULTS, draco, DracoOptions, simplify, SIMPLIFY_DEFAULTS, WELD_DEFAULTS, textureCompress } from '@gltf-transform/functions';
-import { InspectFormat, inspect } from './inspect';
+import { inspect } from './inspect';
 import { ETC1S_DEFAULTS, Filter, Mode, UASTC_DEFAULTS, ktxfix, merge, toktx, XMPOptions, xmp } from './transforms';
-import { formatBytes, MICROMATCH_OPTIONS, underline } from './util';
+import { formatBytes, MICROMATCH_OPTIONS, underline, TableFormat } from './util';
 import { Session } from './session';
 import { ValidateOptions, validate } from './validate';
 
@@ -64,8 +64,8 @@ Use --format=csv or --format=md for alternative display formats.
 	`.trim())
 	.argument('<input>', INPUT_DESC)
 	.option('--format <format>', 'Table output format', {
-		validator: [InspectFormat.PRETTY, InspectFormat.CSV, InspectFormat.MD],
-		default: InspectFormat.PRETTY
+		validator: [TableFormat.PRETTY, TableFormat.CSV, TableFormat.MD],
+		default: TableFormat.PRETTY
 	})
 	.action(async ({args, options, logger}) => {
 		io.setLogger(logger as unknown as Logger);
@@ -73,7 +73,7 @@ Use --format=csv or --format=md for alternative display formats.
 			await io.readAsJSON(args.input as string),
 			io,
 			logger as unknown as Logger,
-			options.format as InspectFormat
+			options.format as TableFormat
 		);
 	});
 
@@ -104,6 +104,10 @@ Example:
 	.option('--ignore <CODE>,<CODE>,...', 'Issue codes to be ignored', {
 		validator: program.ARRAY,
 		default: [],
+	})
+	.option('--format <format>', 'Table output format', {
+		validator: [TableFormat.PRETTY, TableFormat.CSV, TableFormat.MD],
+		default: TableFormat.PRETTY
 	})
 	.action(({args, options, logger}) => {
 		validate(

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -3,6 +3,8 @@ const { spawn: _spawn } = require('child_process');
 
 import _commandExists from 'command-exists';
 import type { ChildProcess } from 'child_process';
+import CLITable from 'cli-table3';
+import { stringify } from 'csv-stringify';
 
 // Constants.
 
@@ -84,6 +86,52 @@ export function formatParagraph(str: string): string {
 
 export function formatHeader(title: string): string {
 	return '' + '\n ' + title.toUpperCase() + '\n ────────────────────────────────────────────';
+}
+
+export enum TableFormat {
+	PRETTY = 'pretty',
+	CSV = 'csv',
+	MD = 'md',
+}
+
+const CLI_TABLE_MARKDOWN_CHARS = {
+	top: '',
+	'top-mid': '',
+	'top-left': '',
+	'top-right': '',
+	bottom: '',
+	'bottom-mid': '',
+	'bottom-left': '',
+	'bottom-right': '',
+	left: '|',
+	'left-mid': '',
+	mid: '',
+	'mid-mid': '',
+	right: '|',
+	'right-mid': '',
+	middle: '|',
+};
+
+export async function formatTable(format: TableFormat, head: string[], rows: string[][]): Promise<string> {
+	switch (format) {
+		case TableFormat.PRETTY: {
+			const table = new CLITable({ head });
+			table.push(...rows);
+			return table.toString();
+		}
+		case TableFormat.CSV:
+			return new Promise((resolve, reject) => {
+				stringify([head, ...rows], (err, output) => {
+					err ? reject(err) : resolve(output);
+				});
+			});
+		case TableFormat.MD: {
+			const table = new CLITable({ head, chars: CLI_TABLE_MARKDOWN_CHARS });
+			table.push(new Array(rows[0].length).fill('---'));
+			table.push(...rows);
+			return table.toString();
+		}
+	}
 }
 
 export function formatXMP(value: string | number | boolean | Record<string, unknown> | null): string {


### PR DESCRIPTION
Example commands:

```bash
gltf-transform validate scene.glb --format csv

gltf-transform validate scene.glb --format md

gltf-transform validate scene.glb --format pretty
```

Example Markdown output:

| code                  | message                                                                                           | severity | pointer           |
| ---                   | ---                                                                                               | ---      | ---               |
| UNSUPPORTED_EXTENSION | Cannot validate an extension as it is not supported by the validator: 'KHR_materials_anisotropy'. | 2        | /extensionsUsed/3 |
| UNUSED_OBJECT         | This object may be unused.                                                                        | 2        | /textures/3       |

- Fixes #231 