### PR TITLE
Store copies of array literal attributes

### DIFF
--- a/packages/core/src/properties/property.ts
+++ b/packages/core/src/properties/property.ts
@@ -1,5 +1,15 @@
 import type { Nullable } from '../constants';
-import { $attributes, $immutableKeys, Graph, GraphNode, GraphEdge, isRef, isRefList, isRefMap } from 'property-graph';
+import {
+	$attributes,
+	$immutableKeys,
+	Graph,
+	GraphNode,
+	GraphEdge,
+	isRef,
+	isRefList,
+	isRefMap,
+	LiteralKeys,
+} from 'property-graph';
 import { equalsArray, equalsObject, equalsRef, equalsRefList, equalsRefMap, isArray, isPlainObject } from '../utils';
 import type { Ref, RefMap, UnknownRef } from '../utils';
 
@@ -90,6 +100,12 @@ export abstract class Property<T extends IProperty = IProperty> extends GraphNod
 	 */
 	protected getDefaults(): Nullable<T> {
 		return Object.assign(super.getDefaults(), { name: '', extras: {} });
+	}
+
+	/** @hidden */
+	protected set<K extends LiteralKeys<T>>(attribute: K, value: T[K]): this {
+		if (Array.isArray(value)) value = value.slice() as T[K]; // copy vector, quat, color …
+		return super.set(attribute, value);
 	}
 
 	/**********************************************************************************************

--- a/packages/core/test/properties/property.test.ts
+++ b/packages/core/test/properties/property.test.ts
@@ -1,5 +1,5 @@
 import test from 'tape';
-import { Document } from '@gltf-transform/core';
+import { Document, vec3 } from '@gltf-transform/core';
 
 test('@gltf-transform/core::property | equals', async (t) => {
 	const document = new Document();
@@ -16,5 +16,19 @@ test('@gltf-transform/core::property | equals', async (t) => {
 	nodeB.setExtras({ a: 1, b: 2 });
 
 	t.notOk(nodeA.equals(nodeB), 'different extras');
+	t.end();
+});
+
+test.only('@gltf-transform/core::property | internal arrays', async (t) => {
+	const doc = new Document();
+	const translation = [0, 0, 0] as vec3;
+	const node = doc.createNode('A').setTranslation(translation);
+
+	t.deepEquals(node.getTranslation(), [0, 0, 0], 'stores original value');
+
+	// Array literals (vector, quaternion, color, …) must be stored as copies.
+	translation[1] = 0.5;
+
+	t.deepEquals(node.getTranslation(), [0, 0, 0], 'unchanged by external mutation');
 	t.end();
 });

--- a/packages/core/test/properties/property.test.ts
+++ b/packages/core/test/properties/property.test.ts
@@ -19,7 +19,7 @@ test('@gltf-transform/core::property | equals', async (t) => {
 	t.end();
 });
 
-test.only('@gltf-transform/core::property | internal arrays', async (t) => {
+test('@gltf-transform/core::property | internal arrays', async (t) => {
 	const doc = new Document();
 	const translation = [0, 0, 0] as vec3;
 	const node = doc.createNode('A').setTranslation(translation);


### PR DESCRIPTION
- Fixes #460

When setting an attribute with an array-literal value, like this:

```javascript
const color = [1, 0, 0, 1];
material.setBaseColorFactor(color);

color[3] = 0.5; // 🚩
```

I think it's more intuitive if the flagged line has no effect, and the property stores a copy of the array literal. This also helps with change detection, relevant to the /view module, as there's no question of whether we're receiving the same array as we already stored.

The change does _not_ apply to typed arrays (`accessor.setArray(...)`, `texture.setImage(...)`) which store a (potentially large) vertex attribute or image, and would incur high costs to copy.
