### PR TITLE
Fix transformations of meshes with multiple vertex streams

### DIFF
--- a/packages/functions/src/transform-mesh.ts
+++ b/packages/functions/src/transform-mesh.ts
@@ -70,8 +70,19 @@ export function transformMesh(mesh: Mesh, matrix: mat4, overwrite = false, skipI
 	}
 
 	// (3) Apply transform.
-	skipIndices = skipIndices || new Set<number>();
+	const attributeSkipIndices = new Map<Accessor, Set<number>>();
 	for (const prim of mesh.listPrimitives()) {
-		transformPrimitive(prim, matrix, skipIndices);
+		const position = prim.getAttribute('POSITION')!;
+
+		let primSkipIndices;
+		if (skipIndices) {
+			primSkipIndices = skipIndices;
+		} else if (attributeSkipIndices.has(position)) {
+			primSkipIndices = attributeSkipIndices.get(position)!;
+		} else {
+			attributeSkipIndices.set(position, (primSkipIndices = new Set<number>()));
+		}
+
+		transformPrimitive(prim, matrix, primSkipIndices);
 	}
 }

--- a/packages/functions/test/transform-mesh.test.ts
+++ b/packages/functions/test/transform-mesh.test.ts
@@ -69,6 +69,26 @@ test('detach shared vertex streams', async (t) => {
 	t.not(primA.getAttribute('POSITION'), primB.getAttribute('POSITION'), 'primA ≠ primB, after (overwrite=false)');
 });
 
+test('update multiple vertex streams', async (t) => {
+	const document = new Document().setLogger(logger);
+	const primA = createPrimitive(document);
+	const primB = createPrimitive(document);
+	const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
+
+	transformMesh(mesh, mat4.fromScaling([], [2, 2, 2]));
+
+	// prettier-ignore
+	const SCALED = [
+		0.5, 10, 0.5,
+		0.5, 10, -0.5,
+		-0.5, 10, -0.5,
+		-0.5, 10, 0.5
+	].map((value) => value * 2.0);
+
+	t.deepEqual(Array.from(primA.getAttribute('POSITION').getArray()), SCALED, 'primA.POSITION');
+	t.deepEqual(Array.from(primB.getAttribute('POSITION').getArray()), SCALED, 'primB.POSITION');
+});
+
 test('skip indices', async (t) => {
 	const document = new Document().setLogger(logger);
 	const prim = createPrimitive(document);


### PR DESCRIPTION
Previously when moving or reorienting a mesh (https://gltf-transform.dev/modules/functions/functions/transformMesh) containing multiple vertex streams, the list of transformed vertex indices was shared, i.e. the Nth vertex would be transformed in one vertex stream but the Nth vertex in the next vertex stream would not.

Simplest example of "multiple vertex streams" would be two primitives in the same mesh having different position accessors, rather than sharing a position accessor and having different indices into it.

POSITION, NORMAL, and TANGENT attributes are affected by transforms. Currently this implementation assumes that two primitives sharing positions will also share normals and tangents, if present. That's not guaranteed to be true, and we could improve the implementation further to handle it, but not currently a known use case or priority.


- Fixes #961
- Resolves #962
