### PR TITLE
Lock CI to Node.js v18.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        # See: https://github.com/privatenumber/tsx/issues/354
+        node-version: [v18.18.x]
     env:
       CI: true
     steps:
@@ -37,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      NODE_VERSION: 18.x
+      NODE_VERSION: v18.18.x
     steps:
     # Setup.
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -63,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      NODE_VERSION: 18.x
+      NODE_VERSION: v18.18.x
     steps:
     # Setup.
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
CI fails on the latest Node.js, v18.19. Lock to v18.18 for now. This affects TypeScript code running with [tsx](https://github.com/privatenumber/tsx/), including the project's unit tests, and is unlikely to affect end-users of the library.

Related:

- https://github.com/privatenumber/tsx/issues/354
- https://github.com/nodejs/node/issues/47747