### PR TITLE
feat(functions): Add various vertex count methods

### DIFF
--- a/packages/functions/src/get-vertex-count.ts
+++ b/packages/functions/src/get-vertex-count.ts
@@ -5,10 +5,9 @@ import { InstancedMesh } from '@gltf-transform/extensions';
  * Various methods of estimating a vertex count. For some background on why
  * multiple definitions of a vertex count should exist, see [_Vertex Count
  * Higher in Engine than in 3D Software_](https://shahriyarshahrabi.medium.com/vertex-count-higher-in-engine-than-in-3d-software-badc348ada66).
- *
- * Counts for a {@link Scene}, {@link Node}, or {@link Mesh} will not
- * necessarily match the sum of the counts for each {@link Primitive}. Choose
- * the appropriate method for a correct total or estimate:
+ * Totals for a {@link Scene}, {@link Node}, or {@link Mesh} will not
+ * necessarily match the sum of the totals for each {@link Primitive}. Choose
+ * the appropriate method for a relevant total or estimate:
  *
  * - {@link getSceneVertexCount}
  * - {@link getNodeVertexCount}
@@ -25,6 +24,7 @@ export enum VertexCountMethod {
 	 * pass, without considering the vertex cache.
 	 */
 	RENDER = 'render',
+
 	/**
 	 * Expected number of vertices proceessed by the vertex shader for one render
 	 * pass, assuming a 100% hit ratio on the vertex cache. Assumes vertex attributes
@@ -33,6 +33,7 @@ export enum VertexCountMethod {
 	 * achieve 100% hit ratios in practice.
 	 */
 	RENDER_OPTIMISTIC = 'render-optimistic',
+
 	/**
 	 * Expected number of vertices uploaded to the GPU, assuming that a client
 	 * uploads each unique {@link Primitive} individually, potentially duplicating
@@ -40,6 +41,7 @@ export enum VertexCountMethod {
 	 * reused {@link Mesh Meshes} or {@link Primitive Primitives} in GPU memory.
 	 */
 	UPLOAD = 'upload',
+
 	/**
 	 * Expected number of vertices uploaded to the GPU, assuming that a client
 	 * uploads each unique {@link Accessor} only once. Unless glTF vertex
@@ -47,40 +49,50 @@ export enum VertexCountMethod {
 	 * optimized for that buffer layout, this total will be optimistic.
 	 */
 	UPLOAD_OPTIMISTIC = 'upload-optimistic',
+
 	/**
 	 * Total number of unique vertices represented, considering all attributes of
-	 * each vertex, and removing any duplicates.
-	 *
-	 * NOTE: Has no direct relationship to runtime characteristics, but may be
-	 * helpful in identifying asset optimization opportunities.
+	 * each vertex, and removing any duplicates. Has no direct relationship to
+	 * runtime characteristics, but may be helpful in identifying asset
+	 * optimization opportunities.
 	 *
 	 * @hidden Not yet implemented.
 	 */
 	DISTINCT = 'distinct',
+
 	/**
 	 * Total number of unique vertices represented, considering aonly vertex
-	 * positions, and removing any duplicates.
-	 *
-	 * NOTE: Has no direct relationship to runtime characteristics, but may be
-	 * helpful in identifying asset optimization opportunities.
+	 * positions, and removing any duplicates. Has no direct relationship to
+	 * runtime characteristics, but may be helpful in identifying asset
+	 * optimization opportunities.
 	 *
 	 * @hidden Not yet implemented.
 	 */
 	DISTINCT_POSITION = 'distinct-position',
+
 	/**
 	 * Number of vertex positions never used by any mesh primitive. If all
 	 * vertices are unused, this total will match `'upload-optimistic'`.
-	 *
-	 * NOTE: Has no direct relationship to runtime characteristics, but may be
-	 * helpful in identifying asset optimization opportunities.
 	 */
 	UNUSED = 'unused',
 }
 
+/**
+ * Computes total number of vertices in a {@link Scene}, calculated by the
+ * specified method. Totals for the scene will not necessarily match the sum
+ * of the totals for each {@link Mesh} or {@link Primitive} within it. See
+ * {@link VertexCountMethod} for further information.
+ */
 export function getSceneVertexCount(scene: Scene, method: VertexCountMethod): number {
 	return _getSubtreeVertexCount(scene, method);
 }
 
+/**
+ * Computes total number of vertices in a {@link Node}, calculated by the
+ * specified method. Totals for the node will not necessarily match the sum
+ * of the totals for each {@link Mesh} or {@link Primitive} within it. See
+ * {@link VertexCountMethod} for further information.
+ */
 export function getNodeVertexCount(node: Node | Scene, method: VertexCountMethod): number {
 	return _getSubtreeVertexCount(node, method);
 }
@@ -129,6 +141,12 @@ function _getSubtreeVertexCount(node: Node | Scene, method: VertexCountMethod): 
 	}
 }
 
