### PR TITLE
Improve default options for 'optimize' and 'simplify' stages

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -752,10 +752,6 @@ is indexed in place, without merging.
 		validator: program.NUMBER,
 		default: WELD_DEFAULTS.tolerance,
 	})
-	.option('--exhaustive', 'TODO', {
-		validator: program.BOOLEAN,
-		default: WELD_DEFAULTS.exhaustive,
-	})
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)
 			.transform(weld(options as unknown as WeldOptions))

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -17,9 +17,9 @@ const NAME = 'simplify';
 export interface SimplifyOptions {
 	/** MeshoptSimplifier instance. */
 	simplifier: unknown;
-	/** Target ratio (0–1) of vertices to keep. Default: 0.5 (50%). */
+	/** Target ratio (0–1) of vertices to keep. Default: 0.0 (0%). */
 	ratio?: number;
-	/** Limit on error, as a fraction of mesh radius. Default: 0.01 (1%). */
+	/** Limit on error, as a fraction of mesh radius. Default: 0.0001 (0.01%). */
 	error?: number;
 	/**
 	 * Whether to lock topological borders of the mesh. May be necessary when
@@ -30,8 +30,8 @@ export interface SimplifyOptions {
 }
 
 export const SIMPLIFY_DEFAULTS: Required<Omit<SimplifyOptions, 'simplifier'>> = {
-	ratio: 0.5,
-	error: 0.001,
+	ratio: 0.0,
+	error: 0.0001,
 	lockBorder: false,
 };
 
@@ -44,9 +44,9 @@ export const SIMPLIFY_DEFAULTS: Required<Omit<SimplifyOptions, 'simplifier'>> = 
  * error exceeds the specified 'error' threshold, the algorithm will quit
  * before reaching the target ratio. Examples:
  *
- * - ratio=0.5, error=0.001: Aims for 50% simplification, constrained to 0.1% error.
+ * - ratio=0.0, error=0.0001: Aims for maximum simplification, constrained to 0.01% error.
+ * - ratio=0.5, error=0.0001: Aims for 50% simplification, constrained to 0.01% error.
  * - ratio=0.5, error=1: Aims for 50% simplification, unconstrained by error.
- * - ratio=0.0, error=0.01: Aims for maximum simplification, constrained to 1% error.
  *
  * Topology, particularly split vertices, will also limit the simplifier. For
  * best results, apply a {@link weld} operation before simplification.

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -28,7 +28,7 @@ test('welded', async (t) => {
 	const srcCount = getVertexCount(document);
 	const srcBounds = roundBbox(getBounds(scene), 2);
 
-	await document.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
+	await document.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
 
 	const dstCount = getVertexCount(document);
 	const dstBounds = roundBbox(getBounds(scene), 2);
@@ -46,7 +46,7 @@ test('unwelded', async (t) => {
 	const srcCount = getVertexCount(document);
 	const srcBounds = roundBbox(getBounds(scene), 2);
 
-	await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
+	await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
 
 	const dstCount = getVertexCount(document);
 	const dstBounds = roundBbox(getBounds(scene), 2);


### PR DESCRIPTION
Current defaults allow a lot of variability - error can be quite high, constrained more by the simplification target ratio, and performance can be quite bad in some cases. Particularly, spending a lot of time welding vertices with a broad tolerance threshold.

From testing, it appears that disabling the target simplification ratio and lowering the error tolerance can improve both quality and performance in these cases.

- fixes #886 
- improves #738
- improves #902 