### PR TITLE
feat(functions): Provide option to skip cleanup in transforms

### DIFF
--- a/packages/functions/src/flatten.ts
+++ b/packages/functions/src/flatten.ts
@@ -6,10 +6,20 @@ import { createTransform } from './utils.js';
 const NAME = 'flatten';
 
 /** Options for the {@link flatten} function. */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface FlattenOptions {}
+export interface FlattenOptions {
+	/**
+	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
+	 * default. Cleanup removes temporary resources created during the operation, but may also remove
+	 * pre-existing unused or duplicate resources in the {@link Document}. Applications that require
+	 * keeping these resources may need to disable cleanup, instead calling {@link dedup} and
+	 * {@link prune} manually (with customized options) later in the processing pipeline.
+	 */
+	cleanup?: boolean;
+}
 
-export const FLATTEN_DEFAULTS: Required<FlattenOptions> = {};
+export const FLATTEN_DEFAULTS: Required<FlattenOptions> = {
+	cleanup: true,
+};
 
 /**
  * Flattens the scene graph, leaving {@link Node Nodes} with
@@ -31,7 +41,6 @@ export const FLATTEN_DEFAULTS: Required<FlattenOptions> = {};
  * @category Transforms
  */
 export function flatten(_options: FlattenOptions = FLATTEN_DEFAULTS): Transform {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const options = { ...FLATTEN_DEFAULTS, ..._options } as Required<FlattenOptions>;
 
 	return createTransform(NAME, async (document: Document): Promise<void> => {
@@ -90,7 +99,9 @@ export function flatten(_options: FlattenOptions = FLATTEN_DEFAULTS): Transform 
 		}
 
 		// (5) Clean up leaf nodes.
-		await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false }));
+		if (options.cleanup) {
+			await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false }));
+		}
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/src/join.ts
+++ b/packages/functions/src/join.ts
@@ -29,7 +29,6 @@ const _matrix = [
 ] as mat4;
 
 /** Options for the {@link join} function. */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface JoinOptions {
 	/**
 	 * Prevents joining distinct {@link Mesh Meshes} and {@link Node Nodes}.
@@ -37,18 +36,27 @@ export interface JoinOptions {
 	 * only _named_ Nodes and Meshes, use
 	 * {@link JoinOptions.keepNamed keepNamed} instead. Default: false.
 	 */
-	keepMeshes: boolean;
+	keepMeshes?: boolean;
 	/**
 	 * Prevents joining _named_ {@link Mesh Meshes} and {@link Node Nodes}.
 	 * If {@link JoinOptions.keepMeshes keepMeshes} is enabled, keepNamed will
 	 * have no effect. Default: false.
 	 */
-	keepNamed: boolean;
+	keepNamed?: boolean;
+	/**
+	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
+	 * default. Cleanup removes temporary resources created during the operation, but may also remove
+	 * pre-existing unused or duplicate resources in the {@link Document}. Applications that require
+	 * keeping these resources may need to disable cleanup, instead calling {@link dedup} and
+	 * {@link prune} manually (with customized options) later in the processing pipeline.
+	 */
+	cleanup?: boolean;
 }
 
 export const JOIN_DEFAULTS: Required<JoinOptions> = {
 	keepMeshes: false,
 	keepNamed: false,
+	cleanup: true,
 };
 
 /**
@@ -92,14 +100,16 @@ export function join(_options: JoinOptions = JOIN_DEFAULTS): Transform {
 		}
 
 		// Clean up.
-		await document.transform(
-			prune({
-				propertyTypes: [NODE, MESH, PRIMITIVE, ACCESSOR],
-				keepAttributes: true,
-				keepIndices: true,
-				keepLeaves: false,
-			}),
-		);
+		if (options.cleanup) {
+			await document.transform(
+				prune({
+					propertyTypes: [NODE, MESH, PRIMITIVE, ACCESSOR],
+					keepAttributes: true,
+					keepIndices: true,
+					keepLeaves: false,
+				}),
+			);
+		}
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/src/palette.ts
+++ b/packages/functions/src/palette.ts
@@ -26,11 +26,20 @@ export interface PaletteOptions {
 	 * material values are found, no palettes will be generated. Default: 5.
 	 */
 	min?: number;
