### PR TITLE
Fix for Weld() Error

### DIFF
--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -110,7 +110,7 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 			for (const prim of mesh.listPrimitives()) {
 				weldPrimitive(doc, prim, options);
 
-				if (prim.getIndices()!.getCount() === 0) prim.dispose();
+				if (prim.getIndices()?.getCount() === 0) prim.dispose();
 			}
 
 			if (mesh.listPrimitives().length === 0) mesh.dispose();


### PR DESCRIPTION
#1116

There is a code path that results in `error: Cannot read properties of null (reading 'getCount')`

Where a non-indexed point primitive exits early from weldPrimitive(), but then fails the `prim.getIndices()!.getCount() === 0` check because `prim.getIndices() === null`

I've added a really simple fix here, but it's maybe not the cleanest an alternative could be to perform a specific point prim check instead and then continue