### PR TITLE
Add warning when using both --power-of-two and --width/height in 'resize' command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1174,6 +1174,9 @@ preserving original aspect ratio. Texture dimensions are never increased.
 		type Preset = 'nearest-pot' | 'ceil-pot' | 'floor-pot';
 		let resize: vec2 | Preset;
 		if (options.powerOfTwo) {
+			if (options.width || options.height) {
+				logger.warn('When --power-of-two is specified, --width and --height are ignored.');
+			}
 			resize = `${options.powerOfTwo}-pot` as Preset;
 		} else if (Number.isInteger(options.width) && Number.isInteger(options.height)) {
 			resize = [Number(options.width), Number(options.height)];


### PR DESCRIPTION
related:
- #1225 
- #1213 