### PR TITLE
Faster bitwise-equal weld() implementation

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -307,6 +307,15 @@ commands or using the scripting API.
 		validator: Validator.BOOLEAN,
 		default: true,
 	})
+	.option(
+		'--weld-tolerance <tolerance>',
+		'Tolerance for welding vertex positions, as a fraction of primitive AABB. ' +
+			'When set to zero, welds run much faster and require bitwise equality.',
+		{
+			validator: Validator.NUMBER,
+			default: WELD_DEFAULTS.tolerance,
+		},
+	)
 	.action(async ({ args, options, logger }) => {
 		const opts = options as {
 			instance: boolean;
@@ -321,6 +330,7 @@ commands or using the scripting API.
 			flatten: boolean;
 			join: boolean;
 			weld: boolean;
+			weldTolerance: number;
 		};
 
 		// Baseline transforms.
@@ -334,7 +344,7 @@ commands or using the scripting API.
 		if (opts.weld) {
 			transforms.push(
 				weld({
-					tolerance: opts.simplify ? opts.simplifyError / 2 : WELD_DEFAULTS.tolerance,
+					tolerance: opts.weldTolerance,
 					toleranceNormal: opts.simplify ? 0.5 : WELD_DEFAULTS.toleranceNormal,
 				}),
 			);
@@ -921,14 +931,24 @@ use higher thresholds around 0.5 (±30º).
 	)
 	.argument('<input>', INPUT_DESC)
 	.argument('<output>', OUTPUT_DESC)
-	.option('--tolerance', 'Tolerance for vertex positions, as a fraction of primitive AABB', {
-		validator: Validator.NUMBER,
-		default: WELD_DEFAULTS.tolerance,
-	})
-	.option('--tolerance-normal', 'Tolerance for vertex normals, in radians', {
-		validator: Validator.NUMBER,
-		default: WELD_DEFAULTS.toleranceNormal,
-	})
+	.option(
+		'--tolerance',
+		'Tolerance for welding vertex positions, as a fraction of primitive AABB. ' +
+			'When set to zero, welds run much faster and require bitwise equality.',
+		{
+			validator: Validator.NUMBER,
+			default: WELD_DEFAULTS.tolerance,
+		},
+	)
+	.option(
+		'--tolerance-normal',
+		'Tolerance for vertex normals, in radians. If --tolerance is zero, ' +
+			'--tolerance-normal is ignored and welds require bitwise equality.',
+		{
+			validator: Validator.NUMBER,
+			default: WELD_DEFAULTS.toleranceNormal,
+		},
+	)
 	.action(({ args, options, logger }) =>
 		Session.create(io, logger, args.input, args.output).transform(weld(options as unknown as WeldOptions)),
 	);

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -65,8 +65,9 @@ export class Session {
 			const prevLevel = logger.getVerbosity();
 			if (prevLevel === Verbosity.INFO) logger.setVerbosity(Verbosity.WARN);
 
-			// Simple renderer shows warnings and errors. Disable signal listeners so Ctrl+C works.
-			await new Listr(tasks, { renderer: 'simple', registerSignalListeners: false }).run();
+			// Disable signal listeners so Ctrl+C works. Note that 'simple' and 'default'
+			// renderers have different capability to display errors and warnings.
+			await new Listr(tasks, { renderer: 'default', registerSignalListeners: false }).run();
 			console.log('');
 
 			logger.setVerbosity(prevLevel);

--- a/packages/core/src/properties/accessor.ts
+++ b/packages/core/src/properties/accessor.ts
@@ -460,7 +460,7 @@ export class Accessor extends ExtensibleProperty<IAccessor> {
 	}
 
 	/** Assigns the raw typed array underlying this accessor. */
-	public setArray(array: TypedArray): this {
+	public setArray(array: TypedArray | null): this {
 		this.set('componentType', array ? arrayToComponentType(array) : Accessor.ComponentType.FLOAT);
 		this.set('array', array);
 		return this;

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -304,10 +304,10 @@ function nearestPowerOfTwo(value: number): number {
 	return hi;
 }
 
-function floorPowerOfTwo(value: number): number {
+export function floorPowerOfTwo(value: number): number {
 	return Math.pow(2, Math.floor(Math.log(value) / Math.LN2));
 }
 
-function ceilPowerOfTwo(value: number): number {
+export function ceilPowerOfTwo(value: number): number {
 	return Math.pow(2, Math.ceil(Math.log(value) / Math.LN2));
 }

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -9,6 +9,7 @@ import {
 	Texture,
 	Transform,
 	TransformContext,
+	TypedArray,
 	vec2,
 } from '@gltf-transform/core';
 
@@ -178,16 +179,20 @@ export function shallowEqualsArray(a: ArrayLike<unknown> | null, b: ArrayLike<un
 }
 
 /** @hidden */
-export function remapAttribute(attribute: Accessor, remap: Uint32Array, dstCount: number) {
+export function remapAttribute(attribute: Accessor, remap: TypedArray, dstCount: number) {
 	const elementSize = attribute.getElementSize();
 	const srcCount = attribute.getCount();
 	const srcArray = attribute.getArray()!;
 	const dstArray = srcArray.slice(0, dstCount * elementSize);
+	const done = new Uint8Array(dstCount);
 
-	for (let i = 0; i < srcCount; i++) {
+	for (let srcIndex = 0; srcIndex < srcCount; srcIndex++) {
+		const dstIndex = remap[srcIndex];
+		if (done[dstIndex]) continue;
 		for (let j = 0; j < elementSize; j++) {
-			dstArray[remap[i] * elementSize + j] = srcArray[i * elementSize + j];
+			dstArray[dstIndex * elementSize + j] = srcArray[srcIndex * elementSize + j];
 		}
+		done[dstIndex] = 1;
 	}
 
 	attribute.setArray(dstArray);

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -32,7 +32,7 @@ import {
 // (Approach #4) Hybrid of (1) and (2), assigning vertices to a spatial
 // grid, then searching the local neighborhood (27 cells) for weld candidates.
 //
-// (Approach #5) ... TODO
+// (Approach #5) ... TODO(DO NOT SUBMIT): Document new implementation.
 //
 // RESULTS: For the "Lovecraftian" sample model, after joining, a primitive
 // with 873,000 vertices can be welded down to 230,000 vertices. Results:
@@ -47,7 +47,7 @@ const NAME = 'weld';
 const EMPTY = 2 ** 32 - 1;
 
 const Tolerance = {
-	DEFAULT: 0.0001,
+	DEFAULT: 0,
 	TEXCOORD: 0.0001, // [0, 1]
 	COLOR: 0.01, // [0, 1]
 	NORMAL: 0.05, // [-1, 1], ±3º
@@ -75,6 +75,8 @@ export const WELD_DEFAULTS: Required<WeldOptions> = {
 };
 
 /**
+ * TODO(DO NOT SUBMIT): Document new implementation.
+ *
  * Index {@link Primitive Primitives} and (optionally) merge similar vertices. When merged
  * and indexed, data is shared more efficiently between vertices. File size can
  * be reduced, and the GPU can sometimes use the vertex cache more efficiently.
@@ -108,7 +110,6 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 	return createTransform(NAME, async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
 
-		console.time('weld');
 		for (const mesh of doc.getRoot().listMeshes()) {
 			for (const prim of mesh.listPrimitives()) {
 				weldPrimitive(prim, options);
@@ -118,7 +119,6 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 
 			if (mesh.listPrimitives().length === 0) mesh.dispose();
 		}
-		console.timeEnd('weld');
 
 		if (options.tolerance > 0) {
 			// If tolerance is greater than 0, welding may remove a mesh, so we prune
@@ -139,6 +139,8 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 }
 
 /**
+ * TODO(DO NOT SUBMIT): Document new implementation.
+ *
  * Index a {@link Primitive} and (optionally) weld similar vertices. When merged
  * and indexed, data is shared more efficiently between vertices. File size can
  * be reduced, and the GPU can sometimes use the vertex cache more efficiently.

--- a/packages/functions/test/weld.test.ts
+++ b/packages/functions/test/weld.test.ts
@@ -80,7 +80,7 @@ test('tolerance>0', async (t) => {
 		.setAttribute('NORMAL', normal);
 	doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
-	await doc.transform(weld());
+	await doc.transform(weld({ tolerance: 0.0001 }));
 
 	t.deepEqual(prim1.getIndices().getArray(), new Uint16Array([0, 1, 2, 0, 1, 2]), 'indices on prim1');
 	t.deepEqual(prim2.getIndices().getArray(), new Uint16Array([0, 1, 2, 0, 1, 2]), 'indices on prim2');


### PR DESCRIPTION
Provides an alternative `weld()` implementation based on [Meshoptimizer](https://meshoptimizer.org/)'s approach. When tolerance=0, we use a hashtable to find bitwise-equal vertices quickly. This is vastly faster than previous approaches, but comes without tolerance options. When tolerance is non-zero, `weld()` falls back on the older implementation. In v4.0, the new implementation will be the default.

### Results

| model | before | after |
|-------|--------|-------|
| lovecraftian | 1,232ms | 149ms |
| plant_3 | 2,607ms | 431ms |
| concessionaire | 138ms | 32ms |
| weld_problem | 115ms | 21ms |

### Context

- Fixes https://github.com/donmccurdy/glTF-Transform/issues/738
- Related https://github.com/donmccurdy/glTF-Transform/pull/803
- Related https://github.com/donmccurdy/glTF-Transform/issues/1133

### Tasks

- [x] ~~debug performance regression above. hash collisions maybe?~~
- [x] add benchmark