+/**
+ * Computes total number of vertices in a {@link Mesh}, calculated by the
+ * specified method. Totals for the mesh will not necessarily match the sum
+ * of the totals for each {@link Primitive} within it. See
+ * {@link VertexCountMethod} for further information.
+ */
 export function getMeshVertexCount(mesh: Mesh, method: VertexCountMethod): number {
 	const prims = mesh.listPrimitives();
 	const uniquePrims = Array.from(new Set(prims));
@@ -151,6 +169,10 @@ export function getMeshVertexCount(mesh: Mesh, method: VertexCountMethod): numbe
 	}
 }
 
+/**
+ * Computes total number of vertices in a {@link Primitive}, calculated by the
+ * specified method. See {@link VertexCountMethod} for further information.
+ */
 export function getPrimitiveVertexCount(prim: Primitive, method: VertexCountMethod): number {
 	const position = prim.getAttribute('POSITION')!;
 	const indices = prim.getIndices();
@@ -203,7 +225,7 @@ function _sumUnused(prims: Primitive[]) {
 			}
 		}
 
-		for (let i = 0, il = usedIndices.length; i < il; i++) {
+		for (let i = 0, il = position.getCount(); i < il; i++) {
 			if (usedIndices[i] === 0) unused++;
 		}
 	}

