### PR TITLE
feat(functions): Add 'keepExtras' option to prune()

### DIFF
--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -43,6 +43,8 @@ export interface PruneOptions {
 	keepIndices?: boolean;
 	/** Whether to keep single-color textures that can be converted to material factors. */
 	keepSolidTextures?: boolean;
+	/** Whether custom extras should prevent pruning a property. */
+	keepExtras?: boolean;
 }
 
 export const PRUNE_DEFAULTS: Required<PruneOptions> = {
@@ -63,6 +65,7 @@ export const PRUNE_DEFAULTS: Required<PruneOptions> = {
 	keepAttributes: false,
 	keepIndices: false,
 	keepSolidTextures: false,
+	keepExtras: false,
 };
 
 /**
@@ -89,6 +92,7 @@ export function prune(_options: PruneOptions = PRUNE_DEFAULTS): Transform {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const options = { ...PRUNE_DEFAULTS, ..._options } as Required<PruneOptions>;
 	const propertyTypes = new Set(options.propertyTypes);
+	const keepExtras = options.keepExtras;
 
 	return createTransform(NAME, async (document: Document): Promise<void> => {
 		const logger = document.getLogger();
@@ -116,39 +120,39 @@ export function prune(_options: PruneOptions = PRUNE_DEFAULTS): Transform {
 		if (propertyTypes.has(PropertyType.NODE)) {
 			if (!options.keepLeaves) {
 				for (const scene of root.listScenes()) {
-					nodeTreeShake(graph, scene);
+					nodeTreeShake(graph, scene, keepExtras);
 				}
 			}
 
 			for (const node of root.listNodes()) {
-				treeShake(node);
+				treeShake(node, keepExtras);
 			}
 		}
 
 		if (propertyTypes.has(PropertyType.SKIN)) {
 			for (const skin of root.listSkins()) {
-				treeShake(skin);
+				treeShake(skin, keepExtras);
 			}
 		}
 
 		if (propertyTypes.has(PropertyType.MESH)) {
 			for (const mesh of root.listMeshes()) {
-				treeShake(mesh);
+				treeShake(mesh, keepExtras);
 			}
 		}
 
 		if (propertyTypes.has(PropertyType.CAMERA)) {
 			for (const camera of root.listCameras()) {
-				treeShake(camera);
+				treeShake(camera, keepExtras);
 			}
 		}
 
 		if (propertyTypes.has(PropertyType.PRIMITIVE)) {
-			indirectTreeShake(graph, PropertyType.PRIMITIVE);
+			indirectTreeShake(graph, PropertyType.PRIMITIVE, keepExtras);
 		}
 
 		if (propertyTypes.has(PropertyType.PRIMITIVE_TARGET)) {
-			indirectTreeShake(graph, PropertyType.PRIMITIVE_TARGET);
+			indirectTreeShake(graph, PropertyType.PRIMITIVE_TARGET, keepExtras);
 		}
 
 		// Prune unused vertex attributes.
@@ -195,31 +199,31 @@ export function prune(_options: PruneOptions = PRUNE_DEFAULTS): Transform {
 				}
 				if (!anim.listChannels().length) {
 					const samplers = anim.listSamplers();
-					treeShake(anim);
-					samplers.forEach((sampler) => treeShake(sampler));
+					treeShake(anim, keepExtras);
+					samplers.forEach((sampler) => treeShake(sampler, keepExtras));
 				} else {
-					anim.listSamplers().forEach((sampler) => treeShake(sampler));
+					anim.listSamplers().forEach((sampler) => treeShake(sampler, keepExtras));
 				}
 			}
 		}
 
 		if (propertyTypes.has(PropertyType.MATERIAL)) {
-			root.listMaterials().forEach((material) => treeShake(material));
+			root.listMaterials().forEach((material) => treeShake(material, keepExtras));
 		}
 
 		if (propertyTypes.has(PropertyType.TEXTURE)) {
-			root.listTextures().forEach((texture) => treeShake(texture));
+			root.listTextures().forEach((texture) => treeShake(texture, keepExtras));
 			if (!options.keepSolidTextures) {
 				await pruneSolidTextures(document);
 			}
 		}
 
 		if (propertyTypes.has(PropertyType.ACCESSOR)) {
-			root.listAccessors().forEach((accessor) => treeShake(accessor));
+			root.listAccessors().forEach((accessor) => treeShake(accessor, keepExtras));
 		}
 
 		if (propertyTypes.has(PropertyType.BUFFER)) {
-			root.listBuffers().forEach((buffer) => treeShake(buffer));
+			root.listBuffers().forEach((buffer) => treeShake(buffer, keepExtras));
 		}
 
 		// TODO(bug): This process does not identify unused ExtensionProperty instances. That could
@@ -277,11 +281,12 @@ class DisposeCounter {
  */
 
 /** Disposes of the given property if it is unused. */
-function treeShake(prop: Property): void {
+function treeShake(prop: Property, keepExtras: boolean): void {
 	// Consider a property unused if it has no references from another property, excluding
 	// types Root and AnimationChannel.
 	const parents = prop.listParents().filter((p) => !(p instanceof Root || p instanceof AnimationChannel));
-	if (!parents.length && isEmptyObject(prop.getExtras())) {
+	const needsExtras = keepExtras && !isEmptyObject(prop.getExtras());
+	if (!parents.length && !needsExtras) {
 		prop.dispose();
 	}
 }
@@ -291,18 +296,18 @@ function treeShake(prop: Property): void {
  * graph. It's possible that objects may have been constructed without any outbound links,
  * but since they're not on the graph they don't need to be tree-shaken.
  */
-function indirectTreeShake(graph: Graph<Property>, propertyType: string): void {
+function indirectTreeShake(graph: Graph<Property>, propertyType: string, keepExtras: boolean): void {
 	for (const edge of graph.listEdges()) {
 		const parent = edge.getParent();
 		if (parent.propertyType === propertyType) {
-			treeShake(parent);
+			treeShake(parent, keepExtras);
 		}
 	}
 }
 
 /** Iteratively prunes leaf Nodes without contents. */
-function nodeTreeShake(graph: Graph<Property>, prop: Node | Scene): void {
-	prop.listChildren().forEach((child) => nodeTreeShake(graph, child));
+function nodeTreeShake(graph: Graph<Property>, prop: Node | Scene, keepExtras: boolean): void {
+	prop.listChildren().forEach((child) => nodeTreeShake(graph, child, keepExtras));
 
 	if (prop instanceof Scene) return;
 
@@ -311,7 +316,8 @@ function nodeTreeShake(graph: Graph<Property>, prop: Node | Scene): void {
 		return ptype !== PropertyType.ROOT && ptype !== PropertyType.SCENE && ptype !== PropertyType.NODE;
 	});
 	const isEmpty = graph.listChildren(prop).length === 0;
-	if (isEmpty && !isUsed && isEmptyObject(prop.getExtras())) {
+	const needsExtras = keepExtras && !isEmptyObject(prop.getExtras());
+	if (isEmpty && !isUsed && !needsExtras) {
 		prop.dispose();
 	}
 }

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -26,7 +26,7 @@ import { getPixels } from 'ndarray-pixels';
 import { getTextureColorSpace } from './get-texture-color-space.js';
 import { listTextureInfoByMaterial } from './list-texture-info.js';
 import { listTextureSlots } from './list-texture-slots.js';
-import { createTransform } from './utils.js';
+import { createTransform, isEmptyObject } from './utils.js';
 
 const NAME = 'prune';
 
@@ -281,7 +281,7 @@ function treeShake(prop: Property): void {
 	// Consider a property unused if it has no references from another property, excluding
 	// types Root and AnimationChannel.
 	const parents = prop.listParents().filter((p) => !(p instanceof Root || p instanceof AnimationChannel));
-	if (!parents.length) {
+	if (!parents.length && isEmptyObject(prop.getExtras())) {
 		prop.dispose();
 	}
 }
@@ -311,7 +311,7 @@ function nodeTreeShake(graph: Graph<Property>, prop: Node | Scene): void {
 		return ptype !== PropertyType.ROOT && ptype !== PropertyType.SCENE && ptype !== PropertyType.NODE;
 	});
 	const isEmpty = graph.listChildren(prop).length === 0;
-	if (isEmpty && !isUsed) {
+	if (isEmpty && !isUsed && isEmptyObject(prop.getExtras())) {
 		prop.dispose();
 	}
 }

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -297,6 +297,12 @@ export function isUsed(prop: Property): boolean {
 	return prop.listParents().some((parent) => parent.propertyType !== PropertyType.ROOT);
 }
 
+/** @hidden */
+export function isEmptyObject(object: Record<string, unknown>): boolean {
+	for (const key in object) return false;
+	return true;
+}
+
 /**
  * Creates a unique key associated with the structure and draw call characteristics of
  * a {@link Primitive}, independent of its vertex content. Helper method, used to

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -51,18 +51,3 @@ test('no side effects', async (t) => {
 	t.is(document.getRoot().listNodes().length, 2, 'skips prune');
 	t.is(document.getRoot().listAccessors().length, 2, 'skips dedup');
 });
-
-test('should not prune empty nodes if they have custom data', async (t) => {
-	const io = await createPlatformIO();
-	const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
-	const scene = document.getRoot().getDefaultScene();
-
-	const node = document.createNode('CustomNode');
-	node.setExtras({ customData: 'test' });
-	scene.addChild(node);
-
-	await document.transform(join());
-
-	t.is(document.getRoot().listNodes().length, 2, '2 nodes');
-	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
-});

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -51,3 +51,18 @@ test('no side effects', async (t) => {
 	t.is(document.getRoot().listNodes().length, 2, 'skips prune');
 	t.is(document.getRoot().listAccessors().length, 2, 'skips dedup');
 });
+
+test('should not prune empty nodes if they have custom data', async (t) => {
+	const io = await createPlatformIO();
+	const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
+	const scene = document.getRoot().getDefaultScene();
+
+	const node = document.createNode('CustomNode');
+	node.setExtras({ customData: 'test' });
+	scene.addChild(node);
+
+	await document.transform(join());
+
+	t.is(document.getRoot().listNodes().length, 2, '2 nodes');
+	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
+});

--- a/packages/functions/test/prune.test.ts
+++ b/packages/functions/test/prune.test.ts
@@ -90,6 +90,17 @@ test('leaf nodes', async (t) => {
 	t.truthy(nodeA.isDisposed(), 'nodeA disposed');
 });
 
+test('leaf nodes - extras', async (t) => {
+	const document = new Document().setLogger(logger);
+	const node = document.createNode('CustomNode');
+	node.setExtras({ customData: 'test' });
+	document.createScene().addChild(node);
+
+	await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false }));
+
+	t.is(document.getRoot().listNodes().length, 1, '1 nodes');
+});
+
 test('attributes', async (t) => {
 	const document = new Document().setLogger(logger);
 

--- a/packages/functions/test/prune.test.ts
+++ b/packages/functions/test/prune.test.ts
@@ -96,9 +96,13 @@ test('leaf nodes - extras', async (t) => {
 	node.setExtras({ customData: 'test' });
 	document.createScene().addChild(node);
 
-	await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false }));
+	await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false, keepExtras: true }));
 
 	t.is(document.getRoot().listNodes().length, 1, '1 nodes');
+
+	await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false, keepExtras: false }));
+
+	t.is(document.getRoot().listNodes().length, 0, '0 nodes');
 });
 
 test('attributes', async (t) => {


### PR DESCRIPTION
Continues #1281, co-authored by @Archimagus. Adds a `keepExtras` option to prune(), defaulting to false, which allows properties that would otherwise be pruned to be skipped if they contain custom extras.