### PR TITLE
Clean up --formats and --slots inputs for texture compression

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1460,7 +1460,6 @@ program
 	})
 	.option('--formats <formats>', 'Texture formats to include', {
 		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
-		typeHint: 'hello world',
 		default: '*',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -67,7 +67,7 @@ import {
 	XMPOptions,
 	xmp,
 } from './transforms/index.js';
-import { formatBytes, MICROMATCH_OPTIONS, underline, TableFormat, dim } from './util.js';
+import { formatBytes, MICROMATCH_OPTIONS, underline, TableFormat, dim, regexFromArray } from './util.js';
 import { Session } from './session.js';
 import { ValidateOptions, validate } from './validate.js';
 import { getConfig, loadConfig } from './config.js';
@@ -1421,7 +1421,7 @@ program
 	.option('--pattern <pattern>', 'Pattern (glob) to match textures, by name or URI.', {
 		validator: Validator.STRING,
 	})
-	.option('--formats <formats>', 'Texture formats to include (glob)', {
+	.option('--formats <formats>', 'Texture formats to include', {
 		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
 		default: '*',
 	})
@@ -1431,7 +1431,7 @@ program
 	.option('--lossless <lossless>', 'Use lossless compression mode', { validator: Validator.BOOLEAN, default: false })
 	.action(async ({ args, options, logger }) => {
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
-		const formats = micromatch.makeRe(String(options.formats), MICROMATCH_OPTIONS);
+		const formats = regexFromArray([options.formats] as string[]);
 		const slots = micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS);
 		const { default: encoder } = await import('sharp');
 		return Session.create(io, logger, args.input, args.output).transform(
@@ -1458,8 +1458,9 @@ program
 	.option('--pattern <pattern>', 'Pattern (glob) to match textures, by name or URI.', {
 		validator: Validator.STRING,
 	})
-	.option('--formats <formats>', 'Texture formats to include (glob)', {
+	.option('--formats <formats>', 'Texture formats to include', {
 		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
+		typeHint: 'hello world',
 		default: '*',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })
@@ -1472,7 +1473,7 @@ program
 	})
 	.action(async ({ args, options, logger }) => {
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
-		const formats = micromatch.makeRe(String(options.formats), MICROMATCH_OPTIONS);
+		const formats = regexFromArray([options.formats] as string[]);
 		const slots = micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS);
 		const { default: encoder } = await import('sharp');
 		return Session.create(io, logger, args.input, args.output).transform(
@@ -1500,16 +1501,16 @@ program
 	.option('--pattern <pattern>', 'Pattern (glob) to match textures, by name or URI.', {
 		validator: Validator.STRING,
 	})
-	.option('--formats <formats>', 'Texture formats to include (glob)', {
+	.option('--formats <formats>', 'Texture formats to include', {
 		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
-		default: 'image/png',
+		default: 'png',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })
 	.option('--quality <quality>', 'Quality, 1-100', { validator: Validator.NUMBER })
 	.option('--effort <effort>', 'Level of CPU effort to reduce file size, 0-100', { validator: Validator.NUMBER })
 	.action(async ({ args, options, logger }) => {
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
-		const formats = micromatch.makeRe(String(options.formats), MICROMATCH_OPTIONS);
+		const formats = regexFromArray([options.formats] as string[]);
 		const slots = micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS);
 		const { default: encoder } = await import('sharp');
 		return Session.create(io, logger, args.input, args.output).transform(
@@ -1535,15 +1536,15 @@ program
 	.option('--pattern <pattern>', 'Pattern (glob) to match textures, by name or URI.', {
 		validator: Validator.STRING,
 	})
-	.option('--formats <formats>', 'Texture formats to include (glob)', {
+	.option('--formats <formats>', 'Texture formats to include', {
 		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
-		default: 'image/jpeg',
+		default: 'jpeg',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })
 	.option('--quality <quality>', 'Quality, 1-100', { validator: Validator.NUMBER })
 	.action(async ({ args, options, logger }) => {
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
-		const formats = micromatch.makeRe(String(options.formats), MICROMATCH_OPTIONS);
+		const formats = regexFromArray([options.formats] as string[]);
 		const slots = micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS);
 		const { default: encoder } = await import('sharp');
 		return Session.create(io, logger, args.input, args.output).transform(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -53,6 +53,7 @@ import {
 	PaletteOptions,
 	PALETTE_DEFAULTS,
 	MESHOPT_DEFAULTS,
+	TEXTURE_COMPRESS_SUPPORTED_FORMATS,
 } from '@gltf-transform/functions';
 import { inspect } from './inspect.js';
 import {
@@ -352,7 +353,10 @@ commands or using the scripting API.
 
 		// Texture compression.
 		if (opts.textureCompress === 'ktx2') {
-			const slotsUASTC = '{normalTexture,occlusionTexture,metallicRoughnessTexture}';
+			const slotsUASTC = micromatch.makeRe(
+				'{normalTexture,occlusionTexture,metallicRoughnessTexture}',
+				MICROMATCH_OPTIONS,
+			);
 			transforms.push(
 				toktx({ mode: Mode.UASTC, slots: slotsUASTC, level: 4, rdo: 4, zstd: 18 }),
 				toktx({ mode: Mode.ETC1S, quality: 255 }),
@@ -1418,7 +1422,7 @@ program
 		validator: Validator.STRING,
 	})
 	.option('--formats <formats>', 'Texture formats to include (glob)', {
-		validator: ['image/png', 'image/jpeg', '*'],
+		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
 		default: '*',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })
@@ -1455,7 +1459,7 @@ program
 		validator: Validator.STRING,
 	})
 	.option('--formats <formats>', 'Texture formats to include (glob)', {
-		validator: ['image/png', 'image/jpeg', '*'],
+		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
 		default: '*',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })
@@ -1497,7 +1501,7 @@ program
 		validator: Validator.STRING,
 	})
 	.option('--formats <formats>', 'Texture formats to include (glob)', {
-		validator: ['image/png', 'image/jpeg', '*'],
+		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
 		default: 'image/png',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })
@@ -1532,7 +1536,7 @@ program
 		validator: Validator.STRING,
 	})
 	.option('--formats <formats>', 'Texture formats to include (glob)', {
-		validator: ['image/png', 'image/jpeg', '*'],
+		validator: [...TEXTURE_COMPRESS_SUPPORTED_FORMATS, '*'],
 		default: 'image/jpeg',
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING, default: '*' })

--- a/packages/cli/src/util.ts
+++ b/packages/cli/src/util.ts
@@ -4,6 +4,7 @@ import _commandExists from 'command-exists';
 import CLITable from 'cli-table3';
 import { stringify } from 'csv-stringify';
 import stripAnsi from 'strip-ansi';
+import micromatch from 'micromatch';
 
 // Constants.
 
@@ -18,6 +19,12 @@ export const XMPContext: Record<string, string> = {
 // Using 'micromatch' because 'contains: true' did not work as expected with
 // minimatch. Need to ensure that '*' matches patterns like 'image/png'.
 export const MICROMATCH_OPTIONS = { nocase: true, contains: true };
+
+// See: https://github.com/micromatch/micromatch/issues/224
+export function regexFromArray(values: string[]): RegExp {
+	const pattern = values.map((s) => `(${s})`).join('|');
+	return micromatch.makeRe(pattern, MICROMATCH_OPTIONS);
+}
 
 // Mocks for tests.
 

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -11,8 +11,8 @@ import { lanczos2, lanczos3 } from 'ndarray-lanczos';
 
 const NAME = 'textureCompress';
 
-type Format = (typeof FORMATS)[number];
-const FORMATS = ['jpeg', 'png', 'webp', 'avif'] as const;
+type Format = (typeof TEXTURE_COMPRESS_SUPPORTED_FORMATS)[number];
+export const TEXTURE_COMPRESS_SUPPORTED_FORMATS = ['jpeg', 'png', 'webp', 'avif'] as const;
 const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/avif'];
 
 export interface TextureCompressOptions {
@@ -339,7 +339,7 @@ function getFormat(texture: Texture): Format {
 
 function getFormatFromMimeType(mimeType: string): Format {
 	const format = mimeType.split('/').pop() as Format | undefined;
-	if (!format || !FORMATS.includes(format)) {
+	if (!format || !TEXTURE_COMPRESS_SUPPORTED_FORMATS.includes(format)) {
 		throw new Error(`Unknown MIME type "${mimeType}".`);
 	}
 	return format;


### PR DESCRIPTION
Fixes a typo when using the CLI `optimize` command for KTX2 compression. Extends non-GPU texture compression commands to support WebP and AVIF as input formats. Simplifies syntax:

```bash
# before
gltf-transform webp in.glb out.glb --formats "image/png" --lossless

# after
gltf-transform webp in.glb out.glb --formats "png" --lossless
```