### PR TITLE
`hasModifier` should check parent edges if any of them modifies the child

### DIFF
--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -370,7 +370,7 @@ function hasModifier(prop: Property, cache: Map<Property, boolean>): boolean {
 
 	const graph = prop.getGraph();
 	const visitedNodes = new Set<Property>();
-	const edgeQueue = graph.listChildEdges(prop);
+	const edgeQueue = graph.listParentEdges(prop);
 
 	// Search dependency subtree for 'modifyChild' attribute.
 	while (edgeQueue.length > 0) {


### PR DESCRIPTION
Hi Don,

I think here we should collect the parent edges to check if any of them is set to modify our child prop ?

In my case: I have a node extension that references materials