### PR TITLE
Support textureCompress() on web, with fallback to ndarray-pixels

### DIFF
--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -9,6 +9,7 @@ import {
 	Texture,
 	Transform,
 	TransformContext,
+	vec2,
 } from '@gltf-transform/core';
 
 /**
@@ -245,4 +246,27 @@ export function createPrimGroupKey(prim: Primitive): string {
 		.join('~');
 
 	return `${materialIndex}|${mode}|${indices}|${attributes}|${targets}`;
+}
+
+/** @hidden */
+export function fitWithin(size: vec2, limit: vec2): vec2 {
+	const [maxWidth, maxHeight] = limit;
+	const [srcWidth, srcHeight] = size;
+
+	if (srcWidth <= maxWidth && srcHeight <= maxHeight) return size;
+
+	let dstWidth = srcWidth;
+	let dstHeight = srcHeight;
+
+	if (dstWidth > maxWidth) {
+		dstHeight = Math.floor(dstHeight * (maxWidth / dstWidth));
+		dstWidth = maxWidth;
+	}
+
+	if (dstHeight > maxHeight) {
+		dstWidth = Math.floor(dstWidth * (maxHeight / dstHeight));
+		dstHeight = maxHeight;
+	}
+
+	return [dstWidth, dstHeight];
 }


### PR DESCRIPTION
When the `encoder` option is omitted, `textureCompress()` will now fall back to [`ndarray-pixels`](https://github.com/donmccurdy/ndarray-pixels) and [`ndarray-lanczos`](https://github.com/donmccurdy/ndarray-lanczos). This change is intended to provide alternatives in a web browser, where Sharp (https://sharp.pixelplumbing.com/) is not currently supported.

I'll continue to keep an eye on https://github.com/lovell/sharp/pull/3522, in the hope that it will be possible to install a web-friendly build a Sharp someday.

- fixes #801