### PR TITLE
Add flatten()

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { gzip } from 'node-gzip';
 import { program } from '@caporal/core';
 import { Logger, NodeIO, PropertyType, VertexLayout, vec2 } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
-import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, unweld, weld, reorder, dequantize, unlit, meshopt, DRACO_DEFAULTS, draco, DracoOptions, simplify, SIMPLIFY_DEFAULTS, WELD_DEFAULTS, textureCompress } from '@gltf-transform/functions';
+import { CenterOptions, InstanceOptions, PartitionOptions, PruneOptions, QUANTIZE_DEFAULTS, ResampleOptions, SequenceOptions, TEXTURE_RESIZE_DEFAULTS, TextureResizeFilter, UnweldOptions, WeldOptions, center, dedup, instance, metalRough, partition, prune, quantize, resample, sequence, tangents, unweld, weld, reorder, dequantize, unlit, meshopt, DRACO_DEFAULTS, draco, DracoOptions, simplify, SIMPLIFY_DEFAULTS, WELD_DEFAULTS, textureCompress, flatten, FlattenOptions } from '@gltf-transform/functions';
 import { inspect } from './inspect';
 import { ETC1S_DEFAULTS, Filter, Mode, UASTC_DEFAULTS, ktxfix, merge, toktx, XMPOptions, xmp } from './transforms';
 import { formatBytes, MICROMATCH_OPTIONS, underline, TableFormat } from './util';
@@ -369,6 +369,24 @@ https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)
 			.transform(instance({...options} as InstanceOptions))
+	);
+
+// FLATTEN
+program
+	.command('flatten', 'Flatten scene graph')
+	.help(`
+Flattens the scene graph, leaving Nodes with Meshes, Cameras, and other
+attachments as direct children of the Scene. Skeletons and their
+descendants are left in their original Node structure.
+
+Animation targeting a Node or its parents will prevent that Node from being
+moved.
+	`.trim())
+	.argument('<input>', INPUT_DESC)
+	.argument('<output>', OUTPUT_DESC)
+	.action(({args, options, logger}) =>
+		Session.create(io, logger, args.input, args.output)
+			.transform(flatten({...options} as FlattenOptions))
 	);
 
 program.command('', '\n\n🕋 GEOMETRY ─────────────────────────────────────────');

