### PR TITLE
Enable prune() to remove redundant mesh indices

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -347,7 +347,12 @@ commands or using the scripting API.
 
 		transforms.push(
 			resample({ ready: resampleReady, resample: resampleWASM }),
-			prune({ keepAttributes: false, keepLeaves: false, keepSolidTextures: false }),
+			prune({
+				keepAttributes: false,
+				keepIndices: false,
+				keepLeaves: false,
+				keepSolidTextures: false,
+			}),
 			sparse(),
 		);
 
@@ -500,6 +505,10 @@ that are children of a scene.
 	.argument('<input>', INPUT_DESC)
 	.argument('<output>', OUTPUT_DESC)
 	.option('--keep-attributes <keepAttributes>', 'Whether to keep unused vertex attributes', {
+		validator: Validator.BOOLEAN,
+		default: true, // TODO(v4): Default false.
+	})
+	.option('--keep-indices <keepIndices>', 'Whether to keep unused mesh indices', {
 		validator: Validator.BOOLEAN,
 		default: true, // TODO(v4): Default false.
 	})

--- a/packages/functions/src/join.ts
+++ b/packages/functions/src/join.ts
@@ -95,8 +95,9 @@ export function join(_options: JoinOptions = JOIN_DEFAULTS): Transform {
 		await document.transform(
 			prune({
 				propertyTypes: [NODE, MESH, PRIMITIVE, ACCESSOR],
-				keepLeaves: false,
 				keepAttributes: true,
+				keepIndices: true,
+				keepLeaves: false,
 			}),
 		);
 

--- a/packages/functions/src/palette.ts
+++ b/packages/functions/src/palette.ts
@@ -80,10 +80,11 @@ export function palette(_options: PaletteOptions = PALETTE_DEFAULTS): Transform 
 		// Find and remove unused TEXCOORD_n attributes.
 		await document.transform(
 			prune({
-				keepAttributes: false,
-				keepLeaves: true,
 				propertyTypes: [PropertyType.ACCESSOR],
-			})
+				keepAttributes: false,
+				keepIndices: true,
+				keepLeaves: true,
+			}),
 		);
 
 		const prims = new Set<Primitive>();

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -39,6 +39,8 @@ export interface PruneOptions {
 	keepLeaves?: boolean;
 	/** Whether to keep unused vertex attributes, such as UVs without an assigned texture. */
 	keepAttributes?: boolean;
+	/** Whether to keep redundant mesh indices, where vertex count equals index count. */
+	keepIndices?: boolean;
 	/** Whether to keep single-color textures that can be converted to material factors. */
 	keepSolidTextures?: boolean;
 }
@@ -58,6 +60,7 @@ const PRUNE_DEFAULTS: Required<PruneOptions> = {
 	],
 	keepLeaves: false,
 	keepAttributes: true,
+	keepIndices: false,
 	keepSolidTextures: true,
 };
 
@@ -160,6 +163,15 @@ export function prune(_options: PruneOptions = PRUNE_DEFAULTS): Transform {
 			}
 			for (const [material, prims] of materialPrims) {
 				shiftTexCoords(material, Array.from(prims));
+			}
+		}
+
+		// Prune unused mesh indices.
+		if (!options.keepIndices && propertyTypes.has(PropertyType.ACCESSOR)) {
+			for (const mesh of root.listMeshes()) {
+				for (const prim of mesh.listPrimitives()) {
+					pruneIndices(prim);
+				}
 			}
 		}
 
