### PR TITLE
fix(functions): Fix models broken by instance()

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import { Logger, NodeIO, PropertyType, VertexLayout, vec2, Transform } from '@gl
 import {
 	CenterOptions,
 	InstanceOptions,
+	INSTANCE_DEFAULTS,
 	PartitionOptions,
 	PruneOptions,
 	QUANTIZE_DEFAULTS,
@@ -250,7 +251,7 @@ commands or using the scripting API.
 	})
 	.option('--instance-min <min>', 'Number of instances required for instancing.', {
 		validator: Validator.NUMBER,
-		default: 5,
+		default: INSTANCE_DEFAULTS.min,
 	})
 	.option('--palette <bool>', 'Creates palette textures and merges materials.', {
 		validator: Validator.BOOLEAN,
@@ -262,7 +263,7 @@ commands or using the scripting API.
 			'material values are found, no palettes will be generated.',
 		{
 			validator: Validator.NUMBER,
-			default: 5,
+			default: PALETTE_DEFAULTS.min,
 		},
 	)
 	.option('--simplify <bool>', 'Simplify mesh geometry with meshoptimizer.', {
@@ -647,6 +648,15 @@ https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Vendor/EXT_mesh_
 	)
 	.argument('<input>', INPUT_DESC)
 	.argument('<output>', OUTPUT_DESC)
+	.option(
+		'--min <count>',
+		'Minimum number of meshes in a batch. If fewer compatible meshes ' +
+			'are found, no instanced batches will be generated.',
+		{
+			validator: Validator.NUMBER,
+			default: INSTANCE_DEFAULTS.min,
+		},
+	)
 	.action(({ args, options, logger }) =>
 		Session.create(io, logger, args.input, args.output).transform(instance({ ...options } as InstanceOptions)),
 	);

--- a/packages/core/src/properties/node.ts
+++ b/packages/core/src/properties/node.ts
@@ -48,13 +48,6 @@ interface INode extends IExtensibleProperty {
 export class Node extends ExtensibleProperty<INode> {
 	public declare propertyType: PropertyType.NODE;
 
-	/**
-	 * Internal reference to N parent scenes, omitted from {@link Graph}.
-	 * @internal
-	 * @privateRemarks Requires non-graph state.
-	 */
-	public _parentScenes = new Set<Scene>();
-
 	protected init(): void {
 		this.propertyType = PropertyType.NODE;
 	}
@@ -191,16 +184,14 @@ export class Node extends ExtensibleProperty<INode> {
 	 * The `addChild` method enforces these restrictions automatically, and will
 	 * remove the new child from previous parents where needed. This behavior
 	 * may change in future major releases of the library.
-	 *
-	 * @privateRemarks Requires non-graph state.
 	 */
 	public addChild(child: Node): this {
 		// Remove existing parents.
 		const parentNode = child.getParentNode();
 		if (parentNode) parentNode.removeChild(child);
-		if (child._parentScenes.size) {
-			for (const scene of child._parentScenes) {
-				scene.removeChild(child);
+		for (const parent of child.listParents()) {
+			if (parent.propertyType === PropertyType.SCENE) {
+				(parent as Scene).removeChild(child);
 			}
 		}
 
@@ -226,7 +217,7 @@ export class Node extends ExtensibleProperty<INode> {
 	 * references from properties of any type ({@link Skin}, {@link Root}, ...).
 	 */
 	public getParentNode(): Node | null {
-		for (const parent of this.getGraph().listParents(this)) {
+		for (const parent of this.listParents()) {
 			if (parent.propertyType === PropertyType.NODE) {
 				return parent as Node;
 			}

--- a/packages/core/src/properties/scene.ts
+++ b/packages/core/src/properties/scene.ts
@@ -57,7 +57,8 @@ export class Scene extends ExtensibleProperty<IScene> {
 	 */
 	public addChild(node: Node): this {
 		// Remove existing parent.
-		if (node._parentNode) node._parentNode.removeChild(node);
+		const parentNode = node.getParentNode();
+		if (parentNode) parentNode.removeChild(node);
 
 		// Edge in graph.
 		this.addRef('children', node);

--- a/packages/core/src/properties/scene.ts
+++ b/packages/core/src/properties/scene.ts
@@ -1,4 +1,3 @@
-import { $attributes } from 'property-graph';
 import { Nullable, PropertyType } from '../constants.js';
 import { ExtensibleProperty, IExtensibleProperty } from './extensible-property.js';
 import type { Node } from './node.js';
@@ -52,24 +51,13 @@ export class Scene extends ExtensibleProperty<IScene> {
 	 * The `addChild` method enforces these restrictions automatically, and will
 	 * remove the new child from previous parents where needed. This behavior
 	 * may change in future major releases of the library.
-	 *
-	 * @privateRemarks Requires non-graph state.
 	 */
 	public addChild(node: Node): this {
 		// Remove existing parent.
 		const parentNode = node.getParentNode();
 		if (parentNode) parentNode.removeChild(node);
 
-		// Edge in graph.
-		this.addRef('children', node);
-
-		// Set new parent.
-		// TODO(cleanup): Avoid reaching into $attributes.
-		node._parentScenes.add(this);
-		const childrenRefs = this[$attributes]['children'];
-		const ref = childrenRefs[childrenRefs.length - 1];
-		ref.addEventListener('dispose', () => node._parentScenes.delete(this));
-		return this;
+		return this.addRef('children', node);
 	}
 
 	/** Removes a {@link Node} from the Scene. */

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -141,3 +141,22 @@ test('identity transforms', async (t) => {
 		'has transform info',
 	);
 });
+
+test('getParentNode', (t) => {
+	const srcDocument = new Document();
+	const srcNodeA = srcDocument.createNode('A');
+	const srcNodeB = srcDocument.createNode('B');
+	const srcNodeC = srcDocument.createNode('C');
+	srcNodeA.addChild(srcNodeB).addChild(srcNodeC);
+
+	t.deepEqual(srcNodeA.listChildren(), [srcNodeB, srcNodeC], 'a.listChildren()');
+	t.is(srcNodeB.getParentNode(), srcNodeA, 'b.getParentNode()');
+	t.is(srcNodeC.getParentNode(), srcNodeA, 'c.getParentNode()');
+
+	const dstDocument = srcDocument.clone();
+	const [dstNodeA, dstNodeB, dstNodeC] = dstDocument.getRoot().listNodes();
+
+	t.deepEqual(dstNodeA.listChildren(), [dstNodeB, dstNodeC], 'a.listChildren()');
+	t.is(dstNodeB.getParentNode(), dstNodeA, 'b.getParentNode()');
+	t.is(dstNodeC.getParentNode(), dstNodeA, 'c.getParentNode()');
+});

--- a/packages/functions/src/palette.ts
+++ b/packages/functions/src/palette.ts
@@ -23,14 +23,14 @@ export interface PaletteOptions {
 	blockSize?: number;
 	/**
 	 * Minimum number of blocks in the palette texture. If fewer unique
-	 * material values are found, no palettes will be generated. Default: 2.
+	 * material values are found, no palettes will be generated. Default: 5.
 	 */
 	min?: number;
 }
 
 export const PALETTE_DEFAULTS: Required<PaletteOptions> = {
 	blockSize: 4,
-	min: 2,
+	min: 5,
 };
 
 /**

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -15,7 +15,7 @@ import {
 import { cleanPrimitive } from './clean-primitive.js';
 
 /**
- * Prepares a function used in an {@link Document.transform} pipeline. Use of this wrapper is
+ * Prepares a function used in an {@link Document#transform} pipeline. Use of this wrapper is
  * optional, and plain functions may be used in transform pipelines just as well. The wrapper is
  * used internally so earlier pipeline stages can detect and optimize based on later stages.
  * @hidden

--- a/packages/functions/test/instance.test.ts
+++ b/packages/functions/test/instance.test.ts
@@ -15,7 +15,7 @@ test('translation', async (t) => {
 	const node3 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 2]);
 	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance());
+	await doc.transform(instance({min: 2}));
 
 	t.is(root.listNodes().length, 1, 'creates batch node');
 	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
@@ -49,7 +49,7 @@ test('rotation', async (t) => {
 	const node3 = doc.createNode().setMesh(mesh).setRotation([0, x, 0, x]);
 	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance());
+	await doc.transform(instance({min: 2}));
 
 	t.is(root.listNodes().length, 1, 'creates batch node');
 	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
@@ -82,7 +82,7 @@ test('scale', async (t) => {
 	const node3 = doc.createNode().setMesh(mesh).setScale([1, 1, 5]);
 	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance());
+	await doc.transform(instance({min: 2}));
 
 	t.is(root.listNodes().length, 1, 'creates batch node');
 	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');

--- a/packages/functions/test/palette.test.ts
+++ b/packages/functions/test/palette.test.ts
@@ -55,7 +55,7 @@ test('options.blockSize', async (t) => {
 		new Array(5).fill('OPAQUE'),
 	);
 
-	await document.transform(palette({ blockSize: 10 }));
+	await document.transform(palette({ min: 2, blockSize: 10 }));
 
 	t.is(document.getRoot().listMaterials().length, 1, 'only palette material remains');
 
@@ -118,7 +118,7 @@ test('preserve extensions', async (t) => {
 		.setSpecularColorFactor([0.5, 0.5, 0.5]);
 	material.setExtension('KHR_materials_specular', specular);
 
-	await document.transform(palette());
+	await document.transform(palette({min: 2}));
 
 	t.is(document.getRoot().listMaterials().length, 2, 'specular + non-specular palette materials');
 
@@ -144,7 +144,7 @@ test('pixel values', async (t) => {
 		new Array(3).fill('OPAQUE'),
 	);
 
-	await document.transform(palette({ blockSize: 2 }));
+	await document.transform(palette({ min: 2, blockSize: 2 }));
 
 	const material = document.getRoot().listMaterials()[0];
 	const baseColorPixels = await getPixels(material.getBaseColorTexture().getImage(), 'image/png');


### PR DESCRIPTION
- fixes #1261

Changes:
- Fix `document.clone()` breaking internal `._parentNode` / `._parentScene` references
- Prevent `instance()` from writing batches when no TRS transforms exist
- Default `options.min` values for `palette()` and `instance()` increased from 2 to 5

**Benchmark - before**

```
┌─────────┬───────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │   Task Name   │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │  'clone::sm'  │  '78'   │ 12677701.50567912  │ '±2.87%' │   79    │
│    1    │  'clone::md'  │  '18'   │ 53056004.270126946 │ '±3.53%' │   19    │
│    2    │ 'create::sm'  │  '136'  │ 7318512.770381287  │ '±3.62%' │   137   │
│    3    │ 'create::md'  │  '32'   │ 30542272.728500944 │ '±3.83%' │   33    │
│    4    │ 'dispose::md' │ '2,106' │ 474742.61903649825 │ '±3.22%' │  2110   │
│    5    │  'join::sm'   │  '33'   │ 30217317.439177457 │ '±4.72%' │   34    │
│    6    │  'join::md'   │   '1'   │ 673517695.8978176  │ '±2.95%' │   10    │
│    7    │  'weld::sm'   │ '1,039' │ 962347.0165981696  │ '±1.68%' │  1040   │
│    8    │  'weld::md'   │  '14'   │ 68677394.60865657  │ '±5.81%' │   15    │
└─────────┴───────────────┴─────────┴────────────────────┴──────────┴─────────┘
```

**Benchmark - after**

```
┌─────────┬───────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │   Task Name   │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │  'clone::sm'  │  '80'   │ 12358921.778790744 │ '±2.58%' │   81    │
│    1    │  'clone::md'  │  '19'   │ 52141376.95133686  │ '±2.04%' │   20    │
│    2    │ 'create::sm'  │  '140'  │ 7125451.551684251  │ '±3.33%' │   141   │
│    3    │ 'create::md'  │  '33'   │ 29450553.65562439  │ '±3.63%' │   35    │
│    4    │ 'dispose::md' │ '2,150' │ 465001.9054521466  │ '±3.04%' │  2151   │
│    5    │  'join::sm'   │  '33'   │ 29864753.61270063  │ '±4.87%' │   34    │
│    6    │  'join::md'   │   '1'   │ 672021404.6120644  │ '±2.77%' │   10    │
│    7    │  'weld::sm'   │ '1,040' │ 961322.8369285921  │ '±1.75%' │  1041   │
│    8    │  'weld::md'   │  '14'   │ 68112480.53312302  │ '±3.49%' │   15    │
└─────────┴───────────────┴─────────┴────────────────────┴──────────┴─────────┘
```