### PR TITLE
Fix attribute dynamic range

### DIFF
--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -336,7 +336,8 @@ function getAttributeTolerance(semantic: string, attribute: Accessor, tolerance:
 	_a.length = _b.length = 0;
 	attribute.getMinNormalized(_a);
 	attribute.getMaxNormalized(_b);
-	const range = Math.max(..._b) - Math.min(..._a) || 1;
+	const diff = _b.map((bi, i) => bi - _a[i]);
+	const range = Math.max(...diff);
 	return tolerance * range;
 }
 


### PR DESCRIPTION
Previously, when computing a position attribute's tolerance, we were subtracting the maximum coordinate from the minimum coordinate (so the points [0,0,99] and [0,0,100] would use range=(100-0)=100 instead of range=(100-99)=1 in welding tolerance computations.