### PR TITLE
chore(ci): Add CI for windows local build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,23 @@ jobs:
     - uses: codecov/codecov-action@v4
       with:
         files: coverage/coverage.lcov
+
+  #############################################################################
+  # WINDOWS LOCAL BUILDS
+  windows:
+    runs-on: windows-latest
+    env:
+      CI: true
+      NODE_VERSION: 18.x
+    steps:
+    # Setup.
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: yarn
+
+    # Build.
+    - run: yarn install --frozen-lockfile
+    - run: yarn dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,106 +1,107 @@
 name: build
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 jobs:
-  #############################################################################
-  # NODE
-  node:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # See: https://github.com/privatenumber/tsx/issues/354
-        node-version: [v18, v20]
-    env:
-      CI: true
-    steps:
-    # Setup.
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: yarn
+    #############################################################################
+    # NODE
+    node:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                # See: https://github.com/privatenumber/tsx/issues/354
+                node-version: [v18, v20]
+        env:
+            CI: true
+        steps:
+            # Setup.
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: yarn
 
-    # Build.
-    - run: yarn install --frozen-lockfile
-    - run: yarn dist
+            # Build.
+            - run: yarn install --frozen-lockfile
+            - run: yarn dist
 
-    # Test.
-    - run: yarn test
-    - run: yarn lint
+            # Test.
+            - run: yarn test
+            - run: yarn lint
 
-  #############################################################################
-  # DENO
-  deno:
-    runs-on: ubuntu-latest
-    env:
-      CI: true
-      NODE_VERSION: v18
-    steps:
-    # Setup.
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - uses: denoland/setup-deno@v1
-      with:
-        deno-version: v1.x
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: yarn
+    #############################################################################
+    # DENO
+    deno:
+        runs-on: ubuntu-latest
+        env:
+            CI: true
+            NODE_VERSION: v18
+        steps:
+            # Setup.
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - uses: denoland/setup-deno@v1
+              with:
+                  deno-version: v1.x
+            - name: Use Node.js ${{ env.NODE_VERSION }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: yarn
 
-    # Build.
-    - run: yarn install --frozen-lockfile
-    - run: yarn dist
+            # Build.
+            - run: yarn install --frozen-lockfile
+            - run: yarn dist
 
-    # Test.
-    - run: deno test --allow-read --config scripts/deno.json scripts/deno.test.ts
+            # Test.
+            - run: deno test --allow-read --config scripts/deno.json scripts/deno.test.ts
 
-  #############################################################################
-  # COVERAGE
-  coverage:
-    runs-on: ubuntu-latest
-    env:
-      CI: true
-      NODE_VERSION: v18
-    steps:
-    # Setup.
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: yarn
+    #############################################################################
+    # COVERAGE
+    coverage:
+        runs-on: ubuntu-latest
+        env:
+            CI: true
+            NODE_VERSION: v18
+        steps:
+            # Setup.
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - name: Use Node.js ${{ env.NODE_VERSION }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: yarn
 
-    # Build.
-    - run: yarn install --frozen-lockfile
-    - run: yarn dist
+            # Build.
+            - run: yarn install --frozen-lockfile
+            - run: yarn dist
 
-    # Coverage.
-    - run: yarn coverage
-    - run: yarn coverage:report
-    - uses: codecov/codecov-action@v4
-      with:
-        files: coverage/coverage.lcov
+            # Coverage.
+            - run: yarn coverage
+            - run: yarn coverage:report
+            - uses: codecov/codecov-action@v4
+              with:
+                  files: coverage/coverage.lcov
 
-  #############################################################################
-  # WINDOWS LOCAL BUILDS
-  windows:
-    runs-on: windows-latest
-    env:
-      CI: true
-      NODE_VERSION: 18.x
-    steps:
-    # Setup.
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ env.NODE_VERSION }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ env.NODE_VERSION }}
-        cache: yarn
+    #############################################################################
+    # WINDOWS LOCAL BUILDS
+    windows:
+        runs-on: windows-latest
+        env:
+            CI: true
+            NODE_VERSION: 18.x
+        steps:
+            # Setup.
+            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+            - name: Use Node.js ${{ env.NODE_VERSION }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ env.NODE_VERSION }}
+                  cache: yarn
 
-    # Build.
-    - run: yarn install --frozen-lockfile
-    - run: yarn dist
+            # Build.
+            # See: https://github.com/yarnpkg/yarn/issues/4890
+            - run: yarn install --frozen-lockfile --network-timeout 100000
+            - run: yarn dist

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -17,6 +17,7 @@
 		"@sveltejs/adapter-static": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
+		"@types/he": "^1.2.3",
 		"he": "^1.2.0",
 		"highlight.js": "^11.8.0",
 		"mdsvex": "^0.11.0",

--- a/packages/docs/src/lib/server/model/index.ts
+++ b/packages/docs/src/lib/server/model/index.ts
@@ -1,12 +1,16 @@
 import { Encoder, GD, Parser, createPrefixSort } from '@greendoc/parse';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Project } from 'ts-morph';
 import he from 'he';
 
-const BASE = new URL('../../../../../../', import.meta.url).pathname.replace(/\/$/, '');
+const ROOT_DELTA = '../../../../../../';
+const ROOT_FILE_PATH = resolve(dirname(fileURLToPath(import.meta.url)), ROOT_DELTA);
+const ROOT_WEB_PATH = new URL(ROOT_DELTA, import.meta.url).pathname.replace(/\/$/, '');
 
-const corePath = `${BASE}/packages/core/src/index.ts`;
-const extensionsPath = `${BASE}/packages/extensions/src/index.ts`;
-const functionsPath = `${BASE}/packages/functions/src/index.ts`;
+const corePath = resolve(ROOT_FILE_PATH, `packages/core/src/index.ts`);
+const extensionsPath = resolve(ROOT_FILE_PATH, `packages/extensions/src/index.ts`);
+const functionsPath = resolve(ROOT_FILE_PATH, `packages/functions/src/index.ts`);
 
 const project = new Project({
 	compilerOptions: {
@@ -22,7 +26,7 @@ export const parser = new Parser(project)
 	.addModule({ name: '@gltf-transform/core', slug: 'core', entry: corePath })
 	.addModule({ name: '@gltf-transform/extensions', slug: 'extensions', entry: extensionsPath })
 	.addModule({ name: '@gltf-transform/functions', slug: 'functions', entry: functionsPath })
-	.setRootPath(BASE)
+	.setRootPath(ROOT_WEB_PATH)
 	.setBaseURL('https://github.com/donmccurdy/glTF-Transform/tree/main')
 	.init();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,6 +2196,11 @@
     "@types/minimatch" "^5.1.2"
     "@types/node" "*"
 
+"@types/he@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/he/-/he-1.2.3.tgz#c33ca3096f30cbd5d68d78211572de3f9adff75a"
+  integrity sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==
+
 "@types/inquirer@~9.0.3":
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-9.0.7.tgz#61bb8d0e42f038b9a1738b08fba7fa98ad9b4b24"


### PR DESCRIPTION
Documentation currently does not build on Windows.

This PR adds only a failing test for now, I still need to debug the cause. 

Workaround to build on Windows, without documentation, would be:

```
yarn run dist --ignore "@gltf-transform/docs"
```