### PR TITLE
Fix IOR extension default value according to glTF spec

### DIFF
--- a/packages/extensions/src/khr-materials-ior/ior.ts
+++ b/packages/extensions/src/khr-materials-ior/ior.ts
@@ -23,7 +23,7 @@ export class IOR extends ExtensionProperty<IIOR> {
 	}
 
 	protected getDefaults(): Nullable<IIOR> {
-		return Object.assign(super.getDefaults() as IProperty, { ior: 0 });
+		return Object.assign(super.getDefaults() as IProperty, { ior: 1.5 });
 	}
 
 	/**********************************************************************************************


### PR DESCRIPTION
This PR fixes the IOR extension ior default value according to the glTF KHR_materials_ior extension spec at https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_ior/README.md

The default value was previously 0, with this PR it becomes 1.5.

