### PR TITLE
Add a check to avoid prune in weld when tolerance is zero

### DIFF
--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -129,7 +129,11 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 			if (mesh.listPrimitives().length === 0) mesh.dispose();
 		}
 
-		await doc.transform(prune({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE] }));
+        if (options.tolerance > 0) {
+            // If tolerance is greater than 0, welding may remove a mesh, so we prune
+		    await doc.transform(prune({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE] }));
+        }
+
 		await doc.transform(dedup({ propertyTypes: [PropertyType.ACCESSOR] }));
 
 		logger.debug(`${NAME}: Complete.`);


### PR DESCRIPTION
Addresses feature request in #1058. Since weld with a tolerance of 0 will never remove a mesh, this avoids the call to prune in that case.

This prevents draco compression from stripping empty nodes in a gltf.