### PR TITLE
Prune normals from unlit materials and point clouds

### DIFF
--- a/packages/functions/test/prune.test.ts
+++ b/packages/functions/test/prune.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { Accessor, Document, Primitive, PropertyType } from '@gltf-transform/core';
 import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
-import { prune, unlit } from '@gltf-transform/functions';
+import { prune } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 import ndarray from 'ndarray';
 import { savePixels } from 'ndarray-pixels';


### PR DESCRIPTION
Unlit materials don't respond to light and are unlikely to need normal vectors. Point clouds are also unlikely to use them. When the `keepAttributes` flag is not set, we can remove these normals.

Tasks:

- [x] unit tests