### PR TITLE
Add power-of-two options to textureCompress()

### DIFF
--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -39,9 +39,8 @@ export interface TextureCompressOptions {
 	 * For example, a 4096x8192 texture, resized with limit [2048, 2048] will
 	 * be reduced to 1024x2048.
 	 *
-	 * Presets "nearest-pot", "ceil-pot", and "floor-pot" may be reused to
-	 * resize textures to power-of-two dimensions, required by older graphics
-	 * APIs including WebGL 1.0.
+	 * Presets "nearest-pot", "ceil-pot", and "floor-pot" resize textures to
+	 * power-of-two dimensions, for older graphics APIs including WebGL 1.0.
 	 */
 	resize?: vec2 | 'nearest-pot' | 'ceil-pot' | 'floor-pot';
 	/** Interpolation used if resizing. Default: TextureResizeFilter.LANCZOS3. */

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -316,10 +316,11 @@ async function _encodeWithSharp(
 		const dstSize = Array.isArray(options.resize)
 			? fitWithin(srcSize, options.resize)
 			: fitPowerOfTwo(srcSize, options.resize);
-		const fit = Array.isArray(options.resize) ? 'inside' : 'fill';
-		const kernel = options.resizeFilter;
-		const withoutEnlargement = Array.isArray(options.resize);
-		instance.resize(dstSize[0], dstSize[1], { fit, kernel, withoutEnlargement });
+		instance.resize(dstSize[0], dstSize[1], {
+			withoutEnlargement: Array.isArray(options.resize),
+			fit: Array.isArray(options.resize) ? 'inside' : 'fill',
+			kernel: options.resizeFilter,
+		});
 	}
 
 	return BufferUtils.toView(await instance.toBuffer());

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -270,3 +270,44 @@ export function fitWithin(size: vec2, limit: vec2): vec2 {
 
 	return [dstWidth, dstHeight];
 }
+
+type ResizePreset = 'nearest-pot' | 'ceil-pot' | 'floor-pot';
+
+/** @hidden */
+export function fitPowerOfTwo(size: vec2, method: ResizePreset): vec2 {
+	if (isPowerOfTwo(size[0]) && isPowerOfTwo(size[1])) {
+		return size;
+	}
+
+	switch (method) {
+		case 'nearest-pot':
+			return size.map(nearestPowerOfTwo) as vec2;
+		case 'ceil-pot':
+			return size.map(ceilPowerOfTwo) as vec2;
+		case 'floor-pot':
+			return size.map(floorPowerOfTwo) as vec2;
+	}
+}
+
+function isPowerOfTwo(value: number): boolean {
+	if (value <= 2) return true;
+	return (value & (value - 1)) === 0 && value !== 0;
+}
+
+function nearestPowerOfTwo(value: number): number {
+	if (value <= 4) return 4;
+
+	const lo = floorPowerOfTwo(value);
+	const hi = ceilPowerOfTwo(value);
+
+	if (hi - value > value - lo) return lo;
+	return hi;
+}
+
+function floorPowerOfTwo(value: number): number {
+	return Math.pow(2, Math.floor(Math.log(value) / Math.LN2));
+}
+
+function ceilPowerOfTwo(value: number): number {
+	return Math.pow(2, Math.ceil(Math.log(value) / Math.LN2));
+}


### PR DESCRIPTION
- fixes #1213

Example:

```js
import { textureCompress } from '@gltf-transform/functions';
import sharp from 'sharp';

await document.transform(
    textureCompress({encoder: sharp, resize: 'nearest-pot'})
);
```