### PR TITLE
Add getTextureColorSpace(texture), fix inference on diffuse texture

### DIFF
--- a/packages/cli/src/transforms/ktxfix.ts
+++ b/packages/cli/src/transforms/ktxfix.ts
@@ -1,8 +1,6 @@
 import { KHR_DF_PRIMARIES_BT709, KHR_DF_PRIMARIES_UNSPECIFIED, read, write } from 'ktx-parse';
 import type { Document, Transform } from '@gltf-transform/core';
-import { MICROMATCH_OPTIONS } from '../util.js';
-import { listTextureSlots } from '@gltf-transform/functions';
-import micromatch from 'micromatch';
+import { getTextureColorSpace, listTextureSlots } from '@gltf-transform/functions';
 
 const NAME = 'ktxfix';
 
@@ -25,8 +23,8 @@ export function ktxfix(): Transform {
 			// Don't make changes if we have no information.
 			if (slots.length === 0) continue;
 
-			const isLinear = !slots.find((slot) => micromatch.isMatch(slot, '*{color,emissive}*', MICROMATCH_OPTIONS));
-			const colorPrimaries = isLinear ? KHR_DF_PRIMARIES_UNSPECIFIED : KHR_DF_PRIMARIES_BT709;
+			const colorSpace = getTextureColorSpace(texture);
+			const colorPrimaries = colorSpace === 'srgb' ? KHR_DF_PRIMARIES_BT709 : KHR_DF_PRIMARIES_UNSPECIFIED;
 			const name = texture.getURI() || texture.getName();
 
 			let changed = false;

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -309,7 +309,7 @@ function createParams(
 		}
 	}
 