--- a/packages/core/src/properties/scene.ts
+++ b/packages/core/src/properties/scene.ts
@@ -13,10 +13,10 @@ interface IScene extends IExtensibleProperty {
  *
  * *Scenes represent a set of visual objects to render.*
  *
- * Typically a glTF file contains only a single scene, although more are allowed and useful in some
- * cases. No particular meaning is associated with additional scenes, except as defined by the
- * application. Scenes reference {@link Node}s, and a single node cannot be a member of more than
- * one scene.
+ * Typically a glTF file contains only a single Scene, although more are allowed and useful in some
+ * cases. No particular meaning is associated with additional Scenes, except as defined by the
+ * application. Scenes reference {@link Node}s, and a single Node cannot be a member of more than
+ * one Scene.
  *
  * References:
  * - [glTF → Scenes](https://github.com/KhronosGroup/gltf/blob/main/specification/2.0/README.md#scenes)
@@ -37,12 +37,12 @@ export class Scene extends ExtensibleProperty<IScene> {
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
 		// Scene cannot be copied, only cloned. Copying is shallow, but nodes cannot have more than
-		// one parent. Rather than leaving one of the two scenes without children, throw an error here.
+		// one parent. Rather than leaving one of the two Scenes without children, throw an error here.
 		if (resolve === COPY_IDENTITY) throw new Error('Scene cannot be copied.');
 		return super.copy(other, resolve);
 	}
 
-	/** Adds a {@link Node} to the scene. */
+	/** Adds a {@link Node} to the Scene. */
 	public addChild(node: Node): this {
 		// Remove existing parent.
 		if (node._parent) node._parent.removeChild(node);
@@ -59,17 +59,21 @@ export class Scene extends ExtensibleProperty<IScene> {
 		return this;
 	}
 
-	/** Removes a {@link Node} from the scene. */
+	/** Removes a {@link Node} from the Scene. */
 	public removeChild(node: Node): this {
 		return this.removeRef('children', node);
 	}
 
-	/** Lists all root {@link Node}s in the scene. */
+	/**
+	 * Lists all direct child {@link Node Nodes} in the Scene. Indirect
+	 * descendants (children of children) are not returned, but may be
+	 * reached recursively or with {@link Scene.traverse} instead.
+	 */
 	public listChildren(): Node[] {
 		return this.listRefs('children');
 	}
 
-	/** Visits each {@link Node} in the scene, including descendants, top-down. */
+	/** Visits each {@link Node} in the Scene, including descendants, top-down. */
 	public traverse(fn: (node: Node) => void): this {
 		for (const node of this.listChildren()) node.traverse(fn);
 		return this;

--- a/packages/functions/src/flatten.ts
+++ b/packages/functions/src/flatten.ts
@@ -9,7 +9,7 @@ const NAME = 'flatten';
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface FlattenOptions {}
 
-const FLATTEN_DEFAULTS: Required<FlattenOptions> = {};
+export const FLATTEN_DEFAULTS: Required<FlattenOptions> = {};
 
 /**
  * Flattens the scene graph, leaving {@link Node Nodes} with
@@ -28,7 +28,7 @@ const FLATTEN_DEFAULTS: Required<FlattenOptions> = {};
  * await document.transform(flatten());
  * ```
  */
-export function flatten(_options: FlattenOptions): Transform {
+export function flatten(_options: FlattenOptions = FLATTEN_DEFAULTS): Transform {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const options = { ...FLATTEN_DEFAULTS, ..._options } as Required<FlattenOptions>;
 
@@ -82,8 +82,10 @@ export function flatten(_options: FlattenOptions): Transform {
 			});
 		}
 
-		// TODO(feat): For nodes with animation in their world transform, transform channels.
-		// TODO(feat): (Optional) Merge meshes of sibling nodes.
+		// TODO(feat): Transform animation channels, accounting for previously inherited transforms.
+		if (animated.size) {
+			logger.debug(`${NAME}: Flattening node hierarchies with TRS animation not yet supported.`);
+		}
 
 		// (5) Clean up leaf nodes.
 		await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false }));

--- a/packages/functions/src/flatten.ts
+++ b/packages/functions/src/flatten.ts
@@ -1,0 +1,93 @@
+import { Document, Node, PropertyType, Transform } from '@gltf-transform/core';
+import { clearNodeParent } from './clear-node-parent';
+import { prune } from './prune';
+import { createTransform } from './utils';
+
+const NAME = 'flatten';
+
+/** Options for the {@link flatten} function. */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface FlattenOptions {}
+
+const FLATTEN_DEFAULTS: Required<FlattenOptions> = {};
+
+/**
+ * Flattens the scene graph, leaving {@link Node Nodes} with
+ * {@link Mesh Meshes}, {@link Camera Cameras}, and other attachments
+ * as direct children of the {@link Scene}. Skeletons and their
+ * descendants are left in their original Node structure.
+ *
+ * {@link Animation} targeting a Node or its parents will
+ * prevent that Node from being moved.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { flatten } from '@gltf-transform/functions';
+ *
+ * await document.transform(flatten());
+ * ```
+ */
+export function flatten(_options: FlattenOptions): Transform {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const options = { ...FLATTEN_DEFAULTS, ..._options } as Required<FlattenOptions>;
+
+	return createTransform(NAME, async (document: Document): Promise<void> => {
+		const root = document.getRoot();
+		const logger = document.getLogger();
+
+		// (1) Mark joints.
+		const joints = new Set<Node>();
+		for (const skin of root.listSkins()) {
+			for (const joint of skin.listJoints()) {
+				joints.add(joint);
+			}
+		}
+
+		// (2) Mark animated nodes.
+		const animated = new Set<Node>();
+		for (const animation of root.listAnimations()) {
+			for (const channel of animation.listChannels()) {
+				const node = channel.getTargetNode();
+				if (node) {
+					animated.add(node);
+				}
+			}
+		}
+
+		// (3) Mark descendants of joints and animated nodes.
+		const hasJointParent = new Set<Node>();
+		const hasAnimatedParent = new Set<Node>();
+		for (const scene of root.listScenes()) {
+			scene.traverse((node) => {
+				const parent = node.getParent();
+				if (!(parent instanceof Node)) return;
+				if (joints.has(parent) || hasJointParent.has(parent)) {
+					hasJointParent.add(node);
+				}
+				if (animated.has(parent) || hasAnimatedParent.has(parent)) {
+					hasAnimatedParent.add(node);
+				}
+			});
+		}
+
+		// (4) For each affected node, in top-down order, clear parents.
+		for (const scene of root.listScenes()) {
+			scene.traverse((node) => {
+				if (animated.has(node)) return;
+				if (hasJointParent.has(node)) return;
+				if (hasAnimatedParent.has(node)) return;
+
+				clearNodeParent(node);
+			});
+		}
+
+		// TODO(feat): For nodes with animation in their world transform, transform channels.
+		// TODO(feat): (Optional) Merge meshes of sibling nodes.
+
+		// (5) Clean up leaf nodes.
+		await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false }));
+
+		logger.debug(`${NAME}: Complete.`);
+	});
+}

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -57,6 +57,7 @@ export * from './colorspace';
 export * from './dedup';
 export * from './dequantize';
 export * from './draco';