--- a/packages/functions/src/get-vertex-count.ts
+++ b/packages/functions/src/get-vertex-count.ts
@@ -1,0 +1,187 @@
+import { Scene, Node, Mesh, Primitive } from '@gltf-transform/core';
+import { InstancedMesh } from '@gltf-transform/extensions';
+
+/**
+ * Various methods of estimating a vertex count. For some background on why
+ * multiple definitions of a vertex count should exist, see [_Vertex Count
+ * Higher in Engine than in 3D Software_](https://shahriyarshahrabi.medium.com/vertex-count-higher-in-engine-than-in-3d-software-badc348ada66).
+ *
+ * Counts for a {@link Scene}, {@link Node}, or {@link Mesh} will not
+ * necessarily match the sum of the counts for each {@link Primitive}. Choose
+ * the appropriate method for a correct total or estimate:
+ *
+ * - {@link getSceneVertexCount}
+ * - {@link getNodeVertexCount}
+ * - {@link getMeshVertexCount}
+ * - {@link getPrimitiveVertexCount}
+ *
+ * Many rendering features, such as volumetric transmission, may lead
+ * to additional passes over some or all vertices. These tradeoffs are
+ * implementation-dependent, and not considered here.
+ */
+export enum VertexCountMethod {
+	/**
+	 * Expected number of vertices processed by the vertex shader for one render
+	 * pass, without considering the vertex cache.
+	 */
+	RENDER = 'render',
+	/**
+	 * Expected number of vertices proceessed by the vertex shader for one render
+	 * pass, assuming a 100% hit ratio on the vertex cache. Assumes vertex attributes
+	 * have been optimized for locality of reused references (see {@link reorder}).
+	 * Typical GPU vertex caches are small, holding 16-32 vertices, and rarely
+	 * achieve 100% hit ratios in practice.
+	 */
+	RENDER_OPTIMISTIC = 'render-optimistic',
+	/**
+	 * Expected number of vertices uploaded to the GPU, assuming that a client
+	 * uploads each unique {@link Primitive} individually, potentially duplicating
+	 * reused vertex attributes {@link Accessor Accessors}, but never duplicating
+	 * reused {@link Mesh Meshes} or {@link Primitive Primitives} in GPU memory.
+	 */
+	UPLOAD = 'upload',
+	/**
+	 * Expected number of vertices uploaded to the GPU, assuming that a client
+	 * uploads each unique {@link Accessor} only once. Unless glTF vertex
+	 * attributes are pre-processed to a known buffer layout, and the client is
+	 * optimized for that buffer layout, this total will be optimistic.
+	 */
+	UPLOAD_OPTIMISTIC = 'upload-optimistic',
+	/**
+	 * Total number of unique vertices represented, considering all attributes of
+	 * each vertex, and removing any duplicates.
+	 *
+	 * NOTE: Has no direct relationship to runtime characteristics, but may be
+	 * helpful in identifying asset optimization opportunities.
+	 *
+	 * @hidden Not yet implemented.
+	 */
+	DISTINCT = 'distinct',
+	/**
+	 * Total number of unique vertices represented, considering aonly vertex
+	 * positions, and removing any duplicates.
+	 *
+	 * NOTE: Has no direct relationship to runtime characteristics, but may be
+	 * helpful in identifying asset optimization opportunities.
+	 *
+	 * @hidden Not yet implemented.
+	 */
+	DISTINCT_POSITION = 'distinct-position',
+	/**
+	 * Number of vertex positions never used by any mesh primitive.
+	 *
+	 * NOTE: Has no direct relationship to runtime characteristics, but may be
+	 * helpful in identifying asset optimization opportunities.
+	 *
+	 * @hidden Not yet implemented.
+	 */
+	UNUSED = 'unused',
+}
+
+export function getSceneVertexCount(scene: Scene, method: VertexCountMethod): number {
+	return _getSubtreeVertexCount(scene, method);
+}
+
+export function getNodeVertexCount(node: Node | Scene, method: VertexCountMethod): number {
+	return _getSubtreeVertexCount(node, method);
+}
+
+function _getSubtreeVertexCount(node: Node | Scene, method: VertexCountMethod): number {
+	const instancedMeshes: [number, Mesh][] = [];
+	const nonInstancedMeshes: Mesh[] = [];
+	const meshes: Mesh[] = [];
+
+	node.traverse((node) => {
+		const mesh = node.getMesh();
+		const batch = node.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		if (batch && mesh) {
+			meshes.push(mesh);
+			instancedMeshes.push([batch.listAttributes()[0]!.getCount(), mesh]);
+		} else if (mesh) {
+			meshes.push(mesh);
+			nonInstancedMeshes.push(mesh);
+		}
+	});
+
+	const prims = meshes.flatMap((mesh) => mesh.listPrimitives());
+	const positions = prims.map((prim) => prim.getAttribute('POSITION')!);
+	const uniquePositions = Array.from(new Set(positions));
+
+	switch (method) {
+		case VertexCountMethod.RENDER:
+		case VertexCountMethod.RENDER_OPTIMISTIC:
+			return (
+				_sum(nonInstancedMeshes.map((mesh) => getMeshVertexCount(mesh, method))) +
+				_sum(instancedMeshes.map(([batch, mesh]) => batch * getMeshVertexCount(mesh, method)))
+			);
+		case VertexCountMethod.UPLOAD:
+			return _sum(meshes.map((mesh) => getMeshVertexCount(mesh, method)));
+		case VertexCountMethod.UPLOAD_OPTIMISTIC:
+			return _sum(uniquePositions.map((attribute) => attribute.getCount()));
+		case VertexCountMethod.DISTINCT:
+		case VertexCountMethod.DISTINCT_POSITION:
+		case VertexCountMethod.UNUSED:
+			return _assertNotImplemented(method);
+		default:
+			return _assertUnreachable(method);
+	}
+}
+
+export function getMeshVertexCount(mesh: Mesh, method: VertexCountMethod): number {
+	const prims = mesh.listPrimitives();
+	const uniquePrims = Array.from(new Set(prims));
+	const uniquePositions = Array.from(new Set(uniquePrims.map((prim) => prim.getAttribute('POSITION')!)));
+
+	switch (method) {
+		case VertexCountMethod.RENDER:
+		case VertexCountMethod.RENDER_OPTIMISTIC:
+		case VertexCountMethod.UPLOAD:
+			return _sum(prims.map((prim) => getPrimitiveVertexCount(prim, method)));
+		case VertexCountMethod.UPLOAD_OPTIMISTIC:
+			return _sum(uniquePositions.map((attribute) => attribute.getCount()));
+		case VertexCountMethod.DISTINCT:
+		case VertexCountMethod.DISTINCT_POSITION:
+		case VertexCountMethod.UNUSED:
+			return _assertNotImplemented(method);
+		default:
+			return _assertUnreachable(method);
+	}
+}
+
+export function getPrimitiveVertexCount(prim: Primitive, method: VertexCountMethod): number {
+	const position = prim.getAttribute('POSITION')!;
+	const indices = prim.getIndices();
+
+	switch (method) {
+		case VertexCountMethod.RENDER:
+			return indices ? indices.getCount() : position.getCount();
+		case VertexCountMethod.RENDER_OPTIMISTIC:
+			return indices ? new Set(indices.getArray()).size : position.getCount();
+		case VertexCountMethod.UPLOAD:
+		case VertexCountMethod.UPLOAD_OPTIMISTIC:
+			return position.getCount();
+		case VertexCountMethod.DISTINCT:
+		case VertexCountMethod.DISTINCT_POSITION:
+			return _assertNotImplemented(method);
+		case VertexCountMethod.UNUSED:
+			return position.getCount() - (indices ? new Set(indices.getArray()).size : position.getCount());
+		default:
+			return _assertUnreachable(method);
+	}
+}
+
+function _sum(values: number[]): number {
+	let total = 0;
+	for (let i = 0; i < values.length; i++) {
+		total += values[i];
+	}
+	return total;
+}
+
+function _assertNotImplemented<T>(x: unknown): T {
+	throw new Error(`Not implemented: ${x}`);
+}
+
+function _assertUnreachable<T>(x: never): T {
+	throw new Error(`Unexpected value: ${x}`);
+}

