### PR TITLE
Check if any accessorEdges exist to avoid getParent exception

### DIFF
--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -423,10 +423,12 @@ export class GLTFWriter {
 			// For accessor usage that requires grouping by parent (vertex and instance
 			// attributes) organize buffer views accordingly.
 			if (groupByParent.has(usage)) {
-				const parent = accessorEdges[0].getParent();
-				const parentAccessors = accessorParents.get(parent) || new Set<Accessor>();
-				parentAccessors.add(accessor);
-				accessorParents.set(parent, parentAccessors);
+				if(accessorEdges.length > 0){
+					const parent = accessorEdges[0].getParent();
+					const parentAccessors = accessorParents.get(parent) || new Set<Accessor>();
+					parentAccessors.add(accessor);
+					accessorParents.set(parent, parentAccessors);
+				}
 			}
 		});
 


### PR DESCRIPTION
Related to https://github.com/donmccurdy/glTF-Transform/issues/978

I'm not sure if this is the correct spot to fix it as it should not get to this point and `context.accessorUsageGroupedByParent` should probably not contain the usage.


--- 

Alternative solution I tried (but didnt work) was removing the primitive from the encoding map when draco compression failed:

![image](https://github.com/donmccurdy/glTF-Transform/assets/5083203/54fb651e-6267-4f48-a39f-bf5492f4a238)
