### PR TITLE
Draft: Remove side effects from quantize()

### DIFF
--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -11,19 +11,16 @@ import {
 	Primitive,
 	PrimitiveTarget,
 	Property,
-	PropertyType,
 	Skin,
 	Transform,
 	vec2,
 	vec3,
 	vec4,
 } from '@gltf-transform/core';
-import { dedup } from './dedup.js';
 import { fromRotationTranslationScale, fromScaling, invert, multiply as multiplyMat4 } from 'gl-matrix/mat4';
 import { max, min, scale, transformMat4 } from 'gl-matrix/vec3';
 import { InstancedMesh, KHRMeshQuantization } from '@gltf-transform/extensions';
 import type { Volume } from '@gltf-transform/extensions';
-import { prune } from './prune.js';
 import { createTransform } from './utils.js';
 import { sortPrimitiveWeights } from './sort-primitive-weights.js';
 
@@ -148,14 +145,14 @@ export function quantize(_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transfo
 			}
 		}
 
-		await doc.transform(
-			prune({
-				propertyTypes: [PropertyType.ACCESSOR, PropertyType.SKIN, PropertyType.MATERIAL],
-				keepAttributes: true,
-				keepIndices: true,
-			}),
-			dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL, PropertyType.SKIN] }),
-		);
+		// await doc.transform(
+		// 	prune({
+		// 		propertyTypes: [PropertyType.ACCESSOR, PropertyType.SKIN, PropertyType.MATERIAL],
+		// 		keepAttributes: true,
+		// 		keepIndices: true,
+		// 	}),
+		// 	dedup({ propertyTypes: [PropertyType.ACCESSOR, PropertyType.MATERIAL, PropertyType.SKIN] }),
+		// );
 
 		logger.debug(`${NAME}: Complete.`);
 	});


### PR DESCRIPTION
- fixes #1185 

Still a draft. So far this PR tracks which properties have been created or cloned during the quantization process, and considers only those properties for pruning.

We'll still need to consider how to implement deduplication without actually running the whole `dedup()` transform. Currently the [implementation of `dedup`](https://github.com/donmccurdy/glTF-Transform/blob/main/packages/functions/src/dedup.ts)  is fairly complicated — it was written before `a.equals(b)` was available I think. Maybe it could be simpler by using that. But we need to be pretty careful to not introduce performance regressions for models that may have many thousands of accessors. My rough ideas for next steps would be:

1. expose separate functions like
  - `getDuplicateMaterials(materials)`
  - `getDuplicateAccessors(accessors)`
  - ...
2. call those functions with all materials/accessors/... in `dedup()` and only with modified properties in `quantize()`
3. clean things up and simplify as much as possible

If anyone is interested in improving `dedup()` in a separate PR please let me know, I'm not sure yet when I'll get to that.