--- a/packages/functions/src/get-vertex-count.ts
+++ b/packages/functions/src/get-vertex-count.ts
@@ -36,9 +36,9 @@ export enum VertexCountMethod {
 
 	/**
 	 * Expected number of vertices uploaded to the GPU, assuming that a client
-	 * uploads each unique {@link Primitive} individually, potentially duplicating
-	 * reused vertex attributes {@link Accessor Accessors}, but never duplicating
-	 * reused {@link Mesh Meshes} or {@link Primitive Primitives} in GPU memory.
+	 * uploads each unique {@link Primitive} individually, duplicating vertex
+	 * attribute {@link Accessor Accessors} shared by multiple primitives, but
+	 * never uploading the same mesh or primitive to GPU memory more than once.
 	 */
 	UPLOAD = 'upload',
 

--- a/packages/functions/src/get-vertex-count.ts
+++ b/packages/functions/src/get-vertex-count.ts
@@ -106,6 +106,7 @@ function _getSubtreeVertexCount(node: Node | Scene, method: VertexCountMethod): 
 	const prims = meshes.flatMap((mesh) => mesh.listPrimitives());
 	const positions = prims.map((prim) => prim.getAttribute('POSITION')!);
 	const uniquePositions = Array.from(new Set(positions));
+	const uniqueMeshes = Array.from(new Set(meshes));
 
 	switch (method) {
 		case VertexCountMethod.RENDER:
@@ -115,7 +116,7 @@ function _getSubtreeVertexCount(node: Node | Scene, method: VertexCountMethod): 
 				_sum(instancedMeshes.map(([batch, mesh]) => batch * getMeshVertexCount(mesh, method)))
 			);
 		case VertexCountMethod.UPLOAD:
-			return _sum(meshes.map((mesh) => getMeshVertexCount(mesh, method)));
+			return _sum(uniqueMeshes.map((mesh) => getMeshVertexCount(mesh, method)));
 		case VertexCountMethod.UPLOAD_OPTIMISTIC:
 			return _sum(uniquePositions.map((attribute) => attribute.getCount()));
 		case VertexCountMethod.DISTINCT:

--- a/packages/functions/src/get-vertex-count.ts
+++ b/packages/functions/src/get-vertex-count.ts
@@ -69,7 +69,7 @@ export enum VertexCountMethod {
 	DISTINCT_POSITION = 'distinct-position',
 	/**
 	 * Number of vertex positions never used by any mesh primitive. If all
-	 * vertices are unused, this total will match {@link UPLOAD_OPTIMISTIC}.
+	 * vertices are unused, this total will match `'upload-optimistic'`.
 	 *
 	 * NOTE: Has no direct relationship to runtime characteristics, but may be
 	 * helpful in identifying asset optimization opportunities.

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -5,6 +5,7 @@ export * from './dedup.js';
 export { dequantize, dequantizePrimitive, DequantizeOptions } from './dequantize.js';
 export * from './draco.js';
 export * from './flatten.js';
+export * from './get-vertex-count.js';
 export * from './get-texture-color-space.js';
 export * from './inspect.js';
 export * from './instance.js';

--- a/packages/functions/src/inspect.ts
+++ b/packages/functions/src/inspect.ts
@@ -10,6 +10,7 @@ import {
 } from '@gltf-transform/core';
 import { getGLPrimitiveCount } from './utils.js';
 import { KHR_DF_MODEL_ETC1S, KHR_DF_MODEL_UASTC, read as readKTX } from 'ktx-parse';
+import { VertexCountMethod, getSceneVertexCount } from './get-vertex-count.js';
 
 /** Inspects the contents of a glTF file and returns a JSON report. */
 export function inspect(doc: Document): InspectReport {
@@ -35,6 +36,10 @@ function listScenes(doc: Document): InspectPropertyReport<InspectSceneReport> {
 				rootName: root ? root.getName() : '',
 				bboxMin: toPrecision(sceneBounds.min),
 				bboxMax: toPrecision(sceneBounds.max),
+				renderVertexCount: getSceneVertexCount(scene, VertexCountMethod.RENDER),
+				renderOptimisticVertexCount: getSceneVertexCount(scene, VertexCountMethod.RENDER_OPTIMISTIC),
+				uploadVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD),
+				uploadOptimisticVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD_OPTIMISTIC),
 			};
 		});
 	return { properties: scenes };
