### PR TITLE
Optional option to join to suppress the cleanup step.

### DIFF
--- a/packages/functions/src/join.ts
+++ b/packages/functions/src/join.ts
@@ -44,6 +44,10 @@ export interface JoinOptions {
 	 * have no effect. Default: false.
 	 */
 	keepNamed: boolean;
+	/**
+	 * Prevents the final {@link prune} step from being triggered.
+	 */
+	suppressCleanup?:boolean;
 }
 
 export const JOIN_DEFAULTS: Required<JoinOptions> = {
@@ -91,15 +95,17 @@ export function join(_options: JoinOptions = JOIN_DEFAULTS): Transform {
 			scene.traverse((node) => _joinLevel(document, node, options));
 		}
 
-		// Clean up.
-		await document.transform(
-			prune({
-				propertyTypes: [NODE, MESH, PRIMITIVE, ACCESSOR],
-				keepAttributes: true,
-				keepIndices: true,
-				keepLeaves: false,
-			}),
-		);
+		if(!options.suppressCleanup){
+			// Clean up.
+			await document.transform(
+				prune({
+					propertyTypes: [NODE, MESH, PRIMITIVE, ACCESSOR],
+					keepAttributes: true,
+					keepIndices: true,
+					keepLeaves: false,
+				}),
+			);
+		}
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/src/join.ts
+++ b/packages/functions/src/join.ts
@@ -47,12 +47,13 @@ export interface JoinOptions {
 	/**
 	 * Prevents the final {@link prune} step from being triggered.
 	 */
-	suppressCleanup?:boolean;
+	suppressCleanup?: boolean;
 }
 
 export const JOIN_DEFAULTS: Required<JoinOptions> = {
 	keepMeshes: false,
 	keepNamed: false,
+	suppressCleanup: false,
 };
 
 /**
@@ -95,7 +96,7 @@ export function join(_options: JoinOptions = JOIN_DEFAULTS): Transform {
 			scene.traverse((node) => _joinLevel(document, node, options));
 		}
 
-		if(!options.suppressCleanup){
+		if (!options.suppressCleanup) {
 			// Clean up.
 			await document.transform(
 				prune({

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -29,12 +29,17 @@ export interface SimplifyOptions {
 	 * to ensure no seams appear.
 	 */
 	lockBorder?: boolean;
+	/**
+	 * Prevents the final {@link prune} step from being triggered.
+	 */
+	suppressCleanup?: boolean;
 }
 
 export const SIMPLIFY_DEFAULTS: Required<Omit<SimplifyOptions, 'simplifier'>> = {
 	ratio: 0.0,
 	error: 0.0001,
 	lockBorder: false,
+	suppressCleanup: false,
 };
 
 /**
@@ -102,15 +107,17 @@ export function simplify(_options: SimplifyOptions): Transform {
 			if (mesh.listPrimitives().length === 0) mesh.dispose();
 		}
 
-		// Where simplification removes meshes, we may need to prune leaf nodes.
-		await document.transform(
-			prune({
-				propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE],
-				keepAttributes: true,
-				keepIndices: true,
-				keepLeaves: false,
-			}),
-		);
+		if (!options.suppressCleanup) {
+			// Where simplification removes meshes, we may need to prune leaf nodes.
+			await document.transform(
+				prune({
+					propertyTypes: [PropertyType.ACCESSOR, PropertyType.NODE],
+					keepAttributes: true,
+					keepIndices: true,
+					keepLeaves: false,
+				}),
+			);
+		}
 
 		// Where multiple primitive indices point into the same vertex streams, simplification
 		// may write duplicate streams. Find and remove the duplicates after processing.

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -73,6 +73,10 @@ export interface WeldOptions {
 	overwrite?: boolean;
 	/** Enables a more thorough, but slower, search for vertices to weld. */
 	exhaustive?: boolean;
+	/**
+	 * Prevents the final {@link prune} step from being triggered.
+	 */
+	suppressCleanup?: boolean;
 }
 
 export const WELD_DEFAULTS: Required<WeldOptions> = {
@@ -80,6 +84,7 @@ export const WELD_DEFAULTS: Required<WeldOptions> = {
 	toleranceNormal: Tolerance.NORMAL,
 	overwrite: true,
 	exhaustive: false, // donmccurdy/glTF-Transform#886
+	suppressCleanup: false,
 };
 
 /**
@@ -131,7 +136,7 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 			if (mesh.listPrimitives().length === 0) mesh.dispose();
 		}
 
-		if (options.tolerance > 0) {
+		if (options.tolerance > 0 && !options.suppressCleanup) {
 			// If tolerance is greater than 0, welding may remove a mesh, so we prune
 			await doc.transform(
 				prune({


### PR DESCRIPTION
Resolves #1278

It is too aggressive, this gives the option to suppress it allowing for finer control, while not affecting the default behavior.

Also added option to skip cleanup on simplify and weld.