### PR TITLE
feat(functions): More aggressive prune() defaults

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,6 +54,7 @@ import {
 	PALETTE_DEFAULTS,
 	MESHOPT_DEFAULTS,
 	TEXTURE_COMPRESS_SUPPORTED_FORMATS,
+	PRUNE_DEFAULTS,
 } from '@gltf-transform/functions';
 import { inspect } from './inspect.js';
 import {
@@ -520,22 +521,22 @@ that are children of a scene.
 	.argument('<output>', OUTPUT_DESC)
 	.option('--keep-attributes <keepAttributes>', 'Whether to keep unused vertex attributes', {
 		validator: Validator.BOOLEAN,
-		default: true, // TODO(v4): Default false.
+		default: PRUNE_DEFAULTS.keepAttributes,
 	})
 	.option('--keep-indices <keepIndices>', 'Whether to keep unused mesh indices', {
 		validator: Validator.BOOLEAN,
-		default: true, // TODO(v4): Default false.
+		default: PRUNE_DEFAULTS.keepIndices,
 	})
 	.option('--keep-leaves <keepLeaves>', 'Whether to keep empty leaf nodes', {
 		validator: Validator.BOOLEAN,
-		default: false,
+		default: PRUNE_DEFAULTS.keepLeaves,
 	})
 	.option(
 		'--keep-solid-textures <keepSolidTextures>',
 		'Whether to keep solid (single-color) textures, or convert to material factors',
 		{
 			validator: Validator.BOOLEAN,
-			default: true, // TODO(v4): Default false.
+			default: PRUNE_DEFAULTS.keepSolidTextures,
 		},
 	)
 	.action(({ args, options, logger }) =>

--- a/packages/core/src/io/deno-io.ts
+++ b/packages/core/src/io/deno-io.ts
@@ -45,16 +45,10 @@ export class DenoIO extends PlatformIO {
 	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array>;
 	protected async readURI(uri: string, type: 'text'): Promise<string>;
 	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string> {
-		// TODO(cleanup): The @ts-ignore rules below are necessary for typedoc, but not for normal
-		// compilation with microbundle. Clean this up when possible.
 		switch (type) {
 			case 'view':
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
 				return Deno.readFile(uri);
 			case 'text':
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
 				return Deno.readTextFile(uri);
 		}
 	}

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -44,7 +44,8 @@ export interface PruneOptions {
 	/** Whether to keep single-color textures that can be converted to material factors. */
 	keepSolidTextures?: boolean;
 }
-const PRUNE_DEFAULTS: Required<PruneOptions> = {
+
+export const PRUNE_DEFAULTS: Required<PruneOptions> = {
 	propertyTypes: [
 		PropertyType.NODE,
 		PropertyType.SKIN,
@@ -59,9 +60,9 @@ const PRUNE_DEFAULTS: Required<PruneOptions> = {
 		PropertyType.BUFFER,
 	],
 	keepLeaves: false,
-	keepAttributes: true,
-	keepIndices: true,
-	keepSolidTextures: true,
+	keepAttributes: false,
+	keepIndices: false,
+	keepSolidTextures: false,
 };
 
 /**

--- a/packages/functions/test/prune.test.ts
+++ b/packages/functions/test/prune.test.ts
@@ -192,7 +192,7 @@ test('attributes - texcoords', async (t) => {
 		.setAttribute('TEXCOORD_5', (uvs[5] = document.createAccessor())); // unused
 	document.createMesh().addPrimitive(primA).addPrimitive(primB);
 
-	await document.transform(prune({ propertyTypes: [PropertyType.ACCESSOR] }));
+	await document.transform(prune({ keepAttributes: true, propertyTypes: [PropertyType.ACCESSOR] }));
 
 	t.deepEqual(
 		uvs.map((a) => a.isDisposed()),
@@ -200,7 +200,7 @@ test('attributes - texcoords', async (t) => {
 		'keeps all texcoords',
 	);
 
-	await document.transform(prune({ propertyTypes: [PropertyType.ACCESSOR], keepAttributes: false }));
+	await document.transform(prune({ keepAttributes: false, propertyTypes: [PropertyType.ACCESSOR] }));
 
 	t.deepEqual(
 		uvs.map((a) => a.isDisposed()),


### PR DESCRIPTION
Disables keepAttributes, keepIndices, and keepLeaves by default.

related:

- https://github.com/donmccurdy/glTF-Transform/issues/1223
