### PR TITLE
Deprecate hex getters/setters

### DIFF
--- a/packages/core/src/properties/material.ts
+++ b/packages/core/src/properties/material.ts
@@ -208,6 +208,7 @@ export class Material extends ExtensibleProperty<IMaterial> {
 
 	/**
 	 * Base color / albedo; sRGB hexadecimal color. See {@link Material.getBaseColorTexture getBaseColorTexture}.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
 	 */
 	public getBaseColorHex(): number {
 		return ColorUtils.factorToHex(this.get('baseColorFactor'));
@@ -215,6 +216,7 @@ export class Material extends ExtensibleProperty<IMaterial> {
 
 	/**
 	 * Base color / albedo; sRGB hexadecimal color. See {@link Material.getBaseColorTexture getBaseColorTexture}.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
 	 */
 	public setBaseColorHex(hex: number): this {
 		const factor = this.get('baseColorFactor').slice() as vec4;
@@ -262,12 +264,18 @@ export class Material extends ExtensibleProperty<IMaterial> {
 		return this.set('emissiveFactor', emissiveFactor);
 	}
 
-	/** Emissive; sRGB hexadecimal color. See {@link Material.getBaseColorTexture getBaseColorTexture}. */
+	/**
+	 * Emissive; sRGB hexadecimal color. See {@link Material.getBaseColorTexture getBaseColorTexture}.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public getEmissiveHex(): number {
 		return ColorUtils.factorToHex(this.get('emissiveFactor'));
 	}
 
-	/** Emissive; sRGB hexadecimal color. See {@link Material.getEmissiveTexture getEmissiveTexture}. */
+	/**
+	 * Emissive; sRGB hexadecimal color. See {@link Material.getEmissiveTexture getEmissiveTexture}.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public setEmissiveHex(hex: number): this {
 		const factor = this.get('emissiveFactor').slice() as vec3;
 		return this.set('emissiveFactor', ColorUtils.hexToFactor(hex, factor));

--- a/packages/extensions/src/khr-lights-punctual/light.ts
+++ b/packages/extensions/src/khr-lights-punctual/light.ts
@@ -67,12 +67,18 @@ export class Light extends ExtensionProperty<ILight> {
 		return this.set('color', color);
 	}
 
-	/** Light color; sRGB hexadecimal color. */
+	/**
+	 * Light color; sRGB hexadecimal color.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public getColorHex(): number {
 		return ColorUtils.factorToHex(this.getColor());
 	}
 
-	/** Light color; sRGB hexadecimal color. */
+	/**
+	 * Light color; sRGB hexadecimal color.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public setColorHex(hex: number): this {
 		const color = this.getColor().slice() as vec3;
 		ColorUtils.hexToFactor(hex, color);

--- a/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
+++ b/packages/extensions/src/khr-materials-pbr-specular-glossiness/pbr-specular-glossiness.ts
@@ -65,12 +65,18 @@ export class PBRSpecularGlossiness extends ExtensionProperty<IPBRSpecularGlossin
 		return this.set('diffuseFactor', factor);
 	}
 
-	/** Diffuse; sRGB hexadecimal color. */
+	/**
+	 * Diffuse; sRGB hexadecimal color.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public getDiffuseHex(): number {
 		return ColorUtils.factorToHex(this.getDiffuseFactor());
 	}
 
-	/** Diffuse; sRGB hexadecimal color. */
+	/**
+	 * Diffuse; sRGB hexadecimal color.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public setDiffuseHex(hex: number): this {
 		const factor = this.getDiffuseFactor().slice() as vec4;
 		return this.setDiffuseFactor(ColorUtils.hexToFactor(hex, factor));

--- a/packages/extensions/src/khr-materials-sheen/sheen.ts
+++ b/packages/extensions/src/khr-materials-sheen/sheen.ts
@@ -57,7 +57,10 @@ export class Sheen extends ExtensionProperty<ISheen> {
 		return this.get('sheenColorFactor');
 	}
 
-	/** Sheen; hex color in sRGB colorspace. */
+	/**
+	 * Sheen; hex color in sRGB colorspace.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public getSheenColorHex(): number {
 		return ColorUtils.factorToHex(this.getSheenColorFactor());
 	}
@@ -67,7 +70,10 @@ export class Sheen extends ExtensionProperty<ISheen> {
 		return this.set('sheenColorFactor', factor);
 	}
 
-	/** Sheen; hex color in sRGB colorspace. */
+	/**
+	 * Sheen; hex color in sRGB colorspace.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public setSheenColorHex(hex: number): this {
 		const factor = this.getSheenColorFactor().slice() as vec3;
 		return this.set('sheenColorFactor', ColorUtils.hexToFactor(hex, factor));

--- a/packages/extensions/src/khr-materials-specular/specular.ts
+++ b/packages/extensions/src/khr-materials-specular/specular.ts
@@ -72,12 +72,18 @@ export class Specular extends ExtensionProperty<ISpecular> {
 		return this.set('specularColorFactor', factor);
 	}
 
-	/** Specular color; sRGB hexadecimal color. See {@link Specular.getSpecularTexture getSpecularTexture} */
+	/**
+	 * Specular color; sRGB hexadecimal color. See {@link Specular.getSpecularTexture getSpecularTexture}
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public getSpecularColorHex(): number {
 		return ColorUtils.factorToHex(this.getSpecularColorFactor());
 	}
 
-	/** Specular color; sRGB hexadecimal color. See {@link Specular.getSpecularTexture getSpecularTexture} */
+	/**
+	 * Specular color; sRGB hexadecimal color. See {@link Specular.getSpecularTexture getSpecularTexture}
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
+	 */
 	public setSpecularColorHex(hex: number): this {
 		const factor = this.getSpecularColorFactor().slice() as vec3;
 		return this.set('specularColorFactor', ColorUtils.hexToFactor(hex, factor));

--- a/packages/extensions/src/khr-materials-volume/volume.ts
+++ b/packages/extensions/src/khr-materials-volume/volume.ts
@@ -131,6 +131,7 @@ export class Volume extends ExtensionProperty<IVolume> {
 	/**
 	 * Color (sRGB) that white light turns into due to absorption when reaching the attenuation
 	 * distance.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
 	 */
 	public getAttenuationColorHex(): number {
 		return ColorUtils.factorToHex(this.getAttenuationColor());
@@ -139,6 +140,7 @@ export class Volume extends ExtensionProperty<IVolume> {
 	/**
 	 * Color (sRGB) that white light turns into due to absorption when reaching the attenuation
 	 * distance.
+	 * @deprecated Will be removed in v4. Use {@link ColorUtils.hexToFactor} / {@link ColorUtils.factorToHex} instead.
 	 */
 	public setAttenuationColorHex(hex: number): this {
 		const factor = this.getAttenuationColor().slice() as vec3;

--- a/packages/functions/test/palette.test.ts
+++ b/packages/functions/test/palette.test.ts
@@ -12,7 +12,7 @@ test('basic', async (t) => {
 		['A', 'B', 'C', 'D', 'E'],
 		[0xff0000, 0x00ff00, 0x0000ff, 0x00ff00, 0xff0000],
 		[1.0, 1.0, 1.0, 0.0, 1.0],
-		['OPAQUE', 'OPAQUE', 'OPAQUE', 'OPAQUE', 'BLEND']
+		['OPAQUE', 'OPAQUE', 'OPAQUE', 'OPAQUE', 'BLEND'],
 	);
 
 	await document.transform(palette({ min: 2 }));
@@ -40,7 +40,7 @@ test('options.blockSize', async (t) => {
 		['A', 'B', 'C', 'D', 'E'],
 		[0xff0000, 0x00ff00, 0x0000ff, 0x00ff00, 0xff0000],
 		new Array(5).fill(1.0),
-		new Array(5).fill('OPAQUE')
+		new Array(5).fill('OPAQUE'),
 	);
 
 	await document.transform(palette({ blockSize: 10 }));
@@ -64,7 +64,7 @@ test('options.min', async (t) => {
 		['A', 'B', 'C', 'D', 'E'],
 		[0xff0000, 0x00ff00, 0x0000ff, 0x00ff00, 0xff0000],
 		new Array(5).fill(1.0),
-		new Array(5).fill('OPAQUE')
+		new Array(5).fill('OPAQUE'),
 	);
 
 	t.is(document.getRoot().listMaterials().length, 5, 'initial');
@@ -85,7 +85,7 @@ test('preserve extensions', async (t) => {
 		['A', 'B', 'C', 'D', 'E'],
 		[0xff0000, 0x00ff00, 0x0000ff, 0x00ff00, 0xff0000],
 		new Array(5).fill(1.0),
-		new Array(5).fill('OPAQUE')
+		new Array(5).fill('OPAQUE'),
 	);
 
 	const specular = document
@@ -113,7 +113,7 @@ test('pixel values', async (t) => {
 		['A', 'B', 'C'],
 		[0x808080, 0x000080, 0x800000],
 		new Array(3).fill(1.0),
-		new Array(3).fill('OPAQUE')
+		new Array(3).fill('OPAQUE'),
 	);
 
 	await document.transform(palette({ blockSize: 2 }));
@@ -145,7 +145,7 @@ test('pixel values', async (t) => {
 			0, 0, 0, 0,
 			0, 0, 0, 0,
 		],
-		'pixel values'
+		'pixel values',
 	);
 });
 
@@ -154,9 +154,9 @@ test('pixel values', async (t) => {
 function createMaterials(
 	document: Document,
 	names: string[],
-	baseColorFactors: number[],
+	baseColorHexCodes: number[],
 	roughnessFactors: number[],
-	alphaModes: GLTF.MaterialAlphaMode[]
+	alphaModes: GLTF.MaterialAlphaMode[],
 ): Material[] {
 	const position = document
 		.createAccessor()
@@ -169,7 +169,7 @@ function createMaterials(
 	for (let i = 0; i < names.length; i++) {
 		const material = document
 			.createMaterial(names[i])
-			.setBaseColorHex(baseColorFactors[i])
+			.setBaseColorHex(baseColorHexCodes[i])
 			.setRoughnessFactor(roughnessFactors[i])
 			.setAlphaMode(alphaModes[i]);
 		mesh.addPrimitive(prim.clone().setMaterial(material));


### PR DESCRIPTION
Instead of the separate hex getters/setters, use ColorUtils to convert to/from factors. See: https://gltf-transform.dev/modules/core/classes/ColorUtils.
- Related #1158 