### PR TITLE
Draco: Skip vertex deduplication where required

### DIFF
--- a/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/encoder.ts
@@ -124,7 +124,9 @@ export function encodeGeometry(prim: Primitive, _options: EncoderOptions = DEFAU
 	encoder.SetSpeedOptions(options.encodeSpeed, options.decodeSpeed);
 	encoder.SetTrackEncodedProperties(true);
 
-	if (options.method === EncoderMethod.SEQUENTIAL) {
+	// TODO(cleanup): Use edgebreaker without deduplication if possible.
+	// See https://github.com/google/draco/issues/929.
+	if (options.method === EncoderMethod.SEQUENTIAL || hasMorphTargets || hasSparseAttributes) {
 		encoder.SetEncodingMethod(encoderModule.MESH_SEQUENTIAL_ENCODING);
 	} else {
 		encoder.SetEncodingMethod(encoderModule.MESH_EDGEBREAKER_ENCODING);


### PR DESCRIPTION
Updates Draco compression to use the ExpertEncoder API. This allows us to explicitly disable vertex deduplication when required for morph targets or sparse accessors, rather than forcing sequential encoding and hoping for the best (which sometimes failed).

Related:

- Fixes #978 
- Fixes #618
- Resolves #979
- Related #977
- Related https://github.com/google/draco/issues/929

cc @marwie @hybridherbst