### PR TITLE
resample: Port keyframe resampling to WebAssembly

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-config-prettier": "8.8.0",
     "gl-matrix": "^3.4.3",
     "gltf-validator": "2.0.0-dev.3.9",
+    "keyframe-resample": "^0.0.14",
     "lerna": "6.6.2",
     "meshoptimizer": "0.19.0",
     "microbundle": "0.15.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
 		"draco3dgltf": "^1.5.6",
 		"gltf-validator": "^2.0.0-dev.3.9",
 		"inquirer": "^9.1.4",
+		"keyframe-resample": "^0.0.14",
 		"ktx-parse": "^0.5.0",
 		"language-tags": "^1.0.8",
 		"listr2": "^5.0.7",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1406,7 +1406,13 @@ and LINEAR interpolation. Resampling is nearly lossless, with configurable
 		default: 1e-4,
 	})
 	.action(({ args, options, logger }) =>
-		Session.create(io, logger, args.input, args.output).transform(resample(options as unknown as ResampleOptions))
+		Session.create(io, logger, args.input, args.output).transform(
+			resample({
+				ready: resampleReady,
+				resample: resampleWASM,
+				...(options as unknown as ResampleOptions),
+			})
+		)
 	);
 
 // SEQUENCE

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,6 +7,7 @@ import fetch from 'node-fetch';
 import mikktspace from 'mikktspace';
 import sharp from 'sharp';
 import { MeshoptEncoder, MeshoptSimplifier } from 'meshoptimizer';
+import { ready as resampleReady, resample as resampleWASM } from 'keyframe-resample';
 import { Logger, NodeIO, PropertyType, VertexLayout, vec2, Transform } from '@gltf-transform/core';
 import {
 	CenterOptions,
@@ -282,7 +283,11 @@ commands or using the scripting API.
 			transforms.push(weld());
 		}
 
