### PR TITLE
Restore CommonJS builds for /core, /extensions, and /functions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
     "license": "MIT",
     "type": "module",
     "sideEffects": false,
+    "main": "./dist/core.cjs",
     "module": "./dist/core.modern.js",
     "exports": "./dist/core.modern.js",
     "source": "./src/core.ts",
@@ -18,9 +19,9 @@
         "node >= 14"
     ],
     "scripts": {
-        "dist": "microbundle --format modern --define PACKAGE_VERSION=$npm_package_version",
-        "watch": "microbundle watch --format modern --define PACKAGE_VERSION=$npm_package_version",
-        "watch:debug": "microbundle watch --format modern --define PACKAGE_VERSION=$npm_package_version --no-compress"
+        "dist": "microbundle --format modern,cjs --define PACKAGE_VERSION=$npm_package_version",
+        "watch": "microbundle watch --format modern,cjs --define PACKAGE_VERSION=$npm_package_version",
+        "watch:debug": "microbundle watch --format modern,cjs --define PACKAGE_VERSION=$npm_package_version --no-compress"
     },
     "keywords": [
         "gltf",

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -8,6 +8,7 @@
 	"license": "MIT",
 	"type": "module",
 	"sideEffects": false,
+	"main": "./dist/extensions.cjs",
 	"module": "./dist/extensions.modern.js",
 	"exports": "./dist/extensions.modern.js",
 	"source": "./src/extensions.ts",
@@ -18,9 +19,9 @@
 		"node >= 14"
 	],
 	"scripts": {
-		"dist": "microbundle --format modern",
-		"watch": "microbundle watch --format modern",
-		"watch:debug": "microbundle watch --format modern --no-compress"
+		"dist": "microbundle --format modern,cjs",
+		"watch": "microbundle watch --format modern,cjs",
+		"watch:debug": "microbundle watch --format modern,cjs --no-compress"
 	},
 	"keywords": [
 		"gltf",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -8,6 +8,7 @@
 	"license": "MIT",
 	"type": "module",
 	"sideEffects": false,
+	"main": "./dist/functions.cjs",
 	"module": "./dist/functions.modern.js",
 	"exports": "./dist/functions.modern.js",
 	"source": "./src/index.ts",
@@ -18,9 +19,9 @@
 		"node >= 14"
 	],
 	"scripts": {
-		"dist": "microbundle --format modern",
-		"watch": "microbundle watch --format modern",
-		"watch:debug": "microbundle watch --format modern --no-compress"
+		"dist": "microbundle --format modern,cjs",
+		"watch": "microbundle watch --format modern,cjs",
+		"watch:debug": "microbundle watch --format modern,cjs --no-compress"
 	},
 	"keywords": [
 		"gltf",


### PR DESCRIPTION
Partially reverts https://github.com/donmccurdy/glTF-Transform/pull/800 (which had not yet been released on a stable branch). As much as I'd like to, I don't feel safe about removing the CommonJS builds for the /core, /extensions, and /functions packages yet. The /cli package remains ESM-only, which is both safer and more necessary.