### PR TITLE
add debug info for when draco mesh compression fails on encoding

### DIFF
--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -265,7 +265,7 @@ export class KHRDracoMeshCompression extends Extension {
 				encodedPrim = encodeGeometry(prim, { ...this._encoderOptions, quantizationVolume });
 			} catch (e) {
 				if (e instanceof EncodingError) {
-					logger.warn(`[${NAME}]: ${e.message} Skipping primitive compression.`);
+					logger.warn(`[${NAME}]: ${e.message} Skipping primitive compression – ( name "${prim.getName()}", material "${prim.getMaterial()?.getName()}" )`)
 					continue;
 				}
 				throw e;


### PR DESCRIPTION
When mesh compression fails it can be helpful to know which primitive is causing the exception to have some 'actionable' information

For context: we currently have a bugreport where a model with blend-shapes is causing draco compression to fail
Probably related to https://github.com/donmccurdy/glTF-Transform/issues/693 or https://github.com/google/draco/issues/929

related issue: https://github.com/donmccurdy/glTF-Transform/issues/978