+	/**
+	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
+	 * default. Cleanup removes temporary resources created during the operation, but may also remove
+	 * pre-existing unused or duplicate resources in the {@link Document}. Applications that require
+	 * keeping these resources may need to disable cleanup, instead calling {@link dedup} and
+	 * {@link prune} manually (with customized options) later in the processing pipeline.
+	 */
+	cleanup?: boolean;
 }
 
 export const PALETTE_DEFAULTS: Required<PaletteOptions> = {
 	blockSize: 4,
 	min: 5,
+	cleanup: true,
 };
 
 /**
@@ -291,7 +300,9 @@ export function palette(_options: PaletteOptions = PALETTE_DEFAULTS): Transform 
 			prim.setMaterial(dstMaterial).setAttribute('TEXCOORD_0', uv);
 		}
 
-		await document.transform(prune({ propertyTypes: [PropertyType.MATERIAL] }));
+		if (options.cleanup) {
+			await document.transform(prune({ propertyTypes: [PropertyType.MATERIAL] }));
+		}
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/src/partition.ts
+++ b/packages/functions/src/partition.ts
@@ -7,20 +7,11 @@ const NAME = 'partition';
 export interface PartitionOptions {
 	animations?: boolean | Array<string>;
 	meshes?: boolean | Array<string>;
-	/**
-	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
-	 * default. Cleanup removes temporary resources created during the operation, but may also remove
-	 * pre-existing unused or duplicate resources in the {@link Document}. Applications that require
-	 * keeping these resources may need to disable cleanup, instead calling {@link dedup} and
-	 * {@link prune} manually (with customized options) later in the processing pipeline.
-	 */
-	cleanup?: boolean;
 }
 
 const PARTITION_DEFAULTS: Required<PartitionOptions> = {
 	animations: true,
 	meshes: true,
-	cleanup: true,
 };
 
 /**
@@ -53,9 +44,7 @@ export function partition(_options: PartitionOptions = PARTITION_DEFAULTS): Tran
 			logger.warn(`${NAME}: Select animations or meshes to create a partition.`);
 		}
 
-		if (options.cleanup) {
-			await doc.transform(prune({ propertyTypes: [PropertyType.BUFFER] }));
-		}
+		await doc.transform(prune({ propertyTypes: [PropertyType.BUFFER] }));
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/src/partition.ts
+++ b/packages/functions/src/partition.ts
@@ -7,11 +7,20 @@ const NAME = 'partition';
 export interface PartitionOptions {
 	animations?: boolean | Array<string>;
 	meshes?: boolean | Array<string>;
+	/**
+	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
+	 * default. Cleanup removes temporary resources created during the operation, but may also remove
+	 * pre-existing unused or duplicate resources in the {@link Document}. Applications that require
+	 * keeping these resources may need to disable cleanup, instead calling {@link dedup} and
+	 * {@link prune} manually (with customized options) later in the processing pipeline.
+	 */
+	cleanup?: boolean;
 }
 
 const PARTITION_DEFAULTS: Required<PartitionOptions> = {
 	animations: true,
 	meshes: true,
+	cleanup: true,
 };
 
 /**
@@ -44,7 +53,9 @@ export function partition(_options: PartitionOptions = PARTITION_DEFAULTS): Tran
 			logger.warn(`${NAME}: Select animations or meshes to create a partition.`);
 		}
 
-		await doc.transform(prune({ propertyTypes: [PropertyType.BUFFER] }));
+		if (options.cleanup) {
+			await doc.transform(prune({ propertyTypes: [PropertyType.BUFFER] }));
+		}
 
 		logger.debug(`${NAME}: Complete.`);
 	});

--- a/packages/functions/src/resample.ts
+++ b/packages/functions/src/resample.ts
@@ -8,7 +8,6 @@ import {
 	PropertyType,
 	Root,
 	Transform,
-	TransformContext,
 	TypedArray,
 } from '@gltf-transform/core';
 import { dedup } from './dedup.js';
@@ -71,7 +70,7 @@ const RESAMPLE_DEFAULTS: Required<ResampleOptions> = {
 export function resample(_options: ResampleOptions = RESAMPLE_DEFAULTS): Transform {
 	const options = { ...RESAMPLE_DEFAULTS, ..._options } as Required<ResampleOptions>;
 
-	return createTransform(NAME, async (document: Document, context?: TransformContext): Promise<void> => {
+	return createTransform(NAME, async (document: Document): Promise<void> => {
 		const accessorsVisited = new Set<Accessor>();
 		const srcAccessorCount = document.getRoot().listAccessors().length;
 		const logger = document.getLogger();

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -1,11 +1,10 @@
-import { Document, Primitive, PropertyType, Transform, TransformContext } from '@gltf-transform/core';
+import { Document, Primitive, PropertyType, Transform } from '@gltf-transform/core';
 import {
 	createTransform,
 	formatDeltaOp,
 	deepListAttributes,
 	remapAttribute,
 	deepSwapAttribute,
-	isTransformPending,
 	shallowCloneAccessor,
 } from './utils.js';
 import { weld } from './weld.js';
@@ -90,7 +89,7 @@ export function simplify(_options: SimplifyOptions): Transform {
 		throw new Error(`${NAME}: simplifier dependency required — install "meshoptimizer".`);
 	}
 
-	return createTransform(NAME, async (document: Document, context?: TransformContext): Promise<void> => {
+	return createTransform(NAME, async (document: Document): Promise<void> => {
 		const logger = document.getLogger();
 
 		await simplifier.ready;

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -93,7 +93,7 @@ export function simplify(_options: SimplifyOptions): Transform {
 		const logger = document.getLogger();
 
 		await simplifier.ready;
-		await document.transform(weld({ overwrite: false }));
+		await document.transform(weld({ overwrite: false, cleanup: options.cleanup }));
 
 		// Simplify mesh primitives.
 		for (const mesh of document.getRoot().listMeshes()) {

--- a/packages/functions/test/instance.test.ts
+++ b/packages/functions/test/instance.test.ts
@@ -15,7 +15,7 @@ test('translation', async (t) => {
 	const node3 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 2]);
 	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance({min: 2}));
+	await doc.transform(instance({ min: 2 }));
 
 	t.is(root.listNodes().length, 1, 'creates batch node');
 	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
@@ -49,7 +49,7 @@ test('rotation', async (t) => {
 	const node3 = doc.createNode().setMesh(mesh).setRotation([0, x, 0, x]);
 	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance({min: 2}));
+	await doc.transform(instance({ min: 2 }));
 
 	t.is(root.listNodes().length, 1, 'creates batch node');
 	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
@@ -82,7 +82,7 @@ test('scale', async (t) => {
 	const node3 = doc.createNode().setMesh(mesh).setScale([1, 1, 5]);
 	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance({min: 2}));
+	await doc.transform(instance({ min: 2 }));
 
 	t.is(root.listNodes().length, 1, 'creates batch node');
 	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { getBounds, Document } from '@gltf-transform/core';
 import { join, quantize } from '@gltf-transform/functions';
-import { createPlatformIO, roundBbox } from '@gltf-transform/test-utils';
+import { createPlatformIO, logger, roundBbox } from '@gltf-transform/test-utils';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -34,11 +34,20 @@ test('quantization', async (t) => {
 });
 
 test('no side effects', async (t) => {
-	const document = new Document();
-	document.createNode('A');
-	document.createNode('B');
+	const document = new Document().setLogger(logger);
+	const attributeA = document
+		.createAccessor()
+		.setType('VEC3')
+		.setArray(new Float32Array([1, 2, 3]));
+	const attributeB = attributeA.clone();
+	const prim = document.createPrimitive().setAttribute('POSITION', attributeA).setAttribute('NORMAL', attributeB);
+	const mesh = document.createMesh().addPrimitive(prim);
+	const nodeA = document.createNode('A').setMesh(mesh);
+	const nodeB = document.createNode('B');
+	document.createScene().addChild(nodeA).addChild(nodeB);
 
 	await document.transform(join({ cleanup: false }));
 
-	t.is(document.getRoot().listNodes().length, 2, 'skips cleanup');
+	t.is(document.getRoot().listNodes().length, 2, 'skips prune');
+	t.is(document.getRoot().listAccessors().length, 2, 'skips dedup');
 });

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { getBounds } from '@gltf-transform/core';
+import { getBounds, Document } from '@gltf-transform/core';
 import { join, quantize } from '@gltf-transform/functions';
 import { createPlatformIO, roundBbox } from '@gltf-transform/test-utils';
 import path, { dirname } from 'path';
@@ -31,4 +31,14 @@ test('quantization', async (t) => {
 
 	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
 	t.deepEqual(bboxAfter, bboxBefore, 'same bbox');
+});
+
+test('no side effects', async (t) => {
+	const document = new Document();
+	document.createNode('A');
+	document.createNode('B');
+
+	await document.transform(join({ cleanup: false }));
+
+	t.is(document.getRoot().listNodes().length, 2, 'skips cleanup');
 });

--- a/packages/functions/test/palette.test.ts
+++ b/packages/functions/test/palette.test.ts
@@ -118,7 +118,7 @@ test('preserve extensions', async (t) => {
 		.setSpecularColorFactor([0.5, 0.5, 0.5]);
 	material.setExtension('KHR_materials_specular', specular);
 
-	await document.transform(palette({min: 2}));
+	await document.transform(palette({ min: 2 }));
 
 	t.is(document.getRoot().listMaterials().length, 2, 'specular + non-specular palette materials');
 
@@ -175,6 +175,20 @@ test('pixel values', async (t) => {
 		],
 		'pixel values',
 	);
+});
+
+test('no side effects', async (t) => {
+	const document = new Document().setLogger(logger);
+	const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+	const materialA = document.createMaterial('A').setBaseColorFactor([1, 0, 0, 1]);
+	const materialB = document.createMaterial('B').setBaseColorFactor([0, 1, 0, 1]);
+	const primA = document.createPrimitive().setMaterial(materialA).setAttribute('POSITION', position);
+	const primB = document.createPrimitive().setMaterial(materialB).setAttribute('POSITION', position);
+	document.createMesh().addPrimitive(primA).addPrimitive(primB);
+
+	await document.transform(palette({ cleanup: false, min: 2 }));
+
+	t.true(document.getRoot().listMaterials().length >= 2, 'skips prune and dedup');
 });
 
 /* UTILITIES */

