### PR TITLE
Fix prune() reassigning UVs on shared textures

### DIFF
--- a/packages/functions/src/list-texture-info.ts
+++ b/packages/functions/src/list-texture-info.ts
@@ -57,14 +57,21 @@ export function listTextureInfoByMaterial(material: Material): TextureInfo[] {
 	const results = new Set<TextureInfo>();
 
 	function traverse(prop: Material | ExtensionProperty) {
-		for (const child of graph.listChildren(prop)) {
+		const textureInfoNames = new Set<string>();
+
+		for (const edge of graph.listChildEdges(prop)) {
+			if (edge.getChild() instanceof Texture) {
+				textureInfoNames.add(edge.getName() + 'Info');
+			}
+		}
+
+		for (const edge of graph.listChildEdges(prop)) {
+			const child = edge.getChild();
 			if (visited.has(child)) continue;
 			visited.add(child);
 
-			if (child instanceof Texture) {
-				for (const textureInfo of listTextureInfo(child)) {
-					results.add(textureInfo);
-				}
+			if (child instanceof TextureInfo && textureInfoNames.has(edge.getName())) {
+				results.add(child);
 			} else if (child instanceof ExtensionProperty) {
 				traverse(child);
 			}

--- a/packages/functions/test/list-texture-info.test.ts
+++ b/packages/functions/test/list-texture-info.test.ts
@@ -37,16 +37,19 @@ test('listTextureInfoByMaterial', (t) => {
 	const textureC = document.createTexture();
 	const volumeExtension = document.createExtension(KHRMaterialsVolume);
 	const volume = volumeExtension.createVolume().setThicknessTexture(textureC);
-	const material = document
+	const materialA = document
 		.createMaterial()
 		.setBaseColorTexture(textureA)
 		.setNormalTexture(textureB)
 		.setExtension('KHR_materials_volume', volume);
+	const materialB = document.createMaterial().setBaseColorTexture(textureA);
 
-	const textureInfo = new Set(listTextureInfoByMaterial(material));
-
+	let textureInfo = new Set(listTextureInfoByMaterial(materialA));
 	t.is(textureInfo.size, 3, 'finds TextureInfo x 3');
-	t.true(textureInfo.has(material.getBaseColorTextureInfo()), 'finds material.baseColorTextureInfo');
-	t.true(textureInfo.has(material.getNormalTextureInfo()), 'finds material.normalTextureInfo');
+	t.true(textureInfo.has(materialA.getBaseColorTextureInfo()), 'finds material.baseColorTextureInfo');
+	t.true(textureInfo.has(materialA.getNormalTextureInfo()), 'finds material.normalTextureInfo');
 	t.true(textureInfo.has(volume.getThicknessTextureInfo()), 'finds material.volume.thicknessTextureInfo');
+
+	textureInfo = new Set(listTextureInfoByMaterial(materialB));
+	t.is(textureInfo.size, 1, 'finds TextureInfo x 1');
 });


### PR DESCRIPTION
When running prune with `keepAttributes: false`, unused UVs are removed. In a cleanup step afterward, materials are updated to update references to UVs (e.g. `TEXCOORD_1` → `TEXCOORD_0`) as required. Due to a bug, materials sharing a texture with another material were assigned the wrong UV set in some cases.

- Fixes #1000