### PR TITLE
feat(functions): Add conversions to LINES or TRIANGLES

### DIFF
--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -350,19 +350,29 @@ function listDracoPrimitives(doc: Document): Map<Primitive, string> {
 	const included = new Set<Primitive>();
 	const excluded = new Set<Primitive>();
 
+	let nonIndexed = 0;
+	let nonTriangles = 0;
+
 	// Support compressing only indexed, mode=TRIANGLES primitives.
 	for (const mesh of doc.getRoot().listMeshes()) {
 		for (const prim of mesh.listPrimitives()) {
 			if (!prim.getIndices()) {
 				excluded.add(prim);
-				logger.warn(`[${NAME}] Skipping Draco compression on non-indexed primitive.`);
+				nonIndexed++;
 			} else if (prim.getMode() !== Primitive.Mode.TRIANGLES) {
 				excluded.add(prim);
-				logger.warn(`[${NAME}] Skipping Draco compression on non-TRIANGLES primitive.`);
+				nonTriangles++;
 			} else {
 				included.add(prim);
 			}
 		}
+	}
+
+	if (nonIndexed > 0) {
+		logger.warn(`[${NAME}] Skipping Draco compression of ${nonIndexed} non-indexed primitives.`);
+	}
+	if (nonTriangles > 0) {
+		logger.warn(`[${NAME}] Skipping Draco compression of ${nonTriangles} non-TRIANGLES primitives.`);
 	}
 
 	// Create an Accessor->index mapping.

--- a/packages/functions/src/convert-primitive-mode.ts
+++ b/packages/functions/src/convert-primitive-mode.ts
@@ -1,4 +1,4 @@
-import { ComponentTypeToTypedArray, Document, GLTF, Primitive } from '@gltf-transform/core';
+import { ComponentTypeToTypedArray, Document, Primitive } from '@gltf-transform/core';
 import { BASIC_MODE_MAPPING, getGLPrimitiveCount, shallowCloneAccessor } from './utils.js';
 import { weldPrimitive } from './weld.js';
 
@@ -36,6 +36,7 @@ export function convertPrimitiveToBasicMode(prim: Primitive): void {
 	} else if (srcMode === LINE_LOOP) {
 		throw new Error('not implemented');
 	} else if (srcMode === TRIANGLE_STRIP) {
+		// TODO(test)
 		for (let i = 0, il = srcIndicesArray.length; i < il - 2; i++) {
 			if (i % 2) {
 				dstIndicesArray[i * 3] = srcIndicesArray[i * 3];
@@ -48,6 +49,7 @@ export function convertPrimitiveToBasicMode(prim: Primitive): void {
 			}
 		}
 	} else if (srcMode === TRIANGLE_FAN) {
+		// TODO(test)
 		for (let i = 1; i < dstGLPrimitiveCount - 1; i++) {
 			dstIndicesArray[i * 3] = srcIndicesArray[0];
 			dstIndicesArray[i * 3 + 1] = srcIndicesArray[i];
@@ -59,9 +61,7 @@ export function convertPrimitiveToBasicMode(prim: Primitive): void {
 	prim.setMode(dstMode);
 	const root = document.getRoot();
 	if (srcIndices.listParents().some((parent) => parent !== root && parent !== prim)) {
-		const dstIndices = shallowCloneAccessor(document, srcIndices);
-		dstIndices.setArray(dstIndicesArray);
-		prim.setIndices(dstIndices);
+		prim.setIndices(shallowCloneAccessor(document, srcIndices).setArray(dstIndicesArray));
 	} else {
 		srcIndices.setArray(dstIndicesArray);
 	}

--- a/packages/functions/src/convert-primitive-mode.ts
+++ b/packages/functions/src/convert-primitive-mode.ts
@@ -1,22 +1,12 @@
 import { ComponentTypeToTypedArray, Document, Primitive } from '@gltf-transform/core';
-import { BASIC_MODE_MAPPING, getGLPrimitiveCount, shallowCloneAccessor } from './utils.js';
+import { getGLPrimitiveCount, shallowCloneAccessor } from './utils.js';
 import { weldPrimitive } from './weld.js';
 
-const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
+const { LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-export function convertPrimitiveToBasicMode(prim: Primitive): void {
+export function convertPrimitiveToLines(prim: Primitive): void {
 	const graph = prim.getGraph();
 	const document = Document.fromGraph(graph)!;
-
-	const srcMode = prim.getMode();
-	if (srcMode === POINTS || srcMode === LINES || srcMode === TRIANGLES) {
-		return;
-	}
-
-	const dstMode = BASIC_MODE_MAPPING[srcMode];
-	if (dstMode === undefined) {
-		throw new Error(`Unexpected mode: ${srcMode}`);
-	}
 
 	// Ensure indexed primitive.
 	if (!prim.getIndices()) {
@@ -28,37 +18,72 @@ export function convertPrimitiveToBasicMode(prim: Primitive): void {
 	const srcIndicesArray = srcIndices.getArray()!;
 	const dstGLPrimitiveCount = getGLPrimitiveCount(prim);
 	const IndicesArray = ComponentTypeToTypedArray[srcIndices.getComponentType()];
-	const dstIndicesArray = new IndicesArray(dstGLPrimitiveCount * (dstMode === LINES ? 2 : 3));
+	const dstIndicesArray = new IndicesArray(dstGLPrimitiveCount * 2);
 
 	// Generate GL primitives.
+	const srcMode = prim.getMode();
 	if (srcMode === LINE_STRIP) {
 		throw new Error('not implemented');
 	} else if (srcMode === LINE_LOOP) {
 		throw new Error('not implemented');
-	} else if (srcMode === TRIANGLE_STRIP) {
-		// TODO(test)
-		for (let i = 0, il = srcIndicesArray.length; i < il - 2; i++) {
-			if (i % 2) {
-				dstIndicesArray[i * 3] = srcIndicesArray[i * 3];
-				dstIndicesArray[i * 3 + 2] = srcIndicesArray[i * 3 + 2];
-				dstIndicesArray[i * 3 + 1] = srcIndicesArray[i * 3 + 1];
-			} else {
-				dstIndicesArray[i * 3] = srcIndicesArray[i * 3];
-				dstIndicesArray[i * 3 + 1] = srcIndicesArray[i * 3 + 1];
-				dstIndicesArray[i * 3 + 2] = srcIndicesArray[i * 3 + 2];
-			}
-		}
-	} else if (srcMode === TRIANGLE_FAN) {
-		// TODO(test)
-		for (let i = 1; i < dstGLPrimitiveCount - 1; i++) {
-			dstIndicesArray[i * 3] = srcIndicesArray[0];
-			dstIndicesArray[i * 3 + 1] = srcIndicesArray[i];
-			dstIndicesArray[i * 3 + 2] = srcIndicesArray[i + 1];
-		}
+	} else {
+		throw new Error('Only LINE_STRIP and LINE_LOOP may be converted to LINES.');
 	}
 
 	// Update prim mode and indices.
-	prim.setMode(dstMode);
+	prim.setMode(LINES);
+	const root = document.getRoot();
+	if (srcIndices.listParents().some((parent) => parent !== root && parent !== prim)) {
+		prim.setIndices(shallowCloneAccessor(document, srcIndices).setArray(dstIndicesArray));
+	} else {
+		srcIndices.setArray(dstIndicesArray);
+	}
+}
+
+export function convertPrimitiveToTriangles(prim: Primitive): void {
+	const graph = prim.getGraph();
+	const document = Document.fromGraph(graph)!;
+
+	// Ensure indexed primitive.
+	if (!prim.getIndices()) {
+		weldPrimitive(prim, { tolerance: 0 });
+	}
+
+	// Allocate indices new GL primitives.
+	const srcIndices = prim.getIndices()!;
+	const srcIndicesArray = srcIndices.getArray()!;
+	const dstGLPrimitiveCount = getGLPrimitiveCount(prim);
+	const IndicesArray = ComponentTypeToTypedArray[srcIndices.getComponentType()];
+	const dstIndicesArray = new IndicesArray(dstGLPrimitiveCount * 3);
+
+	// Generate GL primitives.
+	const srcMode = prim.getMode();
+	if (srcMode === TRIANGLE_STRIP) {
+		// https://en.wikipedia.org/wiki/Triangle_strip
+		for (let i = 0, il = srcIndicesArray.length; i < il - 2; i++) {
+			if (i % 2) {
+				dstIndicesArray[i * 3] = srcIndicesArray[i + 1];
+				dstIndicesArray[i * 3 + 1] = srcIndicesArray[i];
+				dstIndicesArray[i * 3 + 2] = srcIndicesArray[i + 2];
+			} else {
+				dstIndicesArray[i * 3] = srcIndicesArray[i];
+				dstIndicesArray[i * 3 + 1] = srcIndicesArray[i + 1];
+				dstIndicesArray[i * 3 + 2] = srcIndicesArray[i + 2];
+			}
+		}
+	} else if (srcMode === TRIANGLE_FAN) {
+		// https://en.wikipedia.org/wiki/Triangle_fan
+		for (let i = 0; i < dstGLPrimitiveCount; i++) {
+			dstIndicesArray[i * 3] = srcIndicesArray[0];
+			dstIndicesArray[i * 3 + 1] = srcIndicesArray[i + 1];
+			dstIndicesArray[i * 3 + 2] = srcIndicesArray[i + 2];
+		}
+	} else {
+		throw new Error('Only TRIANGLE_STRIP and TRIANGLE_FAN may be converted to TRIANGLES.');
+	}
+
+	// Update prim mode and indices.
+	prim.setMode(TRIANGLES);
 	const root = document.getRoot();
 	if (srcIndices.listParents().some((parent) => parent !== root && parent !== prim)) {
 		prim.setIndices(shallowCloneAccessor(document, srcIndices).setArray(dstIndicesArray));

--- a/packages/functions/src/convert-primitive-mode.ts
+++ b/packages/functions/src/convert-primitive-mode.ts
@@ -23,9 +23,22 @@ export function convertPrimitiveToLines(prim: Primitive): void {
 	// Generate GL primitives.
 	const srcMode = prim.getMode();
 	if (srcMode === LINE_STRIP) {
-		throw new Error('not implemented');
+		// https://glasnost.itcarlow.ie/~powerk/opengl/primitives/primitives.htm
+		for (let i = 0; i < dstGLPrimitiveCount; i++) {
+			dstIndicesArray[i * 2] = srcIndicesArray[i];
+			dstIndicesArray[i * 2 + 1] = srcIndicesArray[i + 1];
+		}
 	} else if (srcMode === LINE_LOOP) {
-		throw new Error('not implemented');
+		// https://glasnost.itcarlow.ie/~powerk/opengl/primitives/primitives.htm
+		for (let i = 0; i < dstGLPrimitiveCount; i++) {
+			if (i < dstGLPrimitiveCount - 1) {
+				dstIndicesArray[i * 2] = srcIndicesArray[i];
+				dstIndicesArray[i * 2 + 1] = srcIndicesArray[i + 1];
+			} else {
+				dstIndicesArray[i * 2] = srcIndicesArray[i];
+				dstIndicesArray[i * 2 + 1] = srcIndicesArray[0];
+			}
+		}
 	} else {
 		throw new Error('Only LINE_STRIP and LINE_LOOP may be converted to LINES.');
 	}

--- a/packages/functions/src/convert-primitive-mode.ts
+++ b/packages/functions/src/convert-primitive-mode.ts
@@ -1,0 +1,68 @@
+import { ComponentTypeToTypedArray, Document, GLTF, Primitive } from '@gltf-transform/core';
+import { BASIC_MODE_MAPPING, getGLPrimitiveCount, shallowCloneAccessor } from './utils.js';
+import { weldPrimitive } from './weld.js';
+
+const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
+
+export function convertPrimitiveToBasicMode(prim: Primitive): void {
+	const graph = prim.getGraph();
+	const document = Document.fromGraph(graph)!;
+
+	const srcMode = prim.getMode();
+	if (srcMode === POINTS || srcMode === LINES || srcMode === TRIANGLES) {
+		return;
+	}
+
+	const dstMode = BASIC_MODE_MAPPING[srcMode];
+	if (dstMode === undefined) {
+		throw new Error(`Unexpected mode: ${srcMode}`);
+	}
+
+	// Ensure indexed primitive.
+	if (!prim.getIndices()) {
+		weldPrimitive(prim, { tolerance: 0 });
+	}
+
+	// Allocate indices new GL primitives.
+	const srcIndices = prim.getIndices()!;
+	const srcIndicesArray = srcIndices.getArray()!;
+	const dstGLPrimitiveCount = getGLPrimitiveCount(prim);
+	const IndicesArray = ComponentTypeToTypedArray[srcIndices.getComponentType()];
+	const dstIndicesArray = new IndicesArray(dstGLPrimitiveCount * (dstMode === LINES ? 2 : 3));
+
+	// Generate GL primitives.
+	if (srcMode === LINE_STRIP) {
+		throw new Error('not implemented');
+	} else if (srcMode === LINE_LOOP) {
+		throw new Error('not implemented');
+	} else if (srcMode === TRIANGLE_STRIP) {
+		for (let i = 0, il = srcIndicesArray.length; i < il - 2; i++) {
+			if (i % 2) {
+				dstIndicesArray[i * 3] = srcIndicesArray[i * 3];
+				dstIndicesArray[i * 3 + 2] = srcIndicesArray[i * 3 + 2];
+				dstIndicesArray[i * 3 + 1] = srcIndicesArray[i * 3 + 1];
+			} else {
+				dstIndicesArray[i * 3] = srcIndicesArray[i * 3];
+				dstIndicesArray[i * 3 + 1] = srcIndicesArray[i * 3 + 1];
+				dstIndicesArray[i * 3 + 2] = srcIndicesArray[i * 3 + 2];
+			}
+		}
+	} else if (srcMode === TRIANGLE_FAN) {
+		for (let i = 1; i < dstGLPrimitiveCount - 1; i++) {
+			dstIndicesArray[i * 3] = srcIndicesArray[0];
+			dstIndicesArray[i * 3 + 1] = srcIndicesArray[i];
+			dstIndicesArray[i * 3 + 2] = srcIndicesArray[i + 1];
+		}
+	}
+
+	// Update prim mode and indices.
+	prim.setMode(dstMode);
+	const root = document.getRoot();
+	if (srcIndices.listParents().some((parent) => parent !== root && parent !== prim)) {
+		const dstIndices = shallowCloneAccessor(document, srcIndices);
+		dstIndices.setArray(dstIndicesArray);
+		prim.setIndices(dstIndices);
+	} else {
+		srcIndices.setArray(dstIndicesArray);
+	}
+}

--- a/packages/functions/src/convert-primitive-mode.ts
+++ b/packages/functions/src/convert-primitive-mode.ts
@@ -4,6 +4,21 @@ import { weldPrimitive } from './weld.js';
 
 const { LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
+/**
+ * Converts LINE_STRIP and LINE_LOOP primitives to LINES, which are more widely
+ * supported. Any other topology given as input (points or triangles) will throw an
+ * error.
+ *
+ * Example:
+ *
+ * ```javascript
+ * import { convertPrimitiveToLines } from '@gltf-transform/functions';
+ *
+ * console.log(prim.getMode()); // 2 (LINE_LOOP)
+ * convertPrimitiveToLines(prim.getMode());
+ * console.log(prim.getMode()); // 1 (LINES)
+ * ```
+ */
 export function convertPrimitiveToLines(prim: Primitive): void {
 	const graph = prim.getGraph();
 	const document = Document.fromGraph(graph)!;
@@ -53,6 +68,21 @@ export function convertPrimitiveToLines(prim: Primitive): void {
 	}
 }
 
+/**
+ * Converts TRIANGLE_STRIP and TRIANGLE_LOOP primitives to TRIANGLES, which are
+ * more widely supported. Any other topology given as input (points or lines)
+ * will throw an error.
+ *
+ * Example:
+ *
+ * ```javascript
+ * import { convertPrimitiveToTriangles } from '@gltf-transform/functions';
+ *
+ * console.log(prim.getMode()); // 5 (TRIANGLE_STRIP)
+ * convertPrimitiveToTriangles(prim.getMode());
+ * console.log(prim.getMode()); // 4 (TRIANGLES)
+ * ```
+ */
 export function convertPrimitiveToTriangles(prim: Primitive): void {
 	const graph = prim.getGraph();
 	const document = Document.fromGraph(graph)!;

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,6 +1,7 @@
 export * from './center.js';
 export * from './clear-node-parent.js';
 export * from './clear-node-transform.js';
+export * from './convert-primitive-mode.js';
 export * from './dedup.js';
 export { dequantize, dequantizePrimitive, DequantizeOptions } from './dequantize.js';
 export * from './draco.js';

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -1,5 +1,13 @@
 import { Document, Primitive, ComponentTypeToTypedArray } from '@gltf-transform/core';
-import { createIndices, createPrimGroupKey, remapAttribute, remapIndices, shallowCloneAccessor } from './utils.js';
+import {
+	BASIC_MODES,
+	createIndices,
+	createPrimGroupKey,
+	remapAttribute,
+	remapIndices,
+	shallowCloneAccessor,
+} from './utils.js';
+import { convertPrimitiveToBasicMode } from './convert-primitive-mode.js';
 
 interface JoinPrimitiveOptions {
 	skipValidation?: boolean;
@@ -46,13 +54,20 @@ export function joinPrimitives(prims: Primitive[], options: JoinPrimitiveOptions
 		);
 	}
 
+	// (2) Convert all prims to POINTS, LINES, or TRIANGLES.
+	for (const prim of prims) {
+		if (!BASIC_MODES.includes(prim.getMode())) {
+			convertPrimitiveToBasicMode(prim);
+		}
+	}
+
 	const primRemaps = [] as Uint32Array[]; // remap[srcIndex] → dstIndex, by prim
 	const primVertexCounts = new Uint32Array(prims.length); // vertex count, by prim
 
 	let dstVertexCount = 0;
 	let dstIndicesCount = 0;
 
-	// (2) Build remap lists.
+	// (3) Build remap lists.
 	for (let primIndex = 0; primIndex < prims.length; primIndex++) {
 		const srcPrim = prims[primIndex];
 		const srcIndices = srcPrim.getIndices();
@@ -74,7 +89,7 @@ export function joinPrimitives(prims: Primitive[], options: JoinPrimitiveOptions
 		dstIndicesCount += srcIndicesCount;
 	}
 
-	// (3) Allocate joined attributes.
+	// (4) Allocate joined attributes.
 	const dstPrim = document.createPrimitive().setMode(templatePrim.getMode()).setMaterial(templatePrim.getMaterial());
 	for (const semantic of templatePrim.listSemantics()) {
 		const tplAttribute = templatePrim.getAttribute(semantic)!;
@@ -85,14 +100,14 @@ export function joinPrimitives(prims: Primitive[], options: JoinPrimitiveOptions
 		dstPrim.setAttribute(semantic, dstAttribute);
 	}
 
-	// (4) Allocate joined indices.
+	// (5) Allocate joined indices.
 	const srcIndices = templatePrim.getIndices();
 	const dstIndices = srcIndices
 		? shallowCloneAccessor(document, srcIndices).setArray(createIndices(dstIndicesCount, dstVertexCount))
 		: null;
 	dstPrim.setIndices(dstIndices);
 
-	// (5) Remap attributes into joined Primitive.
+	// (6) Remap attributes into joined Primitive.
 	let dstIndicesOffset = 0;
 	for (let primIndex = 0; primIndex < primRemaps.length; primIndex++) {
 		const srcPrim = prims[primIndex];

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -1,13 +1,6 @@
 import { Document, Primitive, ComponentTypeToTypedArray } from '@gltf-transform/core';
-import {
-	BASIC_MODES,
-	createIndices,
-	createPrimGroupKey,
-	remapAttribute,
-	remapIndices,
-	shallowCloneAccessor,
-} from './utils.js';
-import { convertPrimitiveToBasicMode } from './convert-primitive-mode.js';
+import { createIndices, createPrimGroupKey, remapAttribute, remapIndices, shallowCloneAccessor } from './utils.js';
+import { convertPrimitiveToLines, convertPrimitiveToTriangles } from './convert-primitive-mode.js';
 
 interface JoinPrimitiveOptions {
 	skipValidation?: boolean;
@@ -18,6 +11,8 @@ const JOIN_PRIMITIVE_DEFAULTS: Required<JoinPrimitiveOptions> = {
 };
 
 const EMPTY_U32 = 2 ** 32 - 1;
+
+const { LINE_STRIP, LINE_LOOP, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
 /**
  * Given a list of compatible Mesh {@link Primitive Primitives}, returns new Primitive
@@ -56,8 +51,15 @@ export function joinPrimitives(prims: Primitive[], options: JoinPrimitiveOptions
 
 	// (2) Convert all prims to POINTS, LINES, or TRIANGLES.
 	for (const prim of prims) {
-		if (!BASIC_MODES.includes(prim.getMode())) {
-			convertPrimitiveToBasicMode(prim);
+		switch (prim.getMode()) {
+			case LINE_STRIP:
+			case LINE_LOOP:
+				convertPrimitiveToLines(prim);
+				break;
+			case TRIANGLE_STRIP:
+			case TRIANGLE_FAN:
+				convertPrimitiveToTriangles(prim);
+				break;
 		}
 	}
 

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -105,10 +105,10 @@ export function simplify(_options: SimplifyOptions): Transform {
 			for (const prim of mesh.listPrimitives()) {
 				const mode = prim.getMode();
 				if (mode === TRIANGLES || mode === TRIANGLE_STRIP || mode === TRIANGLE_FAN) {
-					simplifyPrimitive(document, prim, options);
+					simplifyPrimitive(prim, options);
 					if (prim.getIndices()!.getCount() === 0) prim.dispose();
 				} else if (prim.getMode() === POINTS && !!simplifier.simplifyPoints) {
-					simplifyPrimitive(document, prim, options);
+					simplifyPrimitive(prim, options);
 					if (prim.getAttribute('POSITION')!.getCount() === 0) prim.dispose();
 				} else {
 					numUnsupported++;
@@ -139,9 +139,12 @@ export function simplify(_options: SimplifyOptions): Transform {
 	});
 }
 
-export function simplifyPrimitive(document: Document, prim: Primitive, _options: SimplifyOptions): Primitive {
+/** @hidden */
+export function simplifyPrimitive(prim: Primitive, _options: SimplifyOptions): Primitive {
 	const options = { ...SIMPLIFY_DEFAULTS, ..._options } as Required<SimplifyOptions>;
 	const simplifier = options.simplifier as typeof MeshoptSimplifier;
+	const graph = prim.getGraph();
+	const document = Document.fromGraph(graph)!;
 	const logger = document.getLogger();
 
 	switch (prim.getMode()) {

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -160,6 +160,7 @@ export function simplifyPrimitive(document: Document, prim: Primitive, _options:
 	const targetCount = Math.floor((options.ratio * srcIndexCount) / 3) * 3;
 	const flags = options.lockBorder ? ['LockBorder'] : [];
 
+	// TODO(bug): This almost certainly doesn't support all primitive modes!
 	const [dstIndicesArray, error] = simplifier.simplify(
 		indicesArray,
 		positionArray,

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -13,8 +13,11 @@ import { dedup } from './dedup.js';
 import { prune } from './prune.js';
 import { dequantizeAttributeArray } from './dequantize.js';
 import { unweldPrimitive } from './unweld.js';
+import { convertPrimitiveToTriangles } from './convert-primitive-mode.js';
 
 const NAME = 'simplify';
+
+const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
 /** Options for the {@link simplify} function. */
 export interface SimplifyOptions {
@@ -95,21 +98,28 @@ export function simplify(_options: SimplifyOptions): Transform {
 		await simplifier.ready;
 		await document.transform(weld({ overwrite: false, cleanup: options.cleanup }));
 
+		let numUnsupported = 0;
+
 		// Simplify mesh primitives.
 		for (const mesh of document.getRoot().listMeshes()) {
 			for (const prim of mesh.listPrimitives()) {
-				if (prim.getMode() === Primitive.Mode.TRIANGLES) {
+				const mode = prim.getMode();
+				if (mode === TRIANGLES || mode === TRIANGLE_STRIP || mode === TRIANGLE_FAN) {
 					simplifyPrimitive(document, prim, options);
 					if (prim.getIndices()!.getCount() === 0) prim.dispose();
-				} else if (prim.getMode() === Primitive.Mode.POINTS && !!simplifier.simplifyPoints) {
+				} else if (prim.getMode() === POINTS && !!simplifier.simplifyPoints) {
 					simplifyPrimitive(document, prim, options);
 					if (prim.getAttribute('POSITION')!.getCount() === 0) prim.dispose();
 				} else {
-					logger.warn(`${NAME}: Skipping primitive of mesh "${mesh.getName()}": Unsupported draw mode.`);
+					numUnsupported++;
 				}
 			}
 
 			if (mesh.listPrimitives().length === 0) mesh.dispose();
+		}
+
+		if (numUnsupported > 0) {
+			logger.warn(`${NAME}: Skipping simplification of ${numUnsupported} primitives: Unsupported draw mode.`);
 		}
 
 		// Where simplification removes meshes, we may need to prune leaf nodes.
@@ -132,12 +142,22 @@ export function simplify(_options: SimplifyOptions): Transform {
 export function simplifyPrimitive(document: Document, prim: Primitive, _options: SimplifyOptions): Primitive {
 	const options = { ...SIMPLIFY_DEFAULTS, ..._options } as Required<SimplifyOptions>;
 	const simplifier = options.simplifier as typeof MeshoptSimplifier;
+	const logger = document.getLogger();
 
-	if (prim.getMode() === Primitive.Mode.POINTS) {
-		return _simplifyPoints(document, prim, options);
+	switch (prim.getMode()) {
+		case POINTS:
+			return _simplifyPoints(document, prim, options);
+		case LINES:
+		case LINE_STRIP:
+		case LINE_LOOP:
+			logger.warn(`${NAME}: Skipping primitive simplification: Unsupported draw mode.`);
+			return prim;
+		case TRIANGLE_STRIP:
+		case TRIANGLE_FAN:
+			convertPrimitiveToTriangles(prim);
+			break;
 	}
 
-	const logger = document.getLogger();
 	const position = prim.getAttribute('POSITION')!;
 	const srcIndices = prim.getIndices()!;
 	const srcIndexCount = srcIndices.getCount();
@@ -160,7 +180,6 @@ export function simplifyPrimitive(document: Document, prim: Primitive, _options:
 	const targetCount = Math.floor((options.ratio * srcIndexCount) / 3) * 3;
 	const flags = options.lockBorder ? ['LockBorder'] : [];
 
-	// TODO(bug): This almost certainly doesn't support all primitive modes!
 	const [dstIndicesArray, error] = simplifier.simplify(
 		indicesArray,
 		positionArray,

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -414,13 +414,6 @@ export function ceilPowerOfTwo(value: number): number {
 }
 
 /**
- * Basic GLTF primitive modes, intended to be supported in all operations. Other modes can be
- * converted to basic modes with {@link convertPrimitiveMode}.
- * @hidden
- */
-export const BASIC_MODES = [POINTS, LINES, TRIANGLES];
-
-/**
  * Mapping from any glTF primitive mode to its equivalent basic mode, as returned by
  * {@link convertPrimitiveMode}.
  * @hidden

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -3,6 +3,7 @@ import { getPixels, savePixels } from 'ndarray-pixels';
 import {
 	Accessor,
 	Document,
+	GLTF,
 	Primitive,
 	Property,
 	PropertyType,
@@ -13,6 +14,8 @@ import {
 	vec2,
 } from '@gltf-transform/core';
 import { cleanPrimitive } from './clean-primitive.js';
+
+const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
 /**
  * Prepares a function used in an {@link Document#transform} pipeline. Use of this wrapper is
@@ -313,7 +316,7 @@ export function createPrimGroupKey(prim: Primitive): string {
 	const document = Document.fromGraph(prim.getGraph())!;
 	const material = prim.getMaterial();
 	const materialIndex = document.getRoot().listMaterials().indexOf(material!);
-	const mode = prim.getMode();
+	const mode = BASIC_MODE_MAPPING[prim.getMode()];
 	const indices = !!prim.getIndices();
 
 	const attributes = prim
@@ -409,3 +412,25 @@ export function floorPowerOfTwo(value: number): number {
 export function ceilPowerOfTwo(value: number): number {
 	return Math.pow(2, Math.ceil(Math.log(value) / Math.LN2));
 }
+
+/**
+ * Basic GLTF primitive modes, intended to be supported in all operations. Other modes can be
+ * converted to basic modes with {@link convertPrimitiveMode}.
+ * @hidden
+ */
+export const BASIC_MODES = [POINTS, LINES, TRIANGLES];
+
+/**
+ * Mapping from any glTF primitive mode to its equivalent basic mode, as returned by
+ * {@link convertPrimitiveMode}.
+ * @hidden
+ */
+export const BASIC_MODE_MAPPING = {
+	[POINTS]: POINTS,
+	[LINES]: LINES,
+	[LINE_STRIP]: LINES,
+	[LINE_LOOP]: LINES,
+	[TRIANGLES]: TRIANGLES,
+	[TRIANGLE_STRIP]: TRIANGLES,
+	[TRIANGLE_FAN]: TRIANGLES,
+} as Record<GLTF.MeshPrimitiveMode, GLTF.MeshPrimitiveMode>;

--- a/packages/functions/test/convert-primitive-to-basic-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-basic-mode.test.ts
@@ -1,0 +1,110 @@
+import test from 'ava';
+import { Document, GLTF, NodeIO, Primitive } from '@gltf-transform/core';
+import { convertPrimitiveToBasicMode } from '@gltf-transform/functions';
+import { logger, createPlatformIO } from '@gltf-transform/test-utils';
+
+const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
+
+// TODO(impl)
+test.skip('line-strip to lines', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createLineStripPrim(document);
+
+	convertPrimitiveToBasicMode(prim);
+
+	t.is(prim.getMode(), LINES, 'mode');
+});
+
+// TODO(impl)
+test.skip('line-loop to lines', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createLineLoopPrim(document);
+
+	convertPrimitiveToBasicMode(prim);
+
+	t.is(prim.getMode(), LINES, 'mode');
+});
+
+test('triangle-strip to triangles', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createTriangleStripPrim(document);
+	const mesh = document.createMesh().addPrimitive(prim);
+	const node = document.createNode().setMesh(mesh);
+	document.createScene().addChild(node);
+
+	const io = (await createPlatformIO()) as NodeIO;
+	await io.write('triangle-strip.glb', document);
+
+	convertPrimitiveToBasicMode(prim);
+
+	t.is(prim.getMode(), TRIANGLES, 'mode');
+});
+
+test('triangle-fan to triangles', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createTriangleFanPrim(document);
+	const mesh = document.createMesh().addPrimitive(prim);
+	const node = document.createNode().setMesh(mesh);
+	document.createScene().addChild(node);
+
+	const io = (await createPlatformIO()) as NodeIO;
+	await io.write('triangle-fan.glb', document);
+
+	convertPrimitiveToBasicMode(prim);
+
+	t.is(prim.getMode(), TRIANGLES, 'mode');
+});
+
+function createLineStripPrim(document: Document): Primitive {
+	throw new Error('not implemented');
+}
+
+function createLineLoopPrim(document: Document): Primitive {
+	throw new Error('not implemented');
+}
+
+/**
+ * Creates an position vertex attribute array, containing `primCount` triangles,
+ * arranged as a 1xN grid in the XZ plane.
+ */
+function createTriangleStripPrim(document: Document, primCount = 8): Primitive {
+	const vertexCount = primCount + 2;
+	const positionArray = new Float32Array(vertexCount * 3);
+	for (let i = 0; i < positionArray.length; i += 3) {
+		positionArray[i] = i % 2;
+		positionArray[i + 1] = 0;
+		positionArray[i + 2] = Math.floor(i / 2);
+	}
+
+	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
+	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
+	const indices = document
+		.createAccessor()
+		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
+		.setBuffer(buffer);
+
+	return document.createPrimitive().setMode(TRIANGLE_STRIP).setAttribute('POSITION', position).setIndices(indices);
+}
+
+/**
+ * Creates a position vertex attribute array, containing `primCount` triangles,
+ * arranged as a circular fan in the XZ plane.
+ */
+function createTriangleFanPrim(document: Document, primCount = 8): Primitive {
+	const vertexCount = primCount + 2;
+	const positionArray = new Float32Array(vertexCount * 3);
+	for (let i = 0; i < positionArray.length; i += 3) {
+		positionArray[i] = Math.cos((i / vertexCount) * 2 * Math.PI);
+		positionArray[i + 1] = 0;
+		positionArray[i + 2] = Math.sin((i / vertexCount) * 2 * Math.PI);
+	}
+
+	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
+	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
+	const indices = document
+		.createAccessor()
+		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
+		.setBuffer(buffer);
+
+	return document.createPrimitive().setMode(TRIANGLE_FAN).setAttribute('POSITION', position).setIndices(indices);
+}

--- a/packages/functions/test/convert-primitive-to-basic-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-basic-mode.test.ts
@@ -1,7 +1,14 @@
 import test from 'ava';
-import { Document, GLTF, NodeIO, Primitive } from '@gltf-transform/core';
+import { Document, NodeIO, Primitive } from '@gltf-transform/core';
 import { convertPrimitiveToBasicMode } from '@gltf-transform/functions';
-import { logger, createPlatformIO } from '@gltf-transform/test-utils';
+import {
+	logger,
+	createPlatformIO,
+	createLineStripPrim,
+	createLineLoopPrim,
+	createTriangleStripPrim,
+	createTriangleFanPrim,
+} from '@gltf-transform/test-utils';
 
 const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
@@ -54,57 +61,3 @@ test('triangle-fan to triangles', async (t) => {
 
 	t.is(prim.getMode(), TRIANGLES, 'mode');
 });
-
-function createLineStripPrim(document: Document): Primitive {
-	throw new Error('not implemented');
-}
-
-function createLineLoopPrim(document: Document): Primitive {
-	throw new Error('not implemented');
-}
-
-/**
- * Creates an position vertex attribute array, containing `primCount` triangles,
- * arranged as a 1xN grid in the XZ plane.
- */
-function createTriangleStripPrim(document: Document, primCount = 8): Primitive {
-	const vertexCount = primCount + 2;
-	const positionArray = new Float32Array(vertexCount * 3);
-	for (let i = 0; i < positionArray.length; i += 3) {
-		positionArray[i] = i % 2;
-		positionArray[i + 1] = 0;
-		positionArray[i + 2] = Math.floor(i / 2);
-	}
-
-	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
-	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
-	const indices = document
-		.createAccessor()
-		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
-		.setBuffer(buffer);
-
-	return document.createPrimitive().setMode(TRIANGLE_STRIP).setAttribute('POSITION', position).setIndices(indices);
-}
-
-/**
- * Creates a position vertex attribute array, containing `primCount` triangles,
- * arranged as a circular fan in the XZ plane.
- */
-function createTriangleFanPrim(document: Document, primCount = 8): Primitive {
-	const vertexCount = primCount + 2;
-	const positionArray = new Float32Array(vertexCount * 3);
-	for (let i = 0; i < positionArray.length; i += 3) {
-		positionArray[i] = Math.cos((i / vertexCount) * 2 * Math.PI);
-		positionArray[i + 1] = 0;
-		positionArray[i + 2] = Math.sin((i / vertexCount) * 2 * Math.PI);
-	}
-
-	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
-	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
-	const indices = document
-		.createAccessor()
-		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
-		.setBuffer(buffer);
-
-	return document.createPrimitive().setMode(TRIANGLE_FAN).setAttribute('POSITION', position).setIndices(indices);
-}

--- a/packages/functions/test/convert-primitive-to-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-mode.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import { Document, NodeIO, Primitive } from '@gltf-transform/core';
-import { convertPrimitiveToBasicMode } from '@gltf-transform/functions';
+import { convertPrimitiveToLines, convertPrimitiveToTriangles } from '@gltf-transform/functions';
 import {
 	logger,
 	createPlatformIO,
@@ -17,9 +17,14 @@ test.skip('line-strip to lines', async (t) => {
 	const document = new Document().setLogger(logger);
 	const prim = createLineStripPrim(document);
 
-	convertPrimitiveToBasicMode(prim);
+	const io = (await createPlatformIO()) as NodeIO;
+	await io.write('line-strip.glb', document);
+
+	convertPrimitiveToLines(prim);
 
 	t.is(prim.getMode(), LINES, 'mode');
+
+	await io.write('line-loop+strip.glb', document);
 });
 
 // TODO(impl)
@@ -27,9 +32,14 @@ test.skip('line-loop to lines', async (t) => {
 	const document = new Document().setLogger(logger);
 	const prim = createLineLoopPrim(document);
 
-	convertPrimitiveToBasicMode(prim);
+	const io = (await createPlatformIO()) as NodeIO;
+	await io.write('line-loop.glb', document);
+
+	convertPrimitiveToLines(prim);
 
 	t.is(prim.getMode(), LINES, 'mode');
+
+	await io.write('line-loop+converted.glb', document);
 });
 
 test('triangle-strip to triangles', async (t) => {
@@ -39,12 +49,24 @@ test('triangle-strip to triangles', async (t) => {
 	const node = document.createNode().setMesh(mesh);
 	document.createScene().addChild(node);
 
-	const io = (await createPlatformIO()) as NodeIO;
-	await io.write('triangle-strip.glb', document);
-
-	convertPrimitiveToBasicMode(prim);
+	convertPrimitiveToTriangles(prim);
 
 	t.is(prim.getMode(), TRIANGLES, 'mode');
+	t.deepEqual(
+		Array.from(prim.getIndices().getArray()),
+		// prettier-ignore
+		[
+			0, 1, 2,
+			2, 1, 3,
+			2, 3, 4,
+			4, 3, 5,
+			4, 5, 6,
+			6, 5, 7,
+			6, 7, 8,
+			8, 7, 9
+		],
+		'indices',
+	);
 });
 
 test('triangle-fan to triangles', async (t) => {
@@ -54,10 +76,22 @@ test('triangle-fan to triangles', async (t) => {
 	const node = document.createNode().setMesh(mesh);
 	document.createScene().addChild(node);
 
-	const io = (await createPlatformIO()) as NodeIO;
-	await io.write('triangle-fan.glb', document);
-
-	convertPrimitiveToBasicMode(prim);
+	convertPrimitiveToTriangles(prim);
 
 	t.is(prim.getMode(), TRIANGLES, 'mode');
+	t.deepEqual(
+		Array.from(prim.getIndices().getArray()),
+		// prettier-ignore
+		[
+			0, 1, 2,
+			0, 2, 3,
+			0, 3, 4,
+			0, 4, 5,
+			0, 5, 6,
+			0, 6, 7,
+			0, 7, 8,
+			0, 8, 9
+		],
+		'indices',
+	);
 });

--- a/packages/functions/test/convert-primitive-to-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-mode.test.ts
@@ -12,7 +12,6 @@ import {
 
 const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-// TODO(impl)
 test.skip('line-strip to lines', async (t) => {
 	const document = new Document().setLogger(logger);
 	const prim = createLineStripPrim(document);
@@ -93,5 +92,57 @@ test('triangle-fan to triangles', async (t) => {
 			0, 8, 9
 		],
 		'indices',
+	);
+});
+
+test('unsupported', async (t) => {
+	const document = new Document().setLogger(logger);
+	const prim = createTriangleFanPrim(document);
+	const mesh = document.createMesh().addPrimitive(prim);
+	const node = document.createNode().setMesh(mesh);
+	document.createScene().addChild(node);
+
+	// ?? → TRIANGLES
+	t.throws(
+		() => convertPrimitiveToTriangles(prim.setMode(POINTS)),
+		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+		'points to triangles',
+	);
+	t.throws(
+		() => convertPrimitiveToTriangles(prim.setMode(LINES)),
+		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+		'lines to triangles',
+	);
+	t.throws(
+		() => convertPrimitiveToTriangles(prim.setMode(LINE_STRIP)),
+		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+		'line-strip to triangles',
+	);
+	t.throws(
+		() => convertPrimitiveToTriangles(prim.setMode(LINE_LOOP)),
+		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+		'line-loop to triangles',
+	);
+
+	// ?? → LINES
+	t.throws(
+		() => convertPrimitiveToLines(prim.setMode(POINTS)),
+		{ message: /Only LINE_STRIP and LINE_LOOP/i },
+		'points to triangles',
+	);
+	t.throws(
+		() => convertPrimitiveToLines(prim.setMode(TRIANGLES)),
+		{ message: /Only LINE_STRIP and LINE_LOOP/i },
+		'lines to triangles',
+	);
+	t.throws(
+		() => convertPrimitiveToLines(prim.setMode(TRIANGLE_STRIP)),
+		{ message: /Only LINE_STRIP and LINE_LOOP/i },
+		'line-strip to triangles',
+	);
+	t.throws(
+		() => convertPrimitiveToLines(prim.setMode(TRIANGLE_FAN)),
+		{ message: /Only LINE_STRIP and LINE_LOOP/i },
+		'line-loop to triangles',
 	);
 });

--- a/packages/functions/test/convert-primitive-to-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-mode.test.ts
@@ -12,33 +12,59 @@ import {
 
 const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-test.skip('line-strip to lines', async (t) => {
+test('line-strip to lines', async (t) => {
 	const document = new Document().setLogger(logger);
 	const prim = createLineStripPrim(document);
-
-	const io = (await createPlatformIO()) as NodeIO;
-	await io.write('line-strip.glb', document);
+	const mesh = document.createMesh().addPrimitive(prim);
+	const node = document.createNode().setMesh(mesh);
+	document.createScene().addChild(node);
 
 	convertPrimitiveToLines(prim);
 
 	t.is(prim.getMode(), LINES, 'mode');
-
-	await io.write('line-loop+strip.glb', document);
+	t.deepEqual(
+		Array.from(prim.getIndices().getArray()),
+		// prettier-ignore
+		[
+			0, 1,
+			1, 2,
+			2, 3,
+			3, 4,
+			4, 5,
+			5, 6,
+			6, 7,
+			7, 8,
+		],
+		'indices',
+	);
 });
 
-// TODO(impl)
-test.skip('line-loop to lines', async (t) => {
+test('line-loop to lines', async (t) => {
 	const document = new Document().setLogger(logger);
 	const prim = createLineLoopPrim(document);
-
-	const io = (await createPlatformIO()) as NodeIO;
-	await io.write('line-loop.glb', document);
+	const mesh = document.createMesh().addPrimitive(prim);
+	const node = document.createNode().setMesh(mesh);
+	document.createScene().addChild(node);
 
 	convertPrimitiveToLines(prim);
 
 	t.is(prim.getMode(), LINES, 'mode');
-
-	await io.write('line-loop+converted.glb', document);
+	t.deepEqual(
+		Array.from(prim.getIndices().getArray()),
+		// prettier-ignore
+		[
+			0, 1,
+			1, 2,
+			2, 3,
+			3, 4,
+			4, 5,
+			5, 6,
+			6, 7,
+			7, 8,
+			8, 0
+		],
+		'indices',
+	);
 });
 
 test('triangle-strip to triangles', async (t) => {

--- a/packages/functions/test/join-primitives.test.ts
+++ b/packages/functions/test/join-primitives.test.ts
@@ -109,6 +109,10 @@ test('indexed', async (t) => {
 	t.deepEqual(Array.from(primAB.getIndices().getArray()), [0, 1, 2, 3, 4, 5], 'indices data');
 });
 
+/******************************************************************************
+ * UTILITIES
+ */
+
 function createPrimA(document: Document): [Primitive, Accessor, Accessor] {
 	// prettier-ignore
 	const positionA = document.createAccessor()

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -1,11 +1,22 @@
 import test from 'ava';
-import { getBounds, Document } from '@gltf-transform/core';
-import { join, quantize } from '@gltf-transform/functions';
-import { createPlatformIO, logger, roundBbox } from '@gltf-transform/test-utils';
+import { getBounds, Document, Primitive } from '@gltf-transform/core';
+import { join, quantize, transformPrimitive } from '@gltf-transform/functions';
+import {
+	createLineLoopPrim,
+	createLineStripPrim,
+	createPlatformIO,
+	createTriangleFanPrim,
+	createTriangleStripPrim,
+	logger,
+	roundBbox,
+	mat4,
+} from '@gltf-transform/test-utils';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { LINES, TRIANGLES } = Primitive.Mode;
 
 test('basic', async (t) => {
 	const io = await createPlatformIO();
@@ -50,4 +61,37 @@ test('no side effects', async (t) => {
 
 	t.is(document.getRoot().listNodes().length, 2, 'skips prune');
 	t.is(document.getRoot().listAccessors().length, 2, 'skips dedup');
+});
+
+test('primitive modes', async (t) => {
+	const document = new Document().setLogger(logger);
+	const primLineStrip = createLineStripPrim(document);
+	const primLineLoop = createLineLoopPrim(document);
+	const primTriangleStrip = createTriangleStripPrim(document);
+	const primTriangleFan = createTriangleFanPrim(document);
+	const mesh = document
+		.createMesh()
+		.addPrimitive(primLineStrip)
+		.addPrimitive(primLineLoop)
+		.addPrimitive(primTriangleStrip)
+		.addPrimitive(primTriangleFan);
+	const node = document.createNode().setMesh(mesh);
+	document.createScene().addChild(node);
+
+	transformPrimitive(primLineStrip, mat4.fromTranslation([], [-4, 0, 0]));
+	transformPrimitive(primLineLoop, mat4.fromTranslation([], [-2, 0, 0]));
+	transformPrimitive(primTriangleStrip, mat4.fromTranslation([], [2, 0, 0]));
+	transformPrimitive(primTriangleFan, mat4.fromTranslation([], [4, 0, 0]));
+
+	await document.transform(join());
+
+	t.true(primLineStrip.isDisposed(), 'line-strip disposed');
+	t.true(primLineLoop.isDisposed(), 'line-loop disposed');
+	t.true(primTriangleStrip.isDisposed(), 'triangle-strip disposed');
+	t.true(primTriangleFan.isDisposed(), 'triangle-fan disposed');
+
+	t.false(mesh.isDisposed(), 'mesh not disposed');
+	t.is(mesh.listPrimitives().length, 2, 'mesh has two (2) prims');
+	t.is(mesh.listPrimitives()[0].getMode(), LINES, 'joins line-strip and line-loop');
+	t.is(mesh.listPrimitives()[1].getMode(), TRIANGLES, 'joins triangle-strip and triangle-fan');
 });

--- a/packages/test-utils/src/create-basic-primitive.ts
+++ b/packages/test-utils/src/create-basic-primitive.ts
@@ -1,0 +1,59 @@
+import { Document, Primitive } from '@gltf-transform/core';
+
+const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
+
+export function createLineStripPrim(document: Document): Primitive {
+	throw new Error('not implemented');
+}
+
+export function createLineLoopPrim(document: Document): Primitive {
+	throw new Error('not implemented');
+}
+
+/**
+ * Creates an position vertex attribute array, containing `primCount` triangles,
+ * arranged as a 1xN grid in the XZ plane.
+ */
+export function createTriangleStripPrim(document: Document, primCount = 8): Primitive {
+	const vertexCount = primCount + 2;
+	const positionArray = new Float32Array(vertexCount * 3);
+	for (let i = 0; i < positionArray.length; i += 3) {
+		// TODO(test)
+		positionArray[i] = i % 2;
+		positionArray[i + 1] = 0;
+		positionArray[i + 2] = Math.floor(i / 2);
+	}
+
+	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
+	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
+	const indices = document
+		.createAccessor()
+		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
+		.setBuffer(buffer);
+
+	return document.createPrimitive().setMode(TRIANGLE_STRIP).setAttribute('POSITION', position).setIndices(indices);
+}
+
+/**
+ * Creates a position vertex attribute array, containing `primCount` triangles,
+ * arranged as a circular fan in the XZ plane.
+ */
+export function createTriangleFanPrim(document: Document, primCount = 8): Primitive {
+	const vertexCount = primCount + 2;
+	const positionArray = new Float32Array(vertexCount * 3);
+	for (let i = 0; i < positionArray.length; i += 3) {
+		// TODO(test)
+		positionArray[i] = Math.cos((i / vertexCount) * 2 * Math.PI);
+		positionArray[i + 1] = 0;
+		positionArray[i + 2] = Math.sin((i / vertexCount) * 2 * Math.PI);
+	}
+
+	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
+	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
+	const indices = document
+		.createAccessor()
+		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
+		.setBuffer(buffer);
+
+	return document.createPrimitive().setMode(TRIANGLE_FAN).setAttribute('POSITION', position).setIndices(indices);
+}

--- a/packages/test-utils/src/create-basic-primitive.ts
+++ b/packages/test-utils/src/create-basic-primitive.ts
@@ -1,13 +1,38 @@
 import { Document, Primitive } from '@gltf-transform/core';
 
-const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
+const { LINE_STRIP, LINE_LOOP, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-export function createLineStripPrim(document: Document): Primitive {
-	throw new Error('not implemented');
+/**
+ * Creates a series of 'primCount' lines, forming an open-sided N-gon.
+ *
+ * Reference: https://glasnost.itcarlow.ie/~powerk/opengl/primitives/primitives.htm
+ */
+export function createLineStripPrim(document: Document, primCount = 8): Primitive {
+	const vertexCount = primCount + 1;
+	const positionArray = new Float32Array(vertexCount * 3);
+	for (let i = 0; i < positionArray.length / 3; i++) {
+		positionArray[i * 3] = Math.cos((i / vertexCount) * 2 * Math.PI);
+		positionArray[i * 3 + 1] = Math.sin((i / vertexCount) * 2 * Math.PI);
+		positionArray[i * 3 + 2] = 0;
+	}
+
+	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
+	const position = document.createAccessor().setType('VEC3').setArray(positionArray).setBuffer(buffer);
+	const indices = document
+		.createAccessor()
+		.setArray(new Uint16Array(vertexCount).map((_, i) => i))
+		.setBuffer(buffer);
+
+	return document.createPrimitive().setMode(LINE_STRIP).setAttribute('POSITION', position).setIndices(indices);
 }
 
+/**
+ * Creates a series of 'primCount' lines, forming a closed N-gon.
+ *
+ * Reference: https://glasnost.itcarlow.ie/~powerk/opengl/primitives/primitives.htm
+ */
 export function createLineLoopPrim(document: Document): Primitive {
-	throw new Error('not implemented');
+	return createLineStripPrim(document).setMode(LINE_LOOP);
 }
 
 /**

--- a/packages/test-utils/src/create-basic-primitive.ts
+++ b/packages/test-utils/src/create-basic-primitive.ts
@@ -13,15 +13,16 @@ export function createLineLoopPrim(document: Document): Primitive {
 /**
  * Creates an position vertex attribute array, containing `primCount` triangles,
  * arranged as a 1xN grid in the XZ plane.
+ *
+ * Reference: https://en.wikipedia.org/wiki/Triangle_strip
  */
 export function createTriangleStripPrim(document: Document, primCount = 8): Primitive {
 	const vertexCount = primCount + 2;
 	const positionArray = new Float32Array(vertexCount * 3);
-	for (let i = 0; i < positionArray.length; i += 3) {
-		// TODO(test)
-		positionArray[i] = i % 2;
-		positionArray[i + 1] = 0;
-		positionArray[i + 2] = Math.floor(i / 2);
+	for (let i = 0; i < positionArray.length / 3; i++) {
+		positionArray[i * 3] = i % 2;
+		positionArray[i * 3 + 1] = Math.floor(i / 2);
+		positionArray[i * 3 + 2] = 0;
 	}
 
 	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
@@ -37,15 +38,16 @@ export function createTriangleStripPrim(document: Document, primCount = 8): Prim
 /**
  * Creates a position vertex attribute array, containing `primCount` triangles,
  * arranged as a circular fan in the XZ plane.
+ *
+ * Reference: https://en.wikipedia.org/wiki/Triangle_fan
  */
 export function createTriangleFanPrim(document: Document, primCount = 8): Primitive {
 	const vertexCount = primCount + 2;
 	const positionArray = new Float32Array(vertexCount * 3);
-	for (let i = 0; i < positionArray.length; i += 3) {
-		// TODO(test)
-		positionArray[i] = Math.cos((i / vertexCount) * 2 * Math.PI);
-		positionArray[i + 1] = 0;
-		positionArray[i + 2] = Math.sin((i / vertexCount) * 2 * Math.PI);
+	for (let i = 0; i < positionArray.length / 3; i++) {
+		positionArray[i * 3] = Math.cos((i / vertexCount) * 2 * Math.PI);
+		positionArray[i * 3 + 1] = Math.sin((i / vertexCount) * 2 * Math.PI);
+		positionArray[i * 3 + 2] = 0;
 	}
 
 	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -51,4 +51,5 @@ import * as vec3 from 'gl-matrix/vec3';
 import * as vec2 from 'gl-matrix/vec2';
 export { mat4, mat3, quat, vec4, vec3, vec2 };
 
+export * from './create-basic-primitive.js';
 export * from './create-torus-primitive.js';


### PR DESCRIPTION
Converts primitives from LINE_STRIP or LINE_LOOP to LINES, or from TRIANGLE_STRIP or TRIANGLE_FAN to TRIANGLES. Examples:

```javascript
import { convertPrimitiveToLines, convertPrimitiveToTriangles } from '@gltf-transform/functions';

// input: LINE_STRIP or LINE_LOOP
convertPrimitiveToLines(prim);

// input: TRIANGLE_STRIP or TRIANGLE_FAN
convertPrimitiveToTriangles(prim);
```

Related:

- fixes #1312 

Remaining

- [x] fix implementations
- [x] passing tests
- [x] consider renaming, convertPrimitiveToTriangles / convertPrimitiveToLines
- [x] unit tests for join()
- [x] unit tests for simplify()
- [x] documentation