### PR TITLE
Avoid updating Listr2 until I can sunset Node 14 support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,13 @@
                 "typedoc"
             ],
             "enabled": false
-        }
+        },
+        {
+          "description": "Node.js v14 EOL",
+          "matchPackageNames": [
+              "listr2"
+          ],
+          "enabled": false
+      }
     ]
 }


### PR DESCRIPTION
Node.js v14 has reached EOL (https://nodejs.dev/en/about/releases/). I'm not quite ready to drop support in this repository yet, but my dependencies have started to do so already. This PR creates a list of affected dependencies to prevent Renovate from trying to update them until Node.js v14 is no longer supported here.