@@ -240,6 +245,10 @@ export interface InspectSceneReport {
 	rootName: string;
 	bboxMin: number[];
 	bboxMax: number[];
+	renderVertexCount: number;
+	renderOptimisticVertexCount: number;
+	uploadVertexCount: number;
+	uploadOptimisticVertexCount: number;
 }
 
 export interface InspectMeshReport {

--- a/packages/functions/test/get-vertex-count.test.ts
+++ b/packages/functions/test/get-vertex-count.test.ts
@@ -50,7 +50,7 @@ test.skip('distinct-position', async (t) => {
 	t.fail('not implemented');
 });
 
-test.skip('unused', async (t) => {
+test('unused', async (t) => {
 	const document = new Document().setLogger(logger);
 	t.is(getSceneVertexCount(createSceneBasic(document), UNUSED), 0, 'basic');
 	t.is(getSceneVertexCount(createSceneIndexed(document), UNUSED), 0, 'indexed');

--- a/packages/functions/test/get-vertex-count.test.ts
+++ b/packages/functions/test/get-vertex-count.test.ts
@@ -1,0 +1,168 @@
+import test from 'ava';
+import { Document, Scene } from '@gltf-transform/core';
+import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
+import { getSceneVertexCount, VertexCountMethod } from '@gltf-transform/functions';
+import { logger } from '@gltf-transform/test-utils';
+
+const { RENDER, RENDER_OPTIMISTIC, UPLOAD, UPLOAD_OPTIMISTIC, UNUSED } = VertexCountMethod;
+
+test('render', async (t) => {
+	const document = new Document().setLogger(logger);
+	t.is(getSceneVertexCount(createSceneBasic(document), RENDER), 32 * 4, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), RENDER), 32 + 9, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), RENDER), 32 * 5, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), RENDER), 32 * 2, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), RENDER), 15, 'unused');
+});
+
+test('render-optimistic', async (t) => {
+	const document = new Document().setLogger(logger);
+	t.is(getSceneVertexCount(createSceneBasic(document), RENDER_OPTIMISTIC), 32 * 4, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), RENDER_OPTIMISTIC), 32 + 5, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), RENDER_OPTIMISTIC), 32 * 5, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), RENDER_OPTIMISTIC), 32 * 2, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), RENDER_OPTIMISTIC), 11, 'unused');
+});
+
+test('upload', async (t) => {
+	const document = new Document().setLogger(logger);
+	t.is(getSceneVertexCount(createSceneBasic(document), UPLOAD), 32 * 4, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), UPLOAD), 32 * 2, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), UPLOAD), 32, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD), 32 * 2, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), UPLOAD), 32 * 2, 'unused');
+});
+
+test('upload-optimistic', async (t) => {
+	const document = new Document().setLogger(logger);
+	t.is(getSceneVertexCount(createSceneBasic(document), UPLOAD_OPTIMISTIC), 32 * 4, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), UPLOAD_OPTIMISTIC), 32, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), UPLOAD_OPTIMISTIC), 32, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD_OPTIMISTIC), 32, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), UPLOAD_OPTIMISTIC), 32, 'unused');
+});
+
+test.skip('distinct', async (t) => {
+	t.fail('not implemented');
+});
+
+test.skip('distinct-position', async (t) => {
+	t.fail('not implemented');
+});
+
+test.skip('unused', async (t) => {
+	const document = new Document().setLogger(logger);
+	t.is(getSceneVertexCount(createSceneBasic(document), UNUSED), 0, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), UNUSED), 0, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), UNUSED), 0, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UNUSED), 0, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), UNUSED), 24, 'unused');
+});
+
+/**
+ * Creates a scene with 4x meshes, each with 32 unindexed vertices.
+ */
+function createSceneBasic(document: Document): Scene {
+	const scene = document.createScene('Basic');
+	for (let i = 0; i < 4; i++) {
+		const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+		const prim = document.createPrimitive().setAttribute('POSITION', position);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		scene.addChild(node);
+	}
+	return scene;
+}
+
+/**
+ * Creates a scene with many 32 vertices in a vertex stream, partially indexed by each of
+ * several mesh primitives.
+ */
+function createSceneIndexed(document: Document): Scene {
+	const scene = document.createScene('Indexed');
+	const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+	const mesh = document.createMesh();
+	scene.addChild(document.createNode().setMesh(mesh));
+
+	// [0, 1, 2] + [1, 2, 3] + [2, 3, 4]
+	const indicesA = document.createAccessor().setArray(new Uint16Array([0, 1, 2, 1, 2, 3, 2, 3, 4]));
+	const primA = document.createPrimitive().setAttribute('POSITION', position).setIndices(indicesA);
+	mesh.addPrimitive(primA);
+
+	// all vertices x 1
+	const indicesB = document.createAccessor().setArray(new Uint16Array(32).map((_, i) => i));
+	const primB = document.createPrimitive().setAttribute('POSITION', position).setIndices(indicesB);
+	mesh.addPrimitive(primB);
+
+	return scene;
+}
+
+/**
+ * Creates a scene with one mesh primitive having 32 vertices, reused 2x with
+ * typical instancing and 3x with GPU instancing.
+ */
+function createSceneInstanced(document: Document): Scene {
+	const scene = document.createScene('Instanced');
+	const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+	const prim = document.createPrimitive().setAttribute('POSITION', position);
+	const mesh = document.createMesh().addPrimitive(prim);
+
+	// instancing
+	for (let i = 0; i < 2; i++) {
+		scene.addChild(document.createNode().setMesh(mesh));
+	}
+
+	// gpu instancing
+	const batchExtension = document.createExtension(EXTMeshGPUInstancing);
+	const batchTranslation = document
+		.createAccessor()
+		.setType('VEC3')
+		.setArray(new Float32Array([0, 0, 0, 10, 10, 10, 20, 20, 20]));
+	const batch = batchExtension.createInstancedMesh().setAttribute('TRANSLATION', batchTranslation);
+	scene.addChild(document.createNode().setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch));
+
+	return scene;
+}
+
+/**
+ * Creates a scene with 32 vertices in a vertex stream, reused by two mesh primitives.
+ * Some vertex attributes (other than position) differ between the two.
+ */
+function createSceneMixedAttributes(document: Document): Scene {
+	const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+	const indices = document.createAccessor().setArray(new Uint16Array(32).map((_, i) => i));
+	const colorA = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+	const colorB = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+
+	const primA = document
+		.createPrimitive()
+		.setIndices(indices)
+		.setAttribute('POSITION', position)
+		.setAttribute('COLOR_0', colorA);
+	const primB = document
+		.createPrimitive()
+		.setIndices(indices)
+		.setAttribute('POSITION', position)
+		.setAttribute('COLOR_0', colorB);
+
+	const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
+	const node = document.createNode().setMesh(mesh);
+
+	return document.createScene('MixedAttributes').addChild(node);
+}
+
+/**
+ * Creates a scene with two mesh primitives and 32 vertices. Only 8 vertices
+ * are indexed, leaving 24 vertices uploaded but not rendered.
+ */
+function createSceneUnused(document: Document): Scene {
+	const scene = document.createScene('MixedAttributes');
+	const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(96));
+	const indicesA = document.createAccessor().setArray(new Float32Array([5, 6, 7, 8, 9, 10]));
+	const indicesB = document.createAccessor().setArray(new Float32Array([8, 9, 10, 11, 12, 8, 9, 10, 8]));
+	const primA = document.createPrimitive().setIndices(indicesA).setAttribute('POSITION', position);
+	const primB = document.createPrimitive().setIndices(indicesB).setAttribute('POSITION', position);
+	const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
+	const node = document.createNode().setMesh(mesh);
+	return scene.addChild(node);
+}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -4,9 +4,12 @@
 	"version": "4.0.0-alpha.10",
 	"type": "module",
 	"sideEffects": false,
-	"exports": "./dist/test-utils.modern.js",
 	"source": "./src/index.ts",
 	"types": "./dist/index.d.ts",
+	"exports": {
+		"types": "./dist/index.d.ts",
+		"default": "./dist/test-utils.modern.js"
+	},
 	"scripts": {
 		"dist": "microbundle --format modern --no-compress",
 		"watch": "microbundle watch --format modern --no-compress"


### PR DESCRIPTION
Work in progress.

Changes:
- Add `getSceneVertexCount`
- Add `getNodeVertexCount`
- Add `getMeshVertexCount`
- Add `getPrimitiveVertexCount`
- Fixes #1319

Remaining:
- [x] Unit tests
- [ ] VertexCountMethod.DISTINCT
- [ ] VertexCountMethod.DISTINCT_POSITION
- [x] VertexCountMethod.UNUSED

