### PR TITLE
Fix errors in morph normal encoding in quantize() and meshopt()

### DIFF
--- a/packages/core/src/properties/accessor.ts
+++ b/packages/core/src/properties/accessor.ts
@@ -360,7 +360,7 @@ export class Accessor extends ExtensibleProperty<IAccessor> {
 		this.set('normalized', normalized);
 
 		if (normalized) {
-			this._out = (c: number): number => MathUtils.decodeNormalizedInt(c, this.get('componentType'));
+			this._out = (i: number): number => MathUtils.decodeNormalizedInt(i, this.get('componentType'));
 			this._in = (f: number): number => MathUtils.encodeNormalizedInt(f, this.get('componentType'));
 		} else {
 			this._out = MathUtils.identity;

--- a/packages/core/src/utils/math-utils.ts
+++ b/packages/core/src/utils/math-utils.ts
@@ -19,41 +19,44 @@ export class MathUtils {
 		return true;
 	}
 
-	public static decodeNormalizedInt(c: number, componentType: GLTF.AccessorComponentType): number {
+	// TODO(v4): Compare performance if we replace the switch with individual functions.
+	public static decodeNormalizedInt(i: number, componentType: GLTF.AccessorComponentType): number {
 		// Hardcode enums from accessor.ts to avoid a circular dependency.
 		switch (componentType) {
-			case 5126:
-				return c;
-			case 5123:
-				return c / 65535.0;
-			case 5121:
-				return c / 255.0;
-			case 5122:
-				return Math.max(c / 32767.0, -1.0);
-			case 5120:
-				return Math.max(c / 127.0, -1.0);
+			case 5126: // FLOAT
+				return i;
+			case 5123: // UNSIGNED_SHORT
+				return i / 65535.0;
+			case 5121: // UNSIGNED_BYTE
+				return i / 255.0;
+			case 5122: // SHORT
+				return Math.max(i / 32767.0, -1.0);
+			case 5120: // BYTE
+				return Math.max(i / 127.0, -1.0);
 			default:
 				throw new Error('Invalid component type.');
 		}
 	}
 
 	/** @deprecated Renamed to {@link MathUtils.decodeNormalizedInt}. */
-	public static denormalize(c: number, componentType: GLTF.AccessorComponentType): number {
-		return MathUtils.decodeNormalizedInt(c, componentType);
+	public static denormalize(i: number, componentType: GLTF.AccessorComponentType): number {
+		return MathUtils.decodeNormalizedInt(i, componentType);
 	}
 
+	// TODO(v4): Compare performance if we replace the switch with individual functions.
+	// TODO(v4): Consider clamping to [0, 1] or [-1, 1] here.
 	public static encodeNormalizedInt(f: number, componentType: GLTF.AccessorComponentType): number {
 		// Hardcode enums from accessor.ts to avoid a circular dependency.
 		switch (componentType) {
-			case 5126:
+			case 5126: // FLOAT
 				return f;
-			case 5123:
+			case 5123: // UNSIGNED_SHORT
 				return Math.round(f * 65535.0);
-			case 5121:
+			case 5121: // UNSIGNED_BYTE
 				return Math.round(f * 255.0);
-			case 5122:
+			case 5122: // SHORT
 				return Math.round(f * 32767.0);
-			case 5120:
+			case 5120: // BYTE
 				return Math.round(f * 127.0);
 			default:
 				throw new Error('Invalid component type.');

--- a/packages/extensions/src/ext-meshopt-compression/constants.ts
+++ b/packages/extensions/src/ext-meshopt-compression/constants.ts
@@ -16,9 +16,13 @@ export enum MeshoptMode {
 }
 
 export enum MeshoptFilter {
+	/** No filter — quantize only. */
 	NONE = 'NONE',
+	/** Four 8- or 16-bit normalized values. */
 	OCTAHEDRAL = 'OCTAHEDRAL',
+	/** Four 16-bit normalized values. */
 	QUATERNION = 'QUATERNION',
+	/** K single-precision floating point values. */
 	EXPONENTIAL = 'EXPONENTIAL',
 }
 

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -23,7 +23,7 @@ export function prepareAccessor(
 	accessor: Accessor,
 	encoder: typeof MeshoptEncoder,
 	mode: MeshoptMode,
-	filterOptions: { filter: MeshoptFilter; bits?: number }
+	filterOptions: { filter: MeshoptFilter; bits?: number },
 ): PreparedAccessor {
 	const { filter, bits } = filterOptions as { filter: MeshoptFilter; bits: number };
 	const result: PreparedAccessor = {

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -156,6 +156,8 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 		//   output in some cases (e.g. Matilda.glb), for unknown reasons. gltfpack uses manual
 		//   quantization for these attributes.
 		// - NORMAL and TANGENT attributes use Octahedral filters, but deltas in morphs do not.
+		// - When specifying bit depth for vertex attributes, check the defaults in `quantize.ts`
+		//	 and overrides in `meshopt.ts`. Don't store deltas at higher precision than base.
 		if (refName === 'attributes') {
 			if (refKey === 'POSITION') return { filter: MeshoptFilter.NONE };
 			if (refKey === 'TEXCOORD_0') return { filter: MeshoptFilter.NONE };

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -8,6 +8,7 @@ import {
 	GLTF,
 	MathUtils,
 	Primitive,
+	PropertyType,
 	Root,
 	TypedArray,
 	TypedArrayConstructor,
@@ -36,7 +37,7 @@ export function prepareAccessor(
 	if (mode !== MeshoptMode.ATTRIBUTES) return result;
 
 	if (filter !== MeshoptFilter.NONE) {
-		let array = accessor.getNormalized() ? denormalizeArray(accessor) : new Float32Array(result.array);
+		let array = accessor.getNormalized() ? decodeNormalizedIntArray(accessor) : new Float32Array(result.array);
 
 		switch (filter) {
 			case MeshoptFilter.EXPONENTIAL: // → K single-precision floating point values.
@@ -83,7 +84,7 @@ export function prepareAccessor(
 	return result;
 }
 
-function denormalizeArray(attribute: Accessor): Float32Array {
+function decodeNormalizedIntArray(attribute: Accessor): Float32Array {
 	const componentType = attribute.getComponentType();
 	const srcArray = attribute.getArray()!;
 	const dstArray = new Float32Array(srcArray.length);
@@ -141,6 +142,7 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 	for (const ref of refs) {
 		const refName = ref.getName();
 		const refKey = (ref.getAttributes().key || '') as string;
+		const isDelta = ref.getParent().propertyType === PropertyType.PRIMITIVE_TARGET;
 
 		// Indices.
 		if (refName === 'indices') return { filter: MeshoptFilter.NONE };
@@ -153,13 +155,15 @@ export function getMeshoptFilter(accessor: Accessor, doc: Document): { filter: M
 		// - POSITION and TEXCOORD_0 could use exponential filtering, but this produces broken
 		//   output in some cases (e.g. Matilda.glb), for unknown reasons. gltfpack uses manual
 		//   quantization for these attributes.
+		// - NORMAL and TANGENT attributes use Octahedral filters, but deltas in morphs do not.
 		if (refName === 'attributes') {
 			if (refKey === 'POSITION') return { filter: MeshoptFilter.NONE };
 			if (refKey === 'TEXCOORD_0') return { filter: MeshoptFilter.NONE };
-			if (refKey === 'NORMAL') return { filter: MeshoptFilter.OCTAHEDRAL, bits: 8 };
-			if (refKey === 'TANGENT') return { filter: MeshoptFilter.OCTAHEDRAL, bits: 8 };
 			if (refKey.startsWith('JOINTS_')) return { filter: MeshoptFilter.NONE };
 			if (refKey.startsWith('WEIGHTS_')) return { filter: MeshoptFilter.NONE };
+			if (refKey === 'NORMAL' || refKey === 'TANGENT') {
+				return isDelta ? { filter: MeshoptFilter.NONE } : { filter: MeshoptFilter.OCTAHEDRAL, bits: 8 };
+			}
 		}
 
 		// Animation.

--- a/packages/functions/src/meshopt.ts
+++ b/packages/functions/src/meshopt.ts
@@ -58,6 +58,7 @@ export function meshopt(_options: MeshoptOptions): Transform {
 		// _not_ filtered in 'packages/extensions/src/ext-meshopt-compression/encoder.ts'.
 		// Note that normals and tangents use octahedral filters, but _morph_ normals
 		// and tangents do not.
+		// See: https://github.com/donmccurdy/glTF-Transform/issues/1142
 		if (options.level === 'medium') {
 			pattern = /.*/;
 			patternTargets = /.*/;

--- a/packages/functions/src/meshopt.ts
+++ b/packages/functions/src/meshopt.ts
@@ -5,7 +5,7 @@ import { reorder } from './reorder.js';
 import { QUANTIZE_DEFAULTS, QuantizeOptions, quantize } from './quantize.js';
 import { createTransform } from './utils.js';
 
-export interface MeshoptOptions extends Omit<QuantizeOptions, 'pattern'> {
+export interface MeshoptOptions extends Omit<QuantizeOptions, 'pattern' | 'patternTargets'> {
 	encoder: unknown;
 	level?: 'medium' | 'high';
 }
@@ -51,6 +51,21 @@ export function meshopt(_options: MeshoptOptions): Transform {
 	}
 
 	return createTransform(NAME, async (document: Document): Promise<void> => {
+		let pattern: RegExp;
+		let patternTargets: RegExp;
+
+		// IMPORTANT: Vertex attributes should be quantized in 'high' mode IFF they are
+		// _not_ filtered in 'packages/extensions/src/ext-meshopt-compression/encoder.ts'.
+		// Note that normals and tangents use octahedral filters, but _morph_ normals
+		// and tangents do not.
+		if (options.level === 'medium') {
+			pattern = /.*/;
+			patternTargets = /.*/;
+		} else {
+			pattern = /^(POSITION|TEXCOORD|JOINTS|WEIGHTS)(_\d+)?$/;
+			patternTargets = /^(POSITION|TEXCOORD|JOINTS|WEIGHTS|NORMAL|TANGENT)(_\d+)?$/;
+		}
+
 		await document.transform(
 			reorder({
 				encoder: encoder,
@@ -58,9 +73,8 @@ export function meshopt(_options: MeshoptOptions): Transform {
 			}),
 			quantize({
 				...options,
-				// IMPORTANT: Vertex attributes should be quantized in 'high' mode IFF they are
-				// _not_ filtered in 'packages/extensions/src/ext-meshopt-compression/encoder.ts'.
-				pattern: options.level === 'medium' ? /.*/ : /^(POSITION|TEXCOORD|JOINTS|WEIGHTS)(_\d+)?$/,
+				pattern,
+				patternTargets,
 			}),
 		);
 

--- a/packages/functions/src/meshopt.ts
+++ b/packages/functions/src/meshopt.ts
@@ -53,6 +53,7 @@ export function meshopt(_options: MeshoptOptions): Transform {
 	return createTransform(NAME, async (document: Document): Promise<void> => {
 		let pattern: RegExp;
 		let patternTargets: RegExp;
+		let quantizeNormal = options.quantizeNormal;
 
 		// IMPORTANT: Vertex attributes should be quantized in 'high' mode IFF they are
 		// _not_ filtered in 'packages/extensions/src/ext-meshopt-compression/encoder.ts'.
@@ -65,6 +66,7 @@ export function meshopt(_options: MeshoptOptions): Transform {
 		} else {
 			pattern = /^(POSITION|TEXCOORD|JOINTS|WEIGHTS)(_\d+)?$/;
 			patternTargets = /^(POSITION|TEXCOORD|JOINTS|WEIGHTS|NORMAL|TANGENT)(_\d+)?$/;
+			quantizeNormal = Math.min(quantizeNormal, 8); // See meshopt::getMeshoptFilter.
 		}
 
 		await document.transform(
@@ -76,6 +78,7 @@ export function meshopt(_options: MeshoptOptions): Transform {
 				...options,
 				pattern,
 				patternTargets,
+				quantizeNormal,
 			}),
 		);
 

--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -122,7 +122,7 @@ export function quantize(_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transfo
 
 		await doc.transform(
 			prune({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.SKIN, PropertyType.MATERIAL] }),
-			dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL, PropertyType.SKIN] })
+			dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL, PropertyType.SKIN] }),
 		);
 
 		logger.debug(`${NAME}: Complete.`);
@@ -133,7 +133,7 @@ function quantizePrimitive(
 	doc: Document,
 	prim: Primitive | PrimitiveTarget,
 	nodeTransform: VectorTransform<vec3>,
-	options: Required<QuantizeOptions>
+	options: Required<QuantizeOptions>,
 ): void {
 	const logger = doc.getLogger();
 
@@ -193,7 +193,7 @@ function getNodeTransform(volume: bbox): VectorTransform<vec3> {
 	const scale = Math.max(
 		(max[0] - min[0]) / 2, // Divide because interval [-1,1] has length 2.
 		(max[1] - min[1]) / 2,
-		(max[2] - min[2]) / 2
+		(max[2] - min[2]) / 2,
 	);
 
 	// Original center of the mesh, in local space.
@@ -294,7 +294,7 @@ function transformBatch(batch: InstancedMesh, nodeTransform: VectorTransform<vec
 			instanceTranslation ? (instanceTranslation.getElement(i, t) as vec3) : T_IDENTITY,
 			instanceRotation ? (instanceRotation.getElement(i, r) as vec4) : R_IDENTITY,
 			instanceScale ? (instanceScale.getElement(i, s) as vec3) : S_IDENTITY,
-			instanceMatrix
+			instanceMatrix,
 		);
 
 		multiplyMat4(instanceMatrix, instanceMatrix, transformMatrix);
@@ -370,7 +370,7 @@ function getQuantizationSettings(
 	semantic: string,
 	attribute: Accessor,
 	logger: ILogger,
-	options: Required<QuantizeOptions>
+	options: Required<QuantizeOptions>,
 ): { bits: number; ctor?: TypedArrayConstructor } {
 	const min = attribute.getMinNormalized([]);
 	const max = attribute.getMaxNormalized([]);

--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -359,8 +359,7 @@ function quantizeAttribute(attribute: Accessor, ctor: TypedArrayConstructor, bit
 	for (let i = 0, di = 0, el: number[] = []; i < attribute.getCount(); i++) {
 		attribute.getElement(i, el);
 		for (let j = 0; j < el.length; j++) {
-			// Clamp to [min, max] range.
-			// See: https://github.com/donmccurdy/glTF-Transform/issues/1142
+			// Clamp to range.
 			let value = clamp(el[j], range);
 
 			// Map [0.0 ... 1.0] to [0 ... scale].


### PR DESCRIPTION
Fix errors in quantization and meshopt compression of morph normals and tangents.

- Morph normals and tangent deltas are not normalized vectors, and should be quantized, not filtered
- Clamp morph normals and tangents to [-1, 1]
- Extend quantize() options to disambiguate vertex attributes from morph attributes

- Fixes #1142