-		transforms.push(resample(), prune({ keepAttributes: false, keepLeaves: false }), sparse());
+		transforms.push(
+			resample({ ready: resampleReady, resample: resampleWASM }),
+			prune({ keepAttributes: false, keepLeaves: false }),
+			sparse()
+		);
 
 		// Texture compression.
 		if (opts.textureCompress === 'ktx2') {

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -37,7 +37,7 @@
 	"dependencies": {
 		"@gltf-transform/core": "^3.2.1",
 		"@gltf-transform/extensions": "^3.2.1",
-		"keyframe-resample": "^0.0.7",
+		"keyframe-resample": "^0.0.8",
 		"ktx-parse": "^0.5.0",
 		"ndarray": "^1.0.19",
 		"ndarray-lanczos": "^0.3.0",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -23,8 +23,8 @@
 		"node >= 14"
 	],
 	"scripts": {
-		"dist": "microbundle --format modern,cjs --no-compress",
-		"watch": "microbundle watch --format modern,cjs --no-compress",
+		"dist": "microbundle --format modern,cjs",
+		"watch": "microbundle watch --format modern,cjs",
 		"watch:debug": "microbundle watch --format modern,cjs --no-compress"
 	},
 	"keywords": [

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -37,7 +37,6 @@
 	"dependencies": {
 		"@gltf-transform/core": "^3.2.1",
 		"@gltf-transform/extensions": "^3.2.1",
-		"keyframe-resample": "^0.0.8",
 		"ktx-parse": "^0.5.0",
 		"ndarray": "^1.0.19",
 		"ndarray-lanczos": "^0.3.0",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -23,8 +23,8 @@
 		"node >= 14"
 	],
 	"scripts": {
-		"dist": "microbundle --format modern,cjs",
-		"watch": "microbundle watch --format modern,cjs",
+		"dist": "microbundle --format modern,cjs --no-compress",
+		"watch": "microbundle watch --format modern,cjs --no-compress",
 		"watch:debug": "microbundle watch --format modern,cjs --no-compress"
 	},
 	"keywords": [
@@ -37,6 +37,7 @@
 	"dependencies": {
 		"@gltf-transform/core": "^3.2.1",
 		"@gltf-transform/extensions": "^3.2.1",
+		"keyframe-resample": "^0.0.7",
 		"ktx-parse": "^0.5.0",
 		"ndarray": "^1.0.19",
 		"ndarray-lanczos": "^0.3.0",

--- a/packages/functions/src/instance.ts
+++ b/packages/functions/src/instance.ts
@@ -36,13 +36,14 @@ export function instance(_options: InstanceOptions = INSTANCE_DEFAULTS): Transfo
 	return createTransform(NAME, (doc: Document): void => {
 		const logger = doc.getLogger();
 		const root = doc.getRoot();
-		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
 
 		if (root.listAnimations().length) {
 			logger.warn(`${NAME}: Instancing is not currently supported for animated models.`);
 			logger.debug(`${NAME}: Complete.`);
 			return;
 		}
+
+		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
 
 		let numBatches = 0;
 		let numInstances = 0;

--- a/packages/functions/src/resample.ts
+++ b/packages/functions/src/resample.ts
@@ -16,6 +16,8 @@ import { resampleDebug } from 'keyframe-resample';
 
 const NAME = 'resample';
 
+const EMPTY_ARRAY = new Float32Array(0);
+
 export interface ResampleOptions {
 	ready?: Promise<void>;
 	resample?: typeof resampleDebug;
@@ -92,8 +94,16 @@ export function resample(_options: ResampleOptions = RESAMPLE_DEFAULTS): Transfo
 					}
 
 					if (dstCount < srcCount) {
+						// Clone the input/output accessors, without cloning their underlying
+						// arrays. Then assign the resampled data.
+						const inputArray = input.getArray()!;
+						const outputArray = output.getArray()!;
+						input.setArray(EMPTY_ARRAY);
+						output.setArray(EMPTY_ARRAY);
 						sampler.setInput(input.clone().setArray(times.slice(0, dstCount)));
 						sampler.setOutput(output.clone().setArray(values.slice(0, dstCount * elementSize)));
+						input.setArray(inputArray);
+						output.setArray(outputArray);
 					}
 				}
 			}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5779,6 +5779,11 @@ just-diff@^6.0.0:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-6.0.2.tgz#03b65908543ac0521caf6d8eb85035f7d27ea285"
   integrity sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==
 
+keyframe-resample@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/keyframe-resample/-/keyframe-resample-0.0.7.tgz#e5ea38e04220d4f0d774a1a2dccbcdc45270fd4b"
+  integrity sha512-hmOOwBIzAP8oTORplB16TkvIikJ/RylsObuurZTlWx858mJwIPBJXx2NyJtZLj04mCNkGZUT0IDPy4pByDiRvg==
+
 kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5779,10 +5779,10 @@ just-diff@^6.0.0:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-6.0.2.tgz#03b65908543ac0521caf6d8eb85035f7d27ea285"
   integrity sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==
 
-keyframe-resample@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/keyframe-resample/-/keyframe-resample-0.0.8.tgz#80f2197f4d64b0a233e55566964898de8986710b"
-  integrity sha512-rcXBs4MySZu4WuIPEgNlKzhxjdyNa7yqQCOENJrK9BQI9ba+/NbgkJNfgMNyng7F+H7r+y7Hjwdi6OFclhp6aA==
+keyframe-resample@^0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/keyframe-resample/-/keyframe-resample-0.0.14.tgz#0bd6af293d08ab5f149ba4766818cbb957378b45"
+  integrity sha512-6rUeRnOlA7QvCgb4+4akR74kgVEGobcEFMCbkDmPMykPeQ5b81a1/03iIO+vNrYudRH0rYMMPmIB8mPxdxSY9w==
 
 kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5779,10 +5779,10 @@ just-diff@^6.0.0:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-6.0.2.tgz#03b65908543ac0521caf6d8eb85035f7d27ea285"
   integrity sha512-S59eriX5u3/QhMNq3v/gm8Kd0w8OS6Tz2FS1NG4blv+z0MuQcBRJyFWjdovM0Rad4/P4aUPFtnkNjMjyMlMSYA==
 
-keyframe-resample@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/keyframe-resample/-/keyframe-resample-0.0.7.tgz#e5ea38e04220d4f0d774a1a2dccbcdc45270fd4b"
-  integrity sha512-hmOOwBIzAP8oTORplB16TkvIikJ/RylsObuurZTlWx858mJwIPBJXx2NyJtZLj04mCNkGZUT0IDPy4pByDiRvg==
+keyframe-resample@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/keyframe-resample/-/keyframe-resample-0.0.8.tgz#80f2197f4d64b0a233e55566964898de8986710b"
+  integrity sha512-rcXBs4MySZu4WuIPEgNlKzhxjdyNa7yqQCOENJrK9BQI9ba+/NbgkJNfgMNyng7F+H7r+y7Hjwdi6OFclhp6aA==
 
 kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"


### PR DESCRIPTION
As discussed in #922, the resample() function currently spends a lot of time in resource graph operations. Rewriting it to operate directly on the underlying accessor arrays improves performance dramatically (170ms → 60ms for my 800,000 keyframe test dataset on M1 mac). Rewriting the logic in optimized WebAssembly gets even greater savings (170ms → 20ms).

The WebAssembly code is compiled from AssemblyScript, and will be maintained in a separate repository (https://github.com/donmccurdy/keyframe-resample-wasm).  

***

- Fixes #922 
- Fixes #290 

***

Major thanks to @kzhsw for extensive research, prototyping, and advice in #922. 