### PR TITLE
fix(core): Fix invalid state of accessor.normalized after clone

### DIFF
--- a/packages/core/test/properties/accessor.test.ts
+++ b/packages/core/test/properties/accessor.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import { Accessor, Document, GLTF, TypedArray } from '@gltf-transform/core';
-import { createPlatformIO } from '@gltf-transform/test-utils';
+import { createPlatformIO, round } from '@gltf-transform/test-utils';
 
 const { FLOAT, UNSIGNED_BYTE, UNSIGNED_SHORT, UNSIGNED_INT, BYTE, SHORT } = Accessor.ComponentType;
 
@@ -267,7 +267,7 @@ test('write sparse', async (t) => {
 	t.is(rtSparseAccessor.getSparse(), true, 'sparseAccessor.sparse (round trip)');
 
 	t.deepEqual(Array.from(rtEmptyAccessor.getArray()), emptyArray, 'emptyAccessor.array (round trip)');
-	t.deepEqual(Array.from(rtSparseAccessor.getArray()), sparseArray, 'emptyAccessor.array (round trip)');
+	t.deepEqual(Array.from(rtSparseAccessor.getArray()), sparseArray, 'sparseAccessor.array (round trip)');
 });
 
 test('minmax', (t) => {
@@ -294,4 +294,20 @@ test('extras', async (t) => {
 
 	t.deepEqual(document.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
 	t.deepEqual(doc2.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');
+});
+
+// See: https://github.com/donmccurdy/glTF-Transform/issues/1271
+test('clone', async (t) => {
+	const srcDocument = new Document();
+	const srcAccessor = srcDocument
+		.createAccessor()
+		.setType('VEC3')
+		.setNormalized(true)
+		.setArray(new Uint8Array([0, 64, 255]));
+	t.deepEqual(srcAccessor.getElement(0, []).map(round(2)), [0, 0.25, 1]);
+
+	const dstAccessor = srcAccessor.clone();
+	srcAccessor.setArray(new Float32Array([0, 0, 0]));
+
+	t.deepEqual(dstAccessor.getElement(0, []).map(round(2)), [0, 0.25, 1]);
 });


### PR DESCRIPTION
Currently the accessor implementation stores references to functions that encode/decode normalized vertex values. When cloning an accessor, those functions held references to their previous scope, and looked up the previous accessor's normalization state.

This PR changes and simplifies the implementation to avoid storing any unnecessary state. The previous implementation was a premature optimization that (as shown by the benchmarks below) did little or nothing. There might be a small regression in `join()` performance, but that's ongoing work for #1253.

**Changes**

- Fixes #1271

**Benchmark - before**

```
┌─────────┬───────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │   Task Name   │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │  'clone::sm'  │  '78'   │ 12718226.924727235 │ '±2.53%' │   79    │
│    1    │  'clone::md'  │  '18'   │  53303135.9910965  │ '±3.31%' │   19    │
│    2    │ 'create::sm'  │  '135'  │ 7357290.743904955  │ '±3.39%' │   136   │
│    3    │ 'create::md'  │  '33'   │ 30239656.813004438 │ '±3.43%' │   34    │
│    4    │ 'dispose::md' │ '2,063' │ 484532.1858229563  │ '±3.21%' │  2064   │
│    5    │  'join::sm'   │  '33'   │ 30231020.916910734 │ '±4.53%' │   34    │
│    6    │  'join::md'   │   '1'   │ 667896770.6918716  │ '±0.96%' │   10    │
│    7    │  'weld::sm'   │ '1,036' │ 965071.4626192702  │ '±1.77%' │  1037   │
│    8    │  'weld::md'   │  '15'   │  65537336.0812664  │ '±3.01%' │   16    │
└─────────┴───────────────┴─────────┴────────────────────┴──────────┴─────────┘
```

**Benchmark - after**

```
┌─────────┬───────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │   Task Name   │ ops/sec │ Average Time (ns)  │  Margin  │ Samples │
├─────────┼───────────────┼─────────┼────────────────────┼──────────┼─────────┤
│    0    │  'clone::sm'  │  '78'   │ 12777751.054944873 │ '±2.65%' │   79    │
│    1    │  'clone::md'  │  '18'   │ 52808026.30123339  │ '±2.90%' │   19    │
│    2    │ 'create::sm'  │  '135'  │  7378732.41501133  │ '±3.60%' │   137   │
│    3    │ 'create::md'  │  '33'   │ 29939408.004283905 │ '±2.62%' │   34    │
│    4    │ 'dispose::md' │ '2,084' │ 479733.5695019729  │ '±3.22%' │  2085   │
│    5    │  'join::sm'   │  '28'   │ 35120684.052335806 │ '±4.73%' │   29    │
│    6    │  'join::md'   │   '1'   │ 771483329.2603493  │ '±0.80%' │   10    │
│    7    │  'weld::sm'   │ '1,042' │ 959606.5411974577  │ '±1.80%' │  1043   │
│    8    │  'weld::md'   │  '15'   │ 64910143.24873686  │ '±3.33%' │   16    │
└─────────┴───────────────┴─────────┴────────────────────┴──────────┴─────────┘
```