### PR TITLE
ImageUtils: Rename getMemSize → getGPUByteLength

### DIFF
--- a/packages/core/src/utils/image-utils.ts
+++ b/packages/core/src/utils/image-utils.ts
@@ -131,7 +131,7 @@ export class ImageUtils {
 	}
 
 	/** Returns a conservative estimate of the GPU memory required by this image. */
-	public static getMemSize(buffer: Uint8Array, mimeType: string): number | null {
+	public static getGPUByteLength(buffer: Uint8Array, mimeType: string): number | null {
 		if (!this.impls[mimeType]) return null;
 
 		if (this.impls[mimeType].getGPUByteLength) {

--- a/packages/core/test/utils/image-utils.test.ts
+++ b/packages/core/test/utils/image-utils.test.ts
@@ -46,8 +46,8 @@ test('@gltf-transform/core::image-utils | png', { skip: !IS_NODEJS }, (t) => {
 	t.deepEquals(ImageUtils.getSize(fried, 'image/png'), [12, 12], 'png (fried)');
 	t.equals(ImageUtils.getChannels(png, 'image/png'), 4, 'png channels');
 	t.equals(ImageUtils.getChannels(fried, 'image/png'), 4, 'png channels');
-	t.equals(ImageUtils.getMemSize(png, 'image/png'), 349524, 'png gpu size');
-	t.equals(ImageUtils.getMemSize(fried, 'image/png'), 760, 'png gpu size');
+	t.equals(ImageUtils.getGPUByteLength(png, 'image/png'), 349524, 'png gpu size');
+	t.equals(ImageUtils.getGPUByteLength(fried, 'image/png'), 760, 'png gpu size');
 	t.end();
 });
 
@@ -60,7 +60,7 @@ test('@gltf-transform/core::image-utils | jpeg', { skip: !IS_NODEJS }, (t) => {
 	t.deepEquals(ImageUtils.getSize(jpg, 'image/jpeg'), [256, 256], 'jpg size');
 	t.equals(ImageUtils.getChannels(jpg, 'image/jpeg'), 3, 'jpg channels');
 	// See https://github.com/donmccurdy/glTF-Transform/issues/151.
-	t.equals(ImageUtils.getMemSize(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
+	t.equals(ImageUtils.getGPUByteLength(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
 
 	view.setUint16(4, 1000, false);
 	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), 'oob');

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -62,7 +62,7 @@ test('@gltf-transform/extensions::texture-basisu | image-utils', { skip: !IS_NOD
 	t.throws(() => ImageUtils.getSize(new Uint8Array(10), 'image/ktx2'), 'corrupt file');
 	t.deepEquals(ImageUtils.getSize(ktx2, 'image/ktx2'), [256, 256], 'size');
 	t.equals(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
-	t.equals(ImageUtils.getMemSize(ktx2, 'image/ktx2'), 65536, 'gpuSize');
+	t.equals(ImageUtils.getGPUByteLength(ktx2, 'image/ktx2'), 65536, 'gpuSize');
 	t.equals(ImageUtils.extensionToMimeType('ktx2'), 'image/ktx2', 'extensionToMimeType, inferred');
 	t.end();
 });

--- a/packages/extensions/test/texture-webp.test.ts
+++ b/packages/extensions/test/texture-webp.test.ts
@@ -73,6 +73,6 @@ test('@gltf-transform/core::image-utils | webp', { skip: !IS_NODEJS }, (t) => {
 	t.deepEquals(ImageUtils.getSize(webpLossless, 'image/webp'), [256, 256], 'size (lossless)');
 	t.equals(ImageUtils.getChannels(webpLossy, 'image/webp'), 4, 'channels');
 	t.equals(ImageUtils.getChannels(webpLossless, 'image/fake'), null, 'channels (other)');
-	t.equals(ImageUtils.getMemSize(webpLossy, 'image/webp'), 349524, 'gpuSize');
+	t.equals(ImageUtils.getGPUByteLength(webpLossy, 'image/webp'), 349524, 'gpuSize');
 	t.end();
 });

--- a/packages/functions/src/inspect.ts
+++ b/packages/functions/src/inspect.ts
@@ -170,7 +170,7 @@ function listTextures(doc: Document): InspectPropertyReport<InspectTextureReport
 				compression,
 				resolution: resolution ? resolution.join('x') : '',
 				size: texture.getImage()!.byteLength,
-				gpuSize: ImageUtils.getMemSize(texture.getImage()!, texture.getMimeType()),
+				gpuSize: ImageUtils.getGPUByteLength(texture.getImage()!, texture.getMimeType()),
 			};
 		});
 


### PR DESCRIPTION
- Fixes https://github.com/donmccurdy/glTF-Transform/issues/747

Small breaking change for users who:

- (a) use ImageUtils directly
- (b) implement an extension providing support for a non-default image format

I think both of these cases are pretty rare, so this should be a modest enough solution to the naming issue described in #747. It'd be more disruptive to rename getSize to something like getDimensions, I don't feel like that change is really worth it at this point.