### PR TITLE
Reduce normal tolerance for Weld

### DIFF
--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -48,7 +48,7 @@ const Tolerance = {
 	DEFAULT: 0.0001,
 	TEXCOORD: 0.0001, // [0, 1]
 	COLOR: 0.01, // [0, 1]
-	NORMAL: 0.01, // [-1, 1]
+	NORMAL: 0.05, // [-1, 1]
 	JOINTS: 0.0, // [0, ∞]
 	WEIGHTS: 0.01, // [0, ∞]
 };

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -48,7 +48,7 @@ const Tolerance = {
 	DEFAULT: 0.0001,
 	TEXCOORD: 0.0001, // [0, 1]
 	COLOR: 0.01, // [0, 1]
-	NORMAL: 0.5, // [-1, 1]
+	NORMAL: 0.01, // [-1, 1]
 	JOINTS: 0.0, // [0, ∞]
 	WEIGHTS: 0.01, // [0, ∞]
 };


### PR DESCRIPTION
Fix #1028
~~Chose 0.01 as a default tolerance which corresponds to ±arcsin(0.01)/2 = ±0.286°.~~

Chose 0.05 as a default tolerance which corresponds to ±arcsin(0.05)/2 = ±1.43°.