### PR TITLE
resample: only compute slerp when necessary

### DIFF
--- a/packages/functions/src/resample.ts
+++ b/packages/functions/src/resample.ts
@@ -109,9 +109,13 @@ function optimize(sampler: AnimationSampler, path: GLTF.AnimationChannelTargetPa
 
 			if (interpolation === 'LINEAR' && path === 'rotation') {
 				// Prune keyframes colinear with prev/next keyframes.
-				const sample = slerp(tmp as quat, valuePrev as quat, valueNext as quat, t) as number[];
 				const angle = getAngle(valuePrev as quat, value as quat) + getAngle(value as quat, valueNext as quat);
-				keep = !MathUtils.eq(value, sample, tolerance) || angle + Number.EPSILON >= Math.PI;
+				if (angle + Number.EPSILON >= Math.PI) {
+					keep = true;
+				} else {
+					const sample = slerp(tmp as quat, valuePrev as quat, valueNext as quat, t) as number[];
+					keep = !MathUtils.eq(value, sample, tolerance);
+				}
 			} else if (interpolation === 'LINEAR') {
 				// Prune keyframes colinear with prev/next keyframes.
 				const sample = vlerp(tmp, valuePrev, valueNext, t);


### PR DESCRIPTION
Currently when resampling quaternion keyframes, both `angle` and `sample` are computed, but not all of them are used for `keep`, for example, if result of `angle` is larger `Math.PI - Number.EPSILON`, value of `sample` is not needed since `keep` would be always true.

Alternative:
Only compute `angle` when necessary, compute `sample` using slerp first, and compute `angle` if they are close enough.

See also <https://github.com/donmccurdy/glTF-Transform/issues/501>