### PR TITLE
update readme forgotten imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To perform changes to an existing glTF [Document](https://gltf-transform.donmccu
 
 ```typescript
 // Import default functions.
-import { prune, dedup } from '@gltf-transform/functions';
+import { resample, prune, dedup, draco, textureCompress } from '@gltf-transform/functions';
 import * as sharp from 'sharp'; // Node.js only.
 
 await document.transform(


### PR DESCRIPTION
Some imports were missing on the `readme`

not a big deal but it's also cool when the code runs when you copy it