### PR TITLE
Fix parent/child validation regression

### DIFF
--- a/packages/core/src/properties/node.ts
+++ b/packages/core/src/properties/node.ts
@@ -7,6 +7,7 @@ import { ExtensibleProperty, IExtensibleProperty } from './extensible-property.j
 import type { Mesh } from './mesh.js';
 import { COPY_IDENTITY } from './property.js';
 import type { Skin } from './skin.js';
+import type { Scene } from './scene.js';
 
 interface INode extends IExtensibleProperty {
 	translation: vec3;
@@ -22,12 +23,12 @@ interface INode extends IExtensibleProperty {
 /**
  * *Nodes are the objects that comprise a {@link Scene}.*
  *
- * Each node may have one or more children, and a transform (position, rotation, and scale) that
- * applies to all of its descendants. A node may also reference (or "instantiate") other resources
- * at its location, including {@link Mesh}, Camera, Light, and Skin properties. A node cannot be
+ * Each Node may have one or more children, and a transform (position, rotation, and scale) that
+ * applies to all of its descendants. A Node may also reference (or "instantiate") other resources
+ * at its location, including {@link Mesh}, Camera, Light, and Skin properties. A Node cannot be
  * part of more than one {@link Scene}.
  *
- * A node's local transform is represented with array-like objects, intended to be compatible with
+ * A Node's local transform is represented with array-like objects, intended to be compatible with
  * [gl-matrix](https://github.com/toji/gl-matrix), or with the `toArray`/`fromArray` methods of
  * libraries like three.js and babylon.js.
  *
@@ -48,8 +49,18 @@ interface INode extends IExtensibleProperty {
 export class Node extends ExtensibleProperty<INode> {
 	public declare propertyType: PropertyType.NODE;
 
-	/** @internal Internal reference to node's parent, omitted from {@link Graph}. */
+	/**
+	 * Internal reference to ≤1 parent Nodes, omitted from {@link Graph}.
+	 * @internal
+	 * @privateRemarks Requires non-graph state.
+	 */
 	public _parentNode: Node | null = null;
+	/**
+	 * Internal reference to N parent scenes, omitted from {@link Graph}.
+	 * @internal
+	 * @privateRemarks Requires non-graph state.
+	 */
+	public _parentScenes = new Set<Scene>();
 
 	protected init(): void {
 		this.propertyType = PropertyType.NODE;
@@ -69,8 +80,8 @@ export class Node extends ExtensibleProperty<INode> {
 	}
 
 	public copy(other: this, resolve = COPY_IDENTITY): this {
-		// Node cannot be copied, only cloned. Copying is shallow, but nodes cannot have more than
-		// one parent. Rather than leaving one of the two nodes without children, throw an error here.
+		// Node cannot be copied, only cloned. Copying is shallow, but Nodes cannot have more than
+		// one parent. Rather than leaving one of the two Nodes without children, throw an error here.
 		if (resolve === COPY_IDENTITY) throw new Error('Node cannot be copied.');
 		return super.copy(other, resolve);
 	}
@@ -79,37 +90,37 @@ export class Node extends ExtensibleProperty<INode> {
 	 * Local transform.
 	 */
 
-	/** Returns the translation (position) of this node in local space. */
+	/** Returns the translation (position) of this Node in local space. */
 	public getTranslation(): vec3 {
 		return this.get('translation');
 	}
 
-	/** Returns the rotation (quaternion) of this node in local space. */
+	/** Returns the rotation (quaternion) of this Node in local space. */
 	public getRotation(): vec4 {
 		return this.get('rotation');
 	}
 
-	/** Returns the scale of this node in local space. */
+	/** Returns the scale of this Node in local space. */
 	public getScale(): vec3 {
 		return this.get('scale');
 	}
 
-	/** Sets the translation (position) of this node in local space. */
+	/** Sets the translation (position) of this Node in local space. */
 	public setTranslation(translation: vec3): this {
 		return this.set('translation', translation);
 	}
 
-	/** Sets the rotation (quaternion) of this node in local space. */
+	/** Sets the rotation (quaternion) of this Node in local space. */
 	public setRotation(rotation: vec4): this {
 		return this.set('rotation', rotation);
 	}
 
-	/** Sets the scale of this node in local space. */
+	/** Sets the scale of this Node in local space. */
 	public setScale(scale: vec3): this {
 		return this.set('scale', scale);
 	}
 
-	/** Returns the local matrix of this node. */
+	/** Returns the local matrix of this Node. */
 	public getMatrix(): mat4 {
 		return MathUtils.compose(
 			this.get('translation'),
@@ -119,7 +130,7 @@ export class Node extends ExtensibleProperty<INode> {
 		);
 	}
 
-	/** Sets the local matrix of this node. Matrix will be decomposed to TRS properties. */
+	/** Sets the local matrix of this Node. Matrix will be decomposed to TRS properties. */
 	public setMatrix(matrix: mat4): this {
 		const translation = this.get('translation').slice() as vec3;
 		const rotation = this.get('rotation').slice() as vec4;
@@ -132,28 +143,28 @@ export class Node extends ExtensibleProperty<INode> {
 	 * World transform.
 	 */
 
-	/** Returns the translation (position) of this node in world space. */
+	/** Returns the translation (position) of this Node in world space. */
 	public getWorldTranslation(): vec3 {
 		const t = [0, 0, 0] as vec3;
 		MathUtils.decompose(this.getWorldMatrix(), t, [0, 0, 0, 1], [1, 1, 1]);
 		return t;
 	}
 
-	/** Returns the rotation (quaternion) of this node in world space. */
+	/** Returns the rotation (quaternion) of this Node in world space. */
 	public getWorldRotation(): vec4 {
 		const r = [0, 0, 0, 1] as vec4;
 		MathUtils.decompose(this.getWorldMatrix(), [0, 0, 0], r, [1, 1, 1]);
 		return r;
 	}
 
-	/** Returns the scale of this node in world space. */
+	/** Returns the scale of this Node in world space. */
 	public getWorldScale(): vec3 {
 		const s = [1, 1, 1] as vec3;
 		MathUtils.decompose(this.getWorldMatrix(), [0, 0, 0], [0, 0, 0, 1], s);
 		return s;
 	}
 
-	/** Returns the world matrix of this node. */
+	/** Returns the world matrix of this Node. */
 	public getWorldMatrix(): mat4 {
 		// Build ancestor chain.
 		const ancestors: Node[] = [];
@@ -176,16 +187,37 @@ export class Node extends ExtensibleProperty<INode> {
 	 * Scene hierarchy.
 	 */
 
-	/** Adds another node as a child of this one. Nodes cannot have multiple parents. */
+	/**
+	 * Adds the given Node as a child of this Node.
+	 *
+	 * Requirements:
+	 *
+	 * 1. Nodes MAY be root children of multiple {@link Scene Scenes}
+	 * 2. Nodes MUST NOT be children of >1 Node
+	 * 3. Nodes MUST NOT be children of both Nodes and {@link Scene Scenes}
+	 *
+	 * The `addChild` method enforces these restrictions automatically, and will
+	 * remove the new child from previous parents where needed. This behavior
+	 * may change in future major releases of the library.
+	 *
+	 * @privateRemarks Requires non-graph state.
+	 */
 	public addChild(child: Node): this {
-		// Remove existing parent.
+		// Remove existing parents.
 		if (child._parentNode) child._parentNode.removeChild(child);
+		if (child._parentScenes.size) {
+			const prevSize = child._parentScenes.size;
+			for (const scene of child._parentScenes) {
+				scene.removeChild(child);
+			}
+			console.log(`parentScenes: ${prevSize} -> ${child._parentScenes.size}`);
+		}
 
 		// Edge in graph.
 		this.addRef('children', child);
 
 		// Set new parent.
-		// TODO(cleanup): Avoid using $attributes here?
+		// TODO(cleanup): Avoid reaching into $attributes.
 		child._parentNode = this;
 		const childrenRefs = this[$attributes]['children'];
 		const ref = childrenRefs[childrenRefs.length - 1];
@@ -193,12 +225,12 @@ export class Node extends ExtensibleProperty<INode> {
 		return this;
 	}
 
-	/** Removes a node from this node's child node list. */
+	/** Removes a Node from this Node's child Node list. */
 	public removeChild(child: Node): this {
 		return this.removeRef('children', child);
 	}
 
-	/** Lists all child nodes of this node. */
+	/** Lists all child Nodes of this Node. */
 	public listChildren(): Node[] {
 		return this.listRefs('children');
 	}
@@ -226,41 +258,41 @@ export class Node extends ExtensibleProperty<INode> {
 	 * Attachments.
 	 */
 
-	/** Returns the {@link Mesh}, if any, instantiated at this node. */
+	/** Returns the {@link Mesh}, if any, instantiated at this Node. */
 	public getMesh(): Mesh | null {
 		return this.getRef('mesh');
 	}
 
 	/**
-	 * Sets a {@link Mesh} to be instantiated at this node. A single mesh may be instatiated by
-	 * multiple nodes; reuse of this sort is strongly encouraged.
+	 * Sets a {@link Mesh} to be instantiated at this Node. A single mesh may be instatiated by
+	 * multiple Nodes; reuse of this sort is strongly encouraged.
 	 */
 	public setMesh(mesh: Mesh | null): this {
 		return this.setRef('mesh', mesh);
 	}
 
-	/** Returns the {@link Camera}, if any, instantiated at this node. */
+	/** Returns the {@link Camera}, if any, instantiated at this Node. */
 	public getCamera(): Camera | null {
 		return this.getRef('camera');
 	}
 
-	/** Sets a {@link Camera} to be instantiated at this node. */
+	/** Sets a {@link Camera} to be instantiated at this Node. */
 	public setCamera(camera: Camera | null): this {
 		return this.setRef('camera', camera);
 	}
 
-	/** Returns the {@link Skin}, if any, instantiated at this node. */
+	/** Returns the {@link Skin}, if any, instantiated at this Node. */
 	public getSkin(): Skin | null {
 		return this.getRef('skin');
 	}
 
-	/** Sets a {@link Skin} to be instantiated at this node. */
+	/** Sets a {@link Skin} to be instantiated at this Node. */
 	public setSkin(skin: Skin | null): this {
 		return this.setRef('skin', skin);
 	}
 
 	/**
-	 * Initial weights of each {@link PrimitiveTarget} for the mesh instance at this node.
+	 * Initial weights of each {@link PrimitiveTarget} for the mesh instance at this Node.
 	 * Most engines only support 4-8 active morph targets at a time.
 	 */
 	public getWeights(): number[] {
@@ -268,7 +300,7 @@ export class Node extends ExtensibleProperty<INode> {
 	}
 
 	/**
-	 * Initial weights of each {@link PrimitiveTarget} for the mesh instance at this node.
+	 * Initial weights of each {@link PrimitiveTarget} for the mesh instance at this Node.
 	 * Most engines only support 4-8 active morph targets at a time.
 	 */
 	public setWeights(weights: number[]): this {

--- a/packages/core/src/properties/scene.ts
+++ b/packages/core/src/properties/scene.ts
@@ -1,3 +1,4 @@
+import { $attributes } from 'property-graph';
 import { Nullable, PropertyType } from '../constants.js';
 import { ExtensibleProperty, IExtensibleProperty } from './extensible-property.js';
 import type { Node } from './node.js';
@@ -39,9 +40,35 @@ export class Scene extends ExtensibleProperty<IScene> {
 		return super.copy(other, resolve);
 	}
 
-	/** Adds a {@link Node} to the Scene. */
+	/**
+	 * Adds a {@link Node} to the Scene.
+	 *
+	 * Requirements:
+	 *
+	 * 1. Nodes MAY be root children of multiple {@link Scene Scenes}
+	 * 2. Nodes MUST NOT be children of >1 Node
+	 * 3. Nodes MUST NOT be children of both Nodes and {@link Scene Scenes}
+	 *
+	 * The `addChild` method enforces these restrictions automatically, and will
+	 * remove the new child from previous parents where needed. This behavior
+	 * may change in future major releases of the library.
+	 *
+	 * @privateRemarks Requires non-graph state.
+	 */
 	public addChild(node: Node): this {
-		return this.addRef('children', node);
+		// Remove existing parent.
+		if (node._parentNode) node._parentNode.removeChild(node);
+
+		// Edge in graph.
+		this.addRef('children', node);
+
+		// Set new parent.
+		// TODO(cleanup): Avoid reaching into $attributes.
+		node._parentScenes.add(this);
+		const childrenRefs = this[$attributes]['children'];
+		const ref = childrenRefs[childrenRefs.length - 1];
+		ref.addEventListener('dispose', () => node._parentScenes.delete(this));
+		return this;
 	}
 
 	/** Removes a {@link Node} from the Scene. */

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -8,6 +8,9 @@ test('parent', (t) => {
 	const b = document.createNode('B');
 	const c = document.createNode('C');
 
+	// 1. adding node as child of node must de-parent from ≤1 node [and N scenes, tested in scene.test.ts]
+	// 2. adding node as child of scene must de-parent from ≤1 node [also tested in scene.test.ts]
+
 	a.addChild(c);
 	b.addChild(c);
 

--- a/packages/core/test/properties/scene.test.ts
+++ b/packages/core/test/properties/scene.test.ts
@@ -1,6 +1,37 @@
 import test from 'ava';
-import { Document } from '@gltf-transform/core';
+import { Document, Property } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
+
+const toName = (p: Property) => p.getName();
+
+test('parent', (t) => {
+	const document = new Document();
+	const sceneA = document.createScene('SceneA');
+	const sceneB = document.createScene('SceneB');
+	const nodeA = document.createNode('NodeA');
+	const nodeB = document.createNode('NodeB');
+
+	// 1. adding node as child of node must de-parent from N scenes [and ≤1 node, tested in node.test.ts]
+	// 2. adding node as child of scene must de-parent from ≤1 node [but not scenes]
+
+	sceneA.addChild(nodeA);
+	sceneB.addChild(nodeA);
+
+	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], '');
+	t.deepEqual(sceneB.listChildren().map(toName), ['NodeA'], '');
+
+	nodeB.addChild(nodeA);
+
+	t.deepEqual(sceneA.listChildren().map(toName), [], '');
+	t.deepEqual(sceneB.listChildren().map(toName), [], '');
+	t.deepEqual(nodeB.listChildren().map(toName), ['NodeA'], '');
+
+	sceneA.addChild(nodeA);
+
+	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], '');
+	t.deepEqual(sceneB.listChildren().map(toName), [], '');
+	t.deepEqual(nodeB.listChildren().map(toName), [], '');
+});
 
 test('copy', (t) => {
 	const document = new Document();

--- a/packages/core/test/properties/scene.test.ts
+++ b/packages/core/test/properties/scene.test.ts
@@ -17,20 +17,20 @@ test('parent', (t) => {
 	sceneA.addChild(nodeA);
 	sceneB.addChild(nodeA);
 
-	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], '');
-	t.deepEqual(sceneB.listChildren().map(toName), ['NodeA'], '');
+	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneA');
+	t.deepEqual(sceneB.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneB');
 
 	nodeB.addChild(nodeA);
 
-	t.deepEqual(sceneA.listChildren().map(toName), [], '');
-	t.deepEqual(sceneB.listChildren().map(toName), [], '');
-	t.deepEqual(nodeB.listChildren().map(toName), ['NodeA'], '');
+	t.deepEqual(sceneA.listChildren().map(toName), [], 'SceneA = ∅');
+	t.deepEqual(sceneB.listChildren().map(toName), [], 'SceneB = ∅');
+	t.deepEqual(nodeB.listChildren().map(toName), ['NodeA'], 'NodeA ∈ NodeB');
 
 	sceneA.addChild(nodeA);
 
-	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], '');
-	t.deepEqual(sceneB.listChildren().map(toName), [], '');
-	t.deepEqual(nodeB.listChildren().map(toName), [], '');
+	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneA');
+	t.deepEqual(sceneB.listChildren().map(toName), [], 'SceneB = ∅');
+	t.deepEqual(nodeB.listChildren().map(toName), [], 'NodeB = ∅');
 });
 
 test('copy', (t) => {


### PR DESCRIPTION
Requirements:

1. Nodes MAY be root children of multiple Scenes
2. Nodes MUST NOT be children of >1 Node
3. Nodes MUST NOT be children of both Nodes and Scenes

- Fixes #1025
- Fixes regression from #833
