### PR TITLE
Added failing test for join and prevent pruning of empty nodes with custom data

### DIFF
--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -32,3 +32,18 @@ test('quantization', async (t) => {
 	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
 	t.deepEqual(bboxAfter, bboxBefore, 'same bbox');
 });
+
+test('should not prune empty nodes if they have custom data', async (t) => {
+	const io = await createPlatformIO();
+	const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
+	const scene = document.getRoot().getDefaultScene();
+
+	const node = document.createNode('CustomNode');
+	node.setExtras({ customData: 'test' });
+	scene.addChild(node);
+
+	await document.transform(join());
+
+	t.is(document.getRoot().listNodes().length, 2, '2 nodes');
+	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
+});


### PR DESCRIPTION
This pull request adds a failing test for the join function which shows it pruning nodes that have "extra" data that shouldn't be removed, at least optionally.