### PR TITLE
Draft: Set up Lerna/Nx task caching and watch commands

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,24 @@
+{
+	"tasksRunnerOptions": {
+		"default": {
+			"runner": "nx/tasks-runners/default",
+			"options": {
+				"cacheableOperations": ["dist", "watch", "watch:debug", "lint"]
+			}
+		}
+	},
+	"targetDefaults": {
+		"dist": {
+			"dependsOn": ["^dist"],
+			"outputs": ["{projectRoot}/dist", "{projectRoot}/build", "{projectRoot}/.svelte-kit"]
+		},
+		"watch": {
+			"dependsOn": ["^watch"],
+			"outputs": ["{projectRoot}/dist", "{projectRoot}/build", "{projectRoot}/.svelte-kit"]
+		},
+		"watch:debug": {
+			"dependsOn": ["^watch:debug"],
+			"outputs": ["{projectRoot}/dist", "{projectRoot}/build", "{projectRoot}/.svelte-kit"]
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
 	"type": "module",
 	"scripts": {
 		"dist": "lerna run dist",
-		"watch": "lerna run watch --parallel --stream",
-		"watch:debug": "lerna run watch:debug --parallel --stream",
+		"watch": "lerna watch -- lerna run dist --scope=$LERNA_PACKAGE_NAME --include-dependents",
+		"watch:debug": "lerna watch -- lerna run dist:debug --scope=$LERNA_PACKAGE_NAME --include-dependents",
 		"clean:dist": "rm -rf packages/*/dist/**",
 		"clean:deps": "rm -rf packages/*/node_modules/**",
 		"test": "ava packages/{core,extensions,functions,cli}/test/**/*.test.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,8 +18,7 @@
 	},
 	"scripts": {
 		"dist": "microbundle --format esm --target node",
-		"watch": "microbundle watch --format esm --target node",
-		"watch:debug": "microbundle watch --no-compress --format esm --target node"
+		"dist:debug": "microbundle --format esm --target node --no-compress"
 	},
 	"bin": {
 		"gltf-transform": "./bin/cli.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,8 +24,7 @@
 	],
 	"scripts": {
 		"dist": "microbundle --format modern,cjs --define PACKAGE_VERSION=$npm_package_version",
-		"watch": "microbundle watch --format modern,cjs --define PACKAGE_VERSION=$npm_package_version",
-		"watch:debug": "microbundle watch --format modern,cjs --define PACKAGE_VERSION=$npm_package_version --no-compress"
+		"dist:debug": "microbundle --format modern,cjs --define PACKAGE_VERSION=$npm_package_version --no-compress"
 	},
 	"keywords": [
 		"gltf",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -25,5 +25,11 @@
 		"tslib": "^2.4.1",
 		"vite": "^4.3.0"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"@gltf-transform/cli": "^3.3.1",
+		"@gltf-transform/core": "^3.3.1",
+		"@gltf-transform/extensions": "^3.3.1",
+		"@gltf-transform/functions": "^3.3.1"
+	}
 }

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -3,5 +3,5 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
 	plugins: [sveltekit()],
-	server: { port: 3000 }
+	server: { port: 3000 },
 });

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -24,8 +24,7 @@
 	],
 	"scripts": {
 		"dist": "microbundle --format modern,cjs",
-		"watch": "microbundle watch --format modern,cjs",
-		"watch:debug": "microbundle watch --format modern,cjs --no-compress"
+		"dist:debug": "microbundle --format modern,cjs --no-compress"
 	},
 	"keywords": [
 		"gltf",

--- a/packages/extensions/src/constants.ts
+++ b/packages/extensions/src/constants.ts
@@ -20,3 +20,4 @@ export const KHR_MESH_QUANTIZATION = 'KHR_mesh_quantization';
 export const KHR_TEXTURE_BASISU = 'KHR_texture_basisu';
 export const KHR_TEXTURE_TRANSFORM = 'KHR_texture_transform';
 export const KHR_XMP_JSON_LD = 'KHR_xmp_json_ld';
+export const WHATEVER = 'foo23';

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -24,8 +24,7 @@
 	],
 	"scripts": {
 		"dist": "microbundle --format modern,cjs",
-		"watch": "microbundle watch --format modern,cjs",
-		"watch:debug": "microbundle watch --format modern,cjs --no-compress"
+		"dist:debug": "microbundle --format modern,cjs --no-compress"
 	},
 	"keywords": [
 		"gltf",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -8,8 +8,7 @@
 	"source": "./src/index.ts",
 	"types": "./dist/index.d.ts",
 	"scripts": {
-		"dist": "microbundle --format modern --no-compress",
-		"watch": "microbundle watch --format modern --no-compress"
+		"dist": "microbundle --format modern --no-compress"
 	},
 	"dependencies": {
 		"@gltf-transform/core": "^3.3.1",


### PR DESCRIPTION
Attempting to enable [task result caching](https://lerna.js.org/docs/features/cache-tasks) and [workspace watching](https://lerna.js.org/docs/features/workspace-watching) with Lerna/Nx. The first should just speed up builds. The second allows build updates to cascade among packages, such that if /extensions changes, /functions and /cli will rebuild after it in succession. 


My current development build system uses Microbundle's "watch" feature, which is not workspace-aware, and doesn't cascade rebuilds from one package to the next. This is rarely an issue, but if Lerna/Nx can fix it and speed up builds at the same time, that'd be great.

Current blocker – the watcher gets caught in an infinite loop watching the "docs" package rebuild repeatedly. Maybe something to do with outputs being in a folder other than /dist, though I think I've handled that in the PR...

Possibly related:

- https://github.com/lerna/lerna/issues/3630
- https://github.com/nrwl/nx/issues/14038
- https://github.com/lerna/lerna/issues/3630