+export * from './flatten';
 export * from './get-node-scene';
 export * from './inspect';
 export * from './instance';

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -1,6 +1,6 @@
 import type { NdArray } from 'ndarray';
 import { getPixels, savePixels } from 'ndarray-pixels';
-import { Accessor, Primitive, Texture, Transform, TransformContext } from '@gltf-transform/core';
+import { Accessor, Node, Primitive, Scene, Texture, Transform, TransformContext } from '@gltf-transform/core';
 
 /**
  * Prepares a function used in an {@link Document.transform} pipeline. Use of this wrapper is
@@ -162,4 +162,15 @@ export function createIndices(count: number, maxIndex = count): Uint16Array | Ui
 	const array = maxIndex <= 65534 ? new Uint16Array(count) : new Uint32Array(count);
 	for (let i = 0; i < array.length; i++) array[i] = i;
 	return array;
+}
+
+export function traverseNodeParents(node: Node, fn: (parent: Scene | Node) => void): void {
+	let child = node;
+	let parent: Scene | Node | null;
+	while ((parent = child.getParent() as Scene | Node | null)) {
+		fn(parent);
+		if (parent instanceof Node) {
+			child = parent;
+		}
+	}
 }

--- a/packages/functions/test/clear-node-parent.test.ts
+++ b/packages/functions/test/clear-node-parent.test.ts
@@ -25,7 +25,7 @@ test('@gltf-transform/functions::clearNodeParent', async (t) => {
 
 	t.deepEquals(nodeA.getTranslation(), [8, 0, 0], 'A.translation');
 	t.deepEquals(nodeA.getScale(), [4, 4, 4], 'A.scale');
-	t.deepEquals(nodeA.getScale(), [4, 4, 4], 'B.scale');
+	t.deepEquals(nodeB.getScale(), [4, 4, 4], 'B.scale');
 
 	t.end();
 });

--- a/packages/functions/test/flatten.test.ts
+++ b/packages/functions/test/flatten.test.ts
@@ -1,0 +1,81 @@
+require('source-map-support').install();
+
+import test from 'tape';
+import { Document, Logger } from '@gltf-transform/core';
+import { flatten } from '@gltf-transform/functions';
+
+const logger = new Logger(Logger.Verbosity.SILENT);
+
+test('@gltf-transform/functions::flatten', async (t) => {
+	const document = new Document().setLogger(logger);
+	const mesh = document.createMesh();
+	const nodeA = document.createNode('A').setTranslation([2, 0, 0]).setMesh(mesh);
+	const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA).setMesh(mesh);
+	const nodeC = document.createNode('C').addChild(nodeB).setMesh(mesh);
+	const scene = document.createScene().addChild(nodeC);
+
+	t.ok(nodeA.getParent() === nodeB, 'B → A (before)');
+	t.ok(nodeB.getParent() === nodeC, 'C → B (before)');
+	t.ok(nodeC.getParent() === scene, 'Scene → C (before)');
+
+	await document.transform(flatten());
+
+	t.ok(nodeA.getParent() === scene, 'Scene → A (after)');
+	t.ok(nodeB.getParent() === scene, 'Scene → B (after)');
+	t.ok(nodeC.getParent() === scene, 'Scene → C (after)');
+
+	t.deepEquals(nodeA.getTranslation(), [8, 0, 0], 'A.translation');
+	t.deepEquals(nodeA.getScale(), [4, 4, 4], 'A.scale');
+	t.deepEquals(nodeB.getScale(), [4, 4, 4], 'B.scale');
+
+	t.end();
+});
+
+test('@gltf-transform/functions::flatten | skins', async (t) => {
+	const document = new Document().setLogger(logger);
+	const mesh = document.createMesh();
+	const skin = document.createSkin();
+	const nodeA = document.createNode('JointLeaf').setMesh(mesh);
+	const nodeB = document.createNode('JointMid').addChild(nodeA);
+	const nodeC = document.createNode('JointRoot').addChild(nodeB).setSkin(skin);
+	const nodeD = document.createNode('Empty').addChild(nodeC);
+	const scene = document.createScene().addChild(nodeD);
+
+	skin.addJoint(nodeA).addJoint(nodeB).addJoint(nodeC).setSkeleton(nodeC);
+
+	t.ok(nodeA.getParent() === nodeB, 'JointMid → JointLeaf (before)');
+	t.ok(nodeB.getParent() === nodeC, 'JointRoot → JointMid (before)');
+	t.ok(nodeC.getParent() === nodeD, 'Group → JointRoot (before)');
+	t.ok(nodeD.getParent() === scene, 'Scene → Group (before)');
+
+	await document.transform(flatten());
+
+	t.ok(nodeA.getMesh(), 'JointLeaf → mesh');
+	t.ok(nodeA.getParent() === nodeB, 'JointMid → JointLeaf (after)');
+	t.ok(nodeB.getParent() === nodeC, 'JointRoot → JointMid (after)');
+	t.ok(nodeC.getParent() === scene, 'Scene → JointRoot (after)');
+	t.ok(nodeD.isDisposed(), 'Group disposed');
+
+	t.end();
+});
+
+test('@gltf-transform/functions::flatten | trs animation', async (t) => {
+	const document = new Document().setLogger(logger);
+	const mesh = document.createMesh();
+	const nodeA = document.createNode('A').setMesh(mesh);
+	const nodeB = document.createNode('B').setMesh(mesh);
+	const nodeC = document.createNode('Group').addChild(nodeA).addChild(nodeB).setScale([2, 2, 2]);
+	const scene = document.createScene().addChild(nodeC);
+	const channel = document.createAnimationChannel().setTargetNode(nodeA).setTargetPath('scale');
+	document.createAnimation().addChannel(channel);
+
+	await document.transform(flatten());
+
+	t.ok(nodeA.getMesh(), 'A → mesh');
+	t.ok(nodeB.getMesh(), 'B → mesh');
+	t.ok(nodeA.getParent() === nodeC, 'Group → A');
+	t.ok(nodeB.getParent() === scene, 'Scene → B');
+	t.deepEquals(scene.listChildren(), [nodeC, nodeB], 'Scene → [Group, B]');
+
+	t.end();
+});


### PR DESCRIPTION
Progress:

- https://github.com/donmccurdy/glTF-Transform/issues/11

Remaining:

- [x] Unit tests

Design notes:

- Nodes containing Skins, Meshes, Cameras, Lights, etc. are hoisted to become Scene children
- Ineligible Nodes include:
    - Nodes affected by TRS animation (self or inherited)
    - Children of joints (e.g. joint hierarchies, mesh attachments to joints)
- Node transforms are updated in place, not baked into mesh vertices
- Certain edge cases are avoided here, but may become relevant with `join()` later
    - Apply transforms to volumetric materials
    - Dealing with mixed vertex stream structures