@@ -297,6 +309,14 @@ function nodeTreeShake(graph: Graph<Property>, prop: Node | Scene, counter: Disp
 function pruneAttributes(prim: Primitive | PrimitiveTarget, unused: string[]) {
 	for (const semantic of unused) {
 		prim.setAttribute(semantic, null);
+	}
+}
+
+function pruneIndices(prim: Primitive) {
+	const indices = prim.getIndices();
+	const attribute = prim.listAttributes()[0];
+	if (indices && attribute && indices.getCount() === attribute.getCount()) {
+		prim.setIndices(null);
 	}
 }
 

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -60,7 +60,7 @@ const PRUNE_DEFAULTS: Required<PruneOptions> = {
 	],
 	keepLeaves: false,
 	keepAttributes: true,
-	keepIndices: false,
+	keepIndices: true,
 	keepSolidTextures: true,
 };
 

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -79,7 +79,8 @@ const PRUNE_DEFAULTS: Required<PruneOptions> = {
  * document.getRoot().listMaterials(); // → [Material]
  * ```
  *
- * Use {@link PruneOptions} to control what content should be pruned. For example, you can preserve empty objects in the scene hierarchy using the option `keepLeaves`. 
+ * Use {@link PruneOptions} to control what content should be pruned. For example, you can preserve
+ * empty objects in the scene hierarchy using the option `keepLeaves`.
  *
  * @category Transforms
  */

--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -125,7 +125,11 @@ export function quantize(_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transfo
 		}
 
 		await doc.transform(
-			prune({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.SKIN, PropertyType.MATERIAL] }),
+			prune({
+				propertyTypes: [PropertyType.ACCESSOR, PropertyType.SKIN, PropertyType.MATERIAL],
+				keepAttributes: true,
+				keepIndices: true,
+			}),
 			dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL, PropertyType.SKIN] }),
 		);
 

--- a/packages/functions/src/reorder.ts
+++ b/packages/functions/src/reorder.ts
@@ -66,7 +66,7 @@ export function reorder(_options: ReorderOptions): Transform {
 			const [remap, unique] = encoder.reorderMesh(
 				indicesArray,
 				plan.indicesToMode.get(srcIndices) === Primitive.Mode.TRIANGLES,
-				options.target === 'size'
+				options.target === 'size',
 			);
 
 			dstIndices.setArray(unique <= 65534 ? new Uint16Array(indicesArray) : indicesArray);
@@ -90,7 +90,13 @@ export function reorder(_options: ReorderOptions): Transform {
 		}
 
 		// Clean up any attributes left unused by earlier cloning.
-		await doc.transform(prune({ propertyTypes: [PropertyType.ACCESSOR] }));
+		await doc.transform(
+			prune({
+				propertyTypes: [PropertyType.ACCESSOR],
+				keepAttributes: true,
+				keepIndices: true,
+			}),
+		);
 
 		if (!plan.indicesToAttributes.size) {
 			logger.warn(`${NAME}: No qualifying primitives found; may need to weld first.`);

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -103,7 +103,12 @@ export function simplify(_options: SimplifyOptions): Transform {
 
 		// Where simplification removes meshes, we may need to prune leaf nodes.
 		await document.transform(
-			prune({ keepLeaves: false, propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE] }),
+			prune({
+				propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE],
+				keepAttributes: true,
+				keepIndices: true,
+				keepLeaves: false,
+			}),
 		);
 
 		// Where multiple primitive indices point into the same vertex streams, simplification

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -118,7 +118,14 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 
 		if (options.tolerance > 0) {
 			// If tolerance is greater than 0, welding may remove a mesh, so we prune
-			await doc.transform(prune({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE] }));
+			await doc.transform(
+				prune({
+					propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE],
+					keepAttributes: true,
+					keepIndices: true,
+					keepLeaves: false,
+				}),
+			);
 		}
 
 		await doc.transform(dedup({ propertyTypes: [PropertyType.ACCESSOR] }));


### PR DESCRIPTION
- https://github.com/KhronosGroup/glTF-Sample-Models/issues/226

Example:

```js
import { prune } from '@gltf-transform/functions';

await document.transform(prune({keepIndices: false}));
```

This option may be turned on by default in glTF Transform v4.

To do:

- [x] unit tests
- [x] default on or off?
- [x] update CLI 'prune' and 'optimize' commands