### PR TITLE
Avoid duplicate skins in quantize()

### DIFF
--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -120,7 +120,7 @@ const quantize = (_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transform => {
 
 		await doc.transform(
 			prune({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.SKIN, PropertyType.MATERIAL] }),
-			dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL] })
+			dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL, PropertyType.SKIN] })
 		);
 
 		logger.debug(`${NAME}: Complete.`);


### PR DESCRIPTION
- fixes #880 

When quantizing to mesh volumes, some splitting of skins is required. When quantizing to scene volumes, we can avoid it.