### PR TITLE
Choosing mesh compression type per primitive

### DIFF
--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -291,6 +291,23 @@ export class EXTMeshoptCompression extends Extension {
 		this._encoderBufferViewData = {};
 		this._encoderBufferViewAccessors = {};
 
+		const accessorsToUse = new Set<number>();
+		for (const mesh of this.document.getRoot().listMeshes()) {
+			mesh.listPrimitives().forEach((prim, index) => {
+				if(index % 2 === 0) return;
+				prim.listAttributes().forEach((accessor) => {
+					const index = context.accessorIndexMap.get(accessor);
+					if (index !== undefined)
+						accessorsToUse.add(index)
+				});
+			});
+		}
+
+		if (accessorsToUse.size === 0) {
+			console.log("NO ACCESSORS TO USE");
+			throw new Error("NO ACCESSORS TO USE");
+		}
+
 		for (const accessor of this.document.getRoot().listAccessors()) {
 			// See: https://github.com/donmccurdy/glTF-Transform/pull/323#issuecomment-898791251
 			// Example: https://skfb.ly/6qAD8
@@ -298,6 +315,14 @@ export class EXTMeshoptCompression extends Extension {
 
 			// See: https://github.com/donmccurdy/glTF-Transform/issues/289
 			if (accessor.getSparse()) continue;
+
+			// Test: skip every 2nd buffer view
+			const accessorIndex = context.accessorIndexMap.get(accessor);
+			if (accessorIndex !== undefined && !accessorsToUse.has(accessorIndex)) {
+				console.log("skipping accessor " + accessorIndex);
+				continue;
+			}
+			console.log("MESHOPT: compressing accessor " + accessorIndex);
 
 			const usage = context.getAccessorUsage(accessor);
 			const mode = getMeshoptMode(accessor, usage);

--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -353,8 +353,17 @@ function listDracoPrimitives(doc: Document): Map<Primitive, string> {
 	const excluded = new Set<Primitive>();
 
 	// Support compressing only indexed, mode=TRIANGLES primitives.
+	let i = 0;
 	for (const mesh of doc.getRoot().listMeshes()) {
 		for (const prim of mesh.listPrimitives()) {
+			
+			if(i++ % 2 !== 0) 
+			{
+				logger.info(`[${NAME}] Skip Primitive ${i}.`);
+				continue;
+			}
+			logger.info(`[${NAME}] Select Primitive ${i}.`);
+
 			if (!prim.getIndices()) {
 				excluded.add(prim);
 				logger.warn(`[${NAME}] Skipping Draco compression on non-indexed primitive.`);


### PR DESCRIPTION
Hello,

[as suggested in the discussion](https://github.com/donmccurdy/glTF-Transform/discussions/925) here I've started adding the skips in draco 

and tried to add it to meshopt too but this is not yet working. I'm still including the commit here for talking about the approach (I tried skipping meshopt for every second primitive (or rather all accessors that are used by every second primitive)) 
