### PR TITLE
Weld before Draco compression

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -662,11 +662,7 @@ ${underline('References')}
 		default: DRACO_DEFAULTS.quantizationVolume,
 	})
 	.action(({ args, options, logger }) =>
-		// Include a lossless weld — Draco requires indices.
-		Session.create(io, logger, args.input, args.output).transform(
-			weld({ tolerance: 0 }),
-			draco(options as unknown as DracoOptions)
-		)
+		Session.create(io, logger, args.input, args.output).transform(draco(options as unknown as DracoOptions))
 	);
 
 // MESHOPT

--- a/packages/functions/src/draco.ts
+++ b/packages/functions/src/draco.ts
@@ -1,6 +1,7 @@
 import type { Document, Transform } from '@gltf-transform/core';
 import { KHRDracoMeshCompression } from '@gltf-transform/extensions';
 import { createTransform } from './utils.js';
+import { weld } from './weld.js';
 
 const NAME = 'draco';
 
@@ -36,8 +37,10 @@ export const DRACO_DEFAULTS: DracoOptions = {
  */
 export function draco(_options: DracoOptions = DRACO_DEFAULTS): Transform {
 	const options = { ...DRACO_DEFAULTS, ..._options } as Required<DracoOptions>;
-	return createTransform(NAME, (doc: Document): void => {
-		doc.createExtension(KHRDracoMeshCompression)
+	return createTransform(NAME, async (document: Document): Promise<void> => {
+		await document.transform(weld({ tolerance: 0 }));
+		document
+			.createExtension(KHRDracoMeshCompression)
 			.setRequired(true)
 			.setEncoderOptions({
 				method:


### PR DESCRIPTION
Draco requires indexed geometry. The CLI does a lossless weld automatically if required, but the `draco()` function does not.