-	if (getTextureColorSpace(texture) !== 'srgb') {
+	if (slots.length && getTextureColorSpace(texture) !== 'srgb') {
 		// See: https://github.com/donmccurdy/glTF-Transform/issues/215
 		params.push('--assign_oetf', 'linear', '--assign_primaries', 'none');
 	}

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -7,9 +7,24 @@ import semver from 'semver';
 import tmp from 'tmp';
 import pLimit from 'p-limit';
 
-import { Document, FileUtils, ILogger, ImageUtils, TextureChannel, Transform, vec2, uuid } from '@gltf-transform/core';
+import {
+	Document,
+	FileUtils,
+	ILogger,
+	ImageUtils,
+	TextureChannel,
+	Transform,
+	vec2,
+	uuid,
+	Texture,
+} from '@gltf-transform/core';
 import { KHRTextureBasisu } from '@gltf-transform/extensions';
-import { createTransform, getTextureChannelMask, listTextureSlots } from '@gltf-transform/functions';
+import {
+	createTransform,
+	getTextureChannelMask,
+	getTextureColorSpace,
+	listTextureSlots,
+} from '@gltf-transform/functions';
 import { spawn, commandExists, formatBytes, waitExit, MICROMATCH_OPTIONS } from '../util.js';
 
 tmp.setGracefulCleanup();
@@ -178,7 +193,7 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 				await fs.writeFile(inPath, Buffer.from(image));
 
 				const params = [
-					...createParams(slots, channels, size, logger, numTextures, options, version),
+					...createParams(texture, slots, channels, size, logger, numTextures, options, version),
 					outPath,
 					inPath,
 				];
@@ -230,6 +245,7 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 
 /** Create CLI parameters from the given options. Attempts to write only non-default options. */
 function createParams(
+	texture: Texture,
 	slots: string[],
 	channels: number,
 	size: vec2,
@@ -293,7 +309,7 @@ function createParams(
 		}
 	}
 
-	if (slots.length && !slots.find((slot) => micromatch.isMatch(slot, '*{color,emissive}*', MICROMATCH_OPTIONS))) {
+	if (getTextureColorSpace(texture) !== 'srgb') {
 		// See: https://github.com/donmccurdy/glTF-Transform/issues/215
 		params.push('--assign_oetf', 'linear', '--assign_primaries', 'none');
 	}

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -241,7 +241,7 @@ export class Material extends ExtensibleProperty<IMaterial> {
 
 	/** Sets base color / albedo texture. See {@link getBaseColorTexture}. */
 	public setBaseColorTexture(texture: Texture | null): this {
-		return this.setRef('baseColorTexture', texture, { channels: R | G | B | A, colorSpace: 'srgb' });
+		return this.setRef('baseColorTexture', texture, { channels: R | G | B | A, isColor: true });
 	}
 
 	/**********************************************************************************************
@@ -292,7 +292,7 @@ export class Material extends ExtensibleProperty<IMaterial> {
 
 	/** Sets emissive texture. See {@link getEmissiveTexture}. */
 	public setEmissiveTexture(texture: Texture | null): this {
-		return this.setRef('emissiveTexture', texture, { channels: R | G | B, colorSpace: 'srgb' });
+		return this.setRef('emissiveTexture', texture, { channels: R | G | B, isColor: true });
 	}
 
 	/**********************************************************************************************

--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -241,7 +241,7 @@ export class Material extends ExtensibleProperty<IMaterial> {
 
 	/** Sets base color / albedo texture. See {@link getBaseColorTexture}. */
 	public setBaseColorTexture(texture: Texture | null): this {
-		return this.setRef('baseColorTexture', texture, { channels: R | G | B | A });
+		return this.setRef('baseColorTexture', texture, { channels: R | G | B | A, colorSpace: 'srgb' });
 	}
 
 	/**********************************************************************************************
@@ -292,7 +292,7 @@ export class Material extends ExtensibleProperty<IMaterial> {
 
 	/** Sets emissive texture. See {@link getEmissiveTexture}. */
 	public setEmissiveTexture(texture: Texture | null): this {
-		return this.setRef('emissiveTexture', texture, { channels: R | G | B });
+		return this.setRef('emissiveTexture', texture, { channels: R | G | B, colorSpace: 'srgb' });
 	}
 
 	/**********************************************************************************************

--- a/packages/core/src/utils/property-utils.ts
+++ b/packages/core/src/utils/property-utils.ts
@@ -113,10 +113,11 @@ export interface TextureRefAttributes extends RefAttributes {
 	/** Bitmask for {@link TextureChannel TextureChannels} used by a texture reference. */
 	channels: number;
 	/**
-	 * Color space identifier, as defined by CSS Color Module Level 4. For all
-	 * current glTF textures, this property must be 'srgb' or undefined.
+	 * Specifies that the texture contains color data (base color, emissive, …),
+	 * rather than non-color data (normal maps, metallic roughness, …). Used
+	 * when tuning texture compression settings.
 	 */
-	colorSpace?: string;
+	isColor?: boolean;
 }
 
 export function isArray(value: unknown): boolean {

--- a/packages/core/src/utils/property-utils.ts
+++ b/packages/core/src/utils/property-utils.ts
@@ -112,6 +112,11 @@ export interface AccessorRefAttributes extends RefAttributes {
 export interface TextureRefAttributes extends RefAttributes {
 	/** Bitmask for {@link TextureChannel TextureChannels} used by a texture reference. */
 	channels: number;
+	/**
+	 * Color space identifier, as defined by CSS Color Module Level 4. For all
+	 * current glTF textures, this property must be 'srgb' or undefined.
+	 */
+	colorSpace?: string;
 }
 
 export function isArray(value: unknown): boolean {

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -96,7 +96,7 @@ export class PBRSpecularGlossiness extends ExtensionProperty<IPBRSpecularGlossin
 
 	/** Sets diffuse texture. See {@link getDiffuseTexture}. */
 	public setDiffuseTexture(texture: Texture | null): this {
-		return this.setRef('diffuseTexture', texture, { channels: R | G | B | A });
+		return this.setRef('diffuseTexture', texture, { channels: R | G | B | A, colorSpace: 'srgb' });
 	}
 
 	/**********************************************************************************************

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -96,7 +96,7 @@ export class PBRSpecularGlossiness extends ExtensionProperty<IPBRSpecularGlossin
 
 	/** Sets diffuse texture. See {@link getDiffuseTexture}. */
 	public setDiffuseTexture(texture: Texture | null): this {
-		return this.setRef('diffuseTexture', texture, { channels: R | G | B | A, colorSpace: 'srgb' });
+		return this.setRef('diffuseTexture', texture, { channels: R | G | B | A, isColor: true });
 	}
 
 	/**********************************************************************************************

--- a/packages/extensions/src/khr-materials-sheen/sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/sheen.ts
@@ -92,7 +92,7 @@ export class Sheen extends ExtensionProperty<ISheen> {
 
 	/** Sets sheen color texture. See {@link getSheenColorTexture}. */
 	public setSheenColorTexture(texture: Texture | null): this {
-		return this.setRef('sheenColorTexture', texture, { channels: R | G | B });
+		return this.setRef('sheenColorTexture', texture, { channels: R | G | B, colorSpace: 'srgb' });
 	}
 
 	/**********************************************************************************************

--- a/packages/extensions/src/khr-materials-sheen/sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/sheen.ts
@@ -92,7 +92,7 @@ export class Sheen extends ExtensionProperty<ISheen> {
 
 	/** Sets sheen color texture. See {@link getSheenColorTexture}. */
 	public setSheenColorTexture(texture: Texture | null): this {
-		return this.setRef('sheenColorTexture', texture, { channels: R | G | B, colorSpace: 'srgb' });
+		return this.setRef('sheenColorTexture', texture, { channels: R | G | B, isColor: true });
 	}
 
 	/**********************************************************************************************

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -131,6 +131,6 @@ export class Specular extends ExtensionProperty<ISpecular> {
 
 	/** Sets specular color texture. See {@link getSpecularColorTexture}. */
 	public setSpecularColorTexture(texture: Texture | null): this {
-		return this.setRef('specularColorTexture', texture, { channels: R | G | B });
+		return this.setRef('specularColorTexture', texture, { channels: R | G | B, colorSpace: 'srgb' });
 	}
 }

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -131,6 +131,6 @@ export class Specular extends ExtensionProperty<ISpecular> {
 
 	/** Sets specular color texture. See {@link getSpecularColorTexture}. */
 	public setSpecularColorTexture(texture: Texture | null): this {
-		return this.setRef('specularColorTexture', texture, { channels: R | G | B, colorSpace: 'srgb' });
+		return this.setRef('specularColorTexture', texture, { channels: R | G | B, isColor: true });
 	}
 }

--- a/packages/functions/src/get-texture-color-space.ts
+++ b/packages/functions/src/get-texture-color-space.ts
@@ -1,0 +1,33 @@
+import { Texture } from '@gltf-transform/core';
+
+const SRGB_PATTERN = /color|emissive|diffuse/i;
+
+/**
+ * Returns the color space (if any) implied by the {@link Material} slots to
+ * which a texture is assigned, or null for non-color textures. If the texture
+ * is not connected to any {@link Material}, this function will also return
+ * null — any metadata in the image file will be ignored.
+ *
+ * Under current glTF specifications, only 'srgb' and non-color (null) textures
+ * are used.
+ *
+ * Example:
+ *
+ * ```typescript
+ * import { getTextureColorSpace } from '@gltf-transform/functions';
+ *
+ * const baseColorTexture = material.getBaseColorTexture();
+ * const normalTexture = material.getNormalTexture();
+ *
+ * getTextureColorSpace(baseColorTexture); // → 'srgb'
+ * getTextureColorSpace(normalTexture); // → null
+ * ```
+ */
+export function getTextureColorSpace(texture: Texture): string | null {
+	const graph = texture.getGraph();
+	const edges = graph.listParentEdges(texture);
+	const isSRGB = edges.some((edge) => {
+		return edge.getAttributes().colorSpace === 'srgb' || SRGB_PATTERN.test(edge.getName());
+	});
+	return isSRGB ? 'srgb' : null;
+}

--- a/packages/functions/src/get-texture-color-space.ts
+++ b/packages/functions/src/get-texture-color-space.ts
@@ -27,7 +27,7 @@ export function getTextureColorSpace(texture: Texture): string | null {
 	const graph = texture.getGraph();
 	const edges = graph.listParentEdges(texture);
 	const isSRGB = edges.some((edge) => {
-		return edge.getAttributes().colorSpace === 'srgb' || SRGB_PATTERN.test(edge.getName());
+		return edge.getAttributes().isColor || SRGB_PATTERN.test(edge.getName());
 	});
 	return isSRGB ? 'srgb' : null;
 }

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -58,6 +58,7 @@ export * from './dequantize.js';
 export * from './draco.js';
 export * from './flatten.js';
 export * from './get-node-scene.js';
+export * from './get-texture-color-space.js';
 export * from './inspect.js';
 export * from './instance.js';
 export * from './join-primitives.js';


### PR DESCRIPTION
- fixes #943 

Example:

```typescript
import { getTextureColorSpace } from '@gltf-transform/functions';

const baseColorTexture = material.getBaseColorTexture();
const normalTexture = material.getNormalTexture();

getTextureColorSpace(baseColorTexture); // → 'srgb'
getTextureColorSpace(normalTexture); // → null
```