--- a/packages/functions/test/quantize.test.ts
+++ b/packages/functions/test/quantize.test.ts
@@ -5,7 +5,6 @@ import {
 	bbox,
 	getBounds,
 	Document,
-	Logger,
 	Mesh,
 	Node,
 	Primitive,
@@ -15,9 +14,7 @@ import {
 } from '@gltf-transform/core';
 import { EXTMeshGPUInstancing, KHRMaterialsVolume, Volume } from '@gltf-transform/extensions';
 import { quantize } from '@gltf-transform/functions';
-import { round, roundBbox } from '@gltf-transform/test-utils';
-
-const logger = new Logger(Logger.Verbosity.WARN);
+import { logger, round, roundBbox } from '@gltf-transform/test-utils';
 
 test('exclusions', async (t) => {
 	const doc = new Document().setLogger(logger);
@@ -398,6 +395,16 @@ test('volumetric materials', async (t) => {
 	const volumeB = primB.getMaterial().getExtension<Volume>('KHR_materials_volume');
 	t.is(volumeA.getThicknessFactor(), 1 / 2.5, 'volumeA.thickness');
 	t.is(volumeB.getThicknessFactor(), 1 / 50, 'volumeB.thickness');
+});
+
+test('no side effects', async (t) => {
+	const document = new Document();
+	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+	attributeA.clone();
+
+	await document.transform(quantize({ cleanup: false }));
+
+	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
 });
 
 /* UTILITIES */

--- a/packages/functions/test/reorder.test.ts
+++ b/packages/functions/test/reorder.test.ts
@@ -128,6 +128,16 @@ test('morph targets', async (t) => {
 	);
 });
 
+test('no side effects', async (t) => {
+	const document = new Document().setLogger(logger);
+	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+	attributeA.clone();
+
+	await document.transform(reorder({ cleanup: false, encoder: MeshoptEncoder }));
+
+	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+});
+
 /* UTILITIES */
 
 /** Builds a new float32 attribute for given type and data. */

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -172,6 +172,16 @@ test('points - welded', async (t) => {
 	t.is(prim.getIndices(), null, 'unwelded (after)');
 });
 
+test('no side effects', async (t) => {
+	const document = new Document().setLogger(logger);
+	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+	attributeA.clone();
+
+	await document.transform(simplify({ cleanup: false, simplifier: MeshoptSimplifier }));
+
+	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+});
+
 /* UTILITIES */
 
 function getVertexCount(document: Document): number {

--- a/packages/functions/test/weld.test.ts
+++ b/packages/functions/test/weld.test.ts
@@ -332,6 +332,16 @@ test('degenerate', async (t) => {
 	);
 });
 
+test('no side effects', async (t) => {
+	const document = new Document().setLogger(logger);
+	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+	attributeA.clone();
+
+	await document.transform(weld({ cleanup: false }));
+
+	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+});
+
 /* UTILITIES */
 
 function createUniqueAttribute(document: Document, type: GLTF.AccessorType, count: number): Accessor {


### PR DESCRIPTION
Some workflows require preserving seemingly unused or duplicate resources. Many transforms currently remove those resources as a side effect of cleaning up temporary resources created during normal operations. This PR provides an opt-out, `cleanup: false`, for these functions. Users opting out of cleanup will likely want to run `prune()` and `dedup()` manually, with options set for their needs, later in their pipelines.

Eventually I'd like to change the implementations of these functions so that they can clean up temporary resources without these side effects, but that will be a larger task for a future PR.

Related:

- fixes #1278
- fixes #1185
- alternative #1279
- alternative #1186
- related #1281

Remaining:

- [x] more unit tests

