### PR TITLE
Change ≤,≥ to <=, >= to fix display in terminal

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1639,7 +1639,7 @@ program
 		`
 Scans all Accessors in the Document, detecting whether each Accessor would
 benefit from sparse data storage. Currently, sparse data storage is used only
-when many values (≥ 1/3) are zeroes. Particularly for assets using morph
+when many values (>= 1/3) are zeroes. Particularly for assets using morph
 target ("shape key") animation, sparse data storage may significantly reduce
 file sizes.
 	`.trim(),

--- a/packages/core/src/properties/node.ts
+++ b/packages/core/src/properties/node.ts
@@ -50,7 +50,7 @@ export class Node extends ExtensibleProperty<INode> {
 	public declare propertyType: PropertyType.NODE;
 
 	/**
-	 * Internal reference to ≤1 parent Nodes, omitted from {@link Graph}.
+	 * Internal reference to <=1 parent Nodes, omitted from {@link Graph}.
 	 * @internal
 	 * @privateRemarks Requires non-graph state.
 	 */

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -8,8 +8,8 @@ test('parent', (t) => {
 	const b = document.createNode('B');
 	const c = document.createNode('C');
 
-	// 1. adding node as child of node must de-parent from ≤1 node [and N scenes, tested in scene.test.ts]
-	// 2. adding node as child of scene must de-parent from ≤1 node [also tested in scene.test.ts]
+	// 1. adding node as child of node must de-parent from <=1 node [and N scenes, tested in scene.test.ts]
+	// 2. adding node as child of scene must de-parent from <=1 node [also tested in scene.test.ts]
 
 	a.addChild(c);
 	b.addChild(c);

--- a/packages/core/test/properties/scene.test.ts
+++ b/packages/core/test/properties/scene.test.ts
@@ -11,8 +11,8 @@ test('parent', (t) => {
 	const nodeA = document.createNode('NodeA');
 	const nodeB = document.createNode('NodeB');
 
-	// 1. adding node as child of node must de-parent from N scenes [and ≤1 node, tested in node.test.ts]
-	// 2. adding node as child of scene must de-parent from ≤1 node [but not scenes]
+	// 1. adding node as child of node must de-parent from N scenes [and <=1 node, tested in node.test.ts]
+	// 2. adding node as child of scene must de-parent from <=1 node [but not scenes]
 
 	sceneA.addChild(nodeA);
 	sceneB.addChild(nodeA);

--- a/packages/extensions/src/khr-lights-punctual/light.ts
+++ b/packages/extensions/src/khr-lights-punctual/light.ts
@@ -140,7 +140,7 @@ export class Light extends ExtensionProperty<ILight> {
 	 */
 
 	/**
-	 * Angle, in radians, from centre of spotlight where falloff begins. Must be ≥ 0 and
+	 * Angle, in radians, from centre of spotlight where falloff begins. Must be >= 0 and
 	 * < outerConeAngle.
 	 */
 	public getInnerConeAngle(): number {
@@ -148,7 +148,7 @@ export class Light extends ExtensionProperty<ILight> {
 	}
 
 	/**
-	 * Angle, in radians, from centre of spotlight where falloff begins. Must be ≥ 0 and
+	 * Angle, in radians, from centre of spotlight where falloff begins. Must be >= 0 and
 	 * < outerConeAngle.
 	 */
 	public setInnerConeAngle(angle: number): this {
@@ -157,7 +157,7 @@ export class Light extends ExtensionProperty<ILight> {
 
 	/**
 	 * Angle, in radians, from centre of spotlight where falloff ends. Must be > innerConeAngle and
-	 * ≤ PI / 2.0.
+	 * <= PI / 2.0.
 	 */
 	public getOuterConeAngle(): number {
 		return this.get('outerConeAngle');
@@ -165,7 +165,7 @@ export class Light extends ExtensionProperty<ILight> {
 
 	/**
 	 * Angle, in radians, from centre of spotlight where falloff ends. Must be > innerConeAngle and
-	 * ≤ PI / 2.0.
+	 * <= PI / 2.0.
 	 */
 	public setOuterConeAngle(angle: number): this {
 		return this.set('outerConeAngle', angle);

--- a/packages/functions/src/instance.ts
+++ b/packages/functions/src/instance.ts
@@ -114,7 +114,7 @@ export function instance(_options: InstanceOptions = INSTANCE_DEFAULTS): Transfo
 		if (numBatches > 0) {
 			logger.info(`${NAME}: Created ${numBatches} batches, with ${numInstances} total instances.`);
 		} else {
-			logger.info(`${NAME}: No meshes with ≥${options.min} parent nodes were found.`);
+			logger.info(`${NAME}: No meshes with >=${options.min} parent nodes were found.`);
 		}
 
 		if (batchExtension.listProperties().length === 0) {

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -39,7 +39,7 @@ export function joinPrimitives(prims: Primitive[], options: JoinPrimitiveOptions
 	if (!options.skipValidation && new Set(prims.map(createPrimGroupKey)).size > 1) {
 		throw new Error(
 			'' +
-				'Requires ≥2 Primitives, sharing the same Material ' +
+				'Requires >=2 Primitives, sharing the same Material ' +
 				'and Mode, with compatible vertex attributes and indices.',
 		);
 	}

--- a/packages/functions/src/palette.ts
+++ b/packages/functions/src/palette.ts
@@ -172,7 +172,7 @@ export function palette(_options: PaletteOptions = PALETTE_DEFAULTS): Transform 
 		}
 
 		if (!(baseColorTexture || emissiveTexture || metallicRoughnessTexture)) {
-			logger.debug(`${NAME}: No material property has ≥${min} unique values. Exiting.`);
+			logger.debug(`${NAME}: No material property has >=${min} unique values. Exiting.`);
 			return;
 		}
 

--- a/packages/functions/src/sparse.ts
+++ b/packages/functions/src/sparse.ts
@@ -19,7 +19,7 @@ const SPARSE_DEFAULTS: Required<SparseOptions> = {
 /**
  * Scans all {@link Accessor Accessors} in the Document, detecting whether each Accessor
  * would benefit from sparse data storage. Currently, sparse data storage is used only
- * when many values (≥ ratio) are zeroes. Particularly for assets using morph target
+ * when many values (>= ratio) are zeroes. Particularly for assets using morph target
  * ("shape key") animation, sparse data storage may significantly reduce file sizes.
  *
  * Example:

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -416,11 +416,11 @@ function expandWeldOptions(_options: WeldOptions): Required<WeldOptions> {
 	const options = { ...WELD_DEFAULTS, ..._options } as Required<WeldOptions>;
 
 	if (options.tolerance < 0 || options.tolerance > 0.1) {
-		throw new Error(`${NAME}: Requires 0 ≤ tolerance ≤ 0.1`);
+		throw new Error(`${NAME}: Requires 0 <= tolerance <= 0.1`);
 	}
 
 	if (options.toleranceNormal < 0 || options.toleranceNormal > Math.PI / 2) {
-		throw new Error(`${NAME}: Requires 0 ≤ toleranceNormal ≤ ${(Math.PI / 2).toFixed(2)}`);
+		throw new Error(`${NAME}: Requires 0 <= toleranceNormal <= ${(Math.PI / 2).toFixed(2)}`);
 	}
 
 	if (options.tolerance > 0) {

--- a/packages/functions/test/resample.test.ts
+++ b/packages/functions/test/resample.test.ts
@@ -49,7 +49,7 @@ test('rotation', async (t) => {
 		...quat.fromEuler([], 45, 0, 0),
 		...quat.fromEuler([], 90, 0, 0),
 		...quat.fromEuler([], 135, 0, 0),
-		...quat.fromEuler([], 180, 0, 0), // resampling can't create ≥180º steps!
+		...quat.fromEuler([], 180, 0, 0), // resampling can't create >=180º steps!
 		...quat.fromEuler([], 225, 0, 0),
 		...quat.fromEuler([], 270, 0, 0),
 	]);

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -34,7 +34,7 @@ test('welded', async (t) => {
 	const dstCount = getVertexCount(document);
 	const dstBounds = roundBbox(getBounds(scene), 2);
 
-	t.truthy((srcCount - dstCount) / srcCount > 0.5, '≥50% reduction');
+	t.truthy((srcCount - dstCount) / srcCount > 0.5, '>=50% reduction');
 	t.truthy(srcCount > dstCount, 'src.count > dst.count');
 	t.deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
 });
@@ -52,7 +52,7 @@ test('unwelded', async (t) => {
 	const dstCount = getVertexCount(document);
 	const dstBounds = roundBbox(getBounds(scene), 2);
 
-	t.truthy((srcCount - dstCount) / srcCount > 0.5, '≥50% reduction');
+	t.truthy((srcCount - dstCount) / srcCount > 0.5, '>=50% reduction');
 	t.truthy(srcCount > dstCount, 'src.count > dst.count');
 	t.deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
 });
@@ -87,7 +87,7 @@ test('shared accessors', async (t) => {
 	const dstCount = getVertexCount(document);
 	const dstBounds = roundBbox(getBounds(scene), 2);
 
-	t.truthy((srcCount - dstCount) / srcCount > 0.5, '≥50% reduction');
+	t.truthy((srcCount - dstCount) / srcCount > 0.5, '>=50% reduction');
 	t.truthy(srcCount > dstCount, 'src.count > dst.count');
 	t.deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
 });


### PR DESCRIPTION
Fix for https://github.com/donmccurdy/glTF-Transform/issues/1146

Remove special character to correct display in terminal

change `≤`  to `<=`
change `≥`  to `>=`