### PR TITLE
feat(functions,cli): Expose sharp's limitInputPixels option

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -412,6 +412,7 @@ commands or using the scripting API.
 					encoder,
 					targetFormat: opts.textureCompress === 'auto' ? undefined : opts.textureCompress,
 					resize: [opts.textureSize, opts.textureSize],
+					limitInputPixels: options.limitInputPixels as boolean,
 				}),
 			);
 		}
@@ -1535,6 +1536,7 @@ program
 				quality: options.quality as number,
 				effort: options.effort as number,
 				lossless: options.lossless as boolean,
+				limitInputPixels: options.limitInputPixels as boolean,
 			}),
 		);
 	});
@@ -1577,6 +1579,7 @@ program
 				effort: options.effort as number,
 				lossless: options.lossless as boolean,
 				nearLossless: options.nearLossless as boolean,
+				limitInputPixels: options.limitInputPixels as boolean,
 			}),
 		);
 	});
@@ -1612,6 +1615,7 @@ program
 				slots,
 				quality: options.quality as number,
 				effort: options.effort as number,
+				limitInputPixels: options.limitInputPixels as boolean,
 			}),
 		);
 	});
@@ -1645,6 +1649,7 @@ program
 				formats,
 				slots,
 				quality: options.quality as number,
+				limitInputPixels: options.limitInputPixels as boolean,
 			}),
 		);
 	});
@@ -1758,6 +1763,16 @@ program.option('--vertex-layout <layout>', 'Vertex buffer layout preset.', {
 program.option('--config <path>', 'Installs custom commands or extensions. (EXPERIMENTAL)', {
 	validator: Validator.STRING,
 });
+program.option(
+	'--limit-input-pixels',
+	'Attempts to avoid processing very high resolution images, where memory or ' +
+		'other limits may be exceeded. (EXPERIMENTAL)',
+	{
+		validator: Validator.BOOLEAN,
+		default: true,
+		hidden: true,
+	},
+);
 program.disableGlobalOption('--quiet');
 program.disableGlobalOption('--no-color');
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,4 +1,10 @@
-import { program as _program, Command, Logger as WinstonLogger } from '@donmccurdy/caporal';
+import {
+	program as _program,
+	Command,
+	ParsedOption,
+	Validator as CaporalValidator,
+	Logger as WinstonLogger,
+} from '@donmccurdy/caporal';
 import { ILogger, Verbosity } from '@gltf-transform/core';
 
 const PAD_EMOJI = new Set(['🫖', '🖼', '⏯️']);
@@ -27,8 +33,9 @@ interface IInternalProgram extends IProgram {
 
 export interface IProgramOptions<T = unknown> {
 	default?: T;
-	validator?: ValidatorFn | T[];
+	validator?: CaporalValidator;
 	action?: IActionFn;
+	hidden?: boolean;
 }
 
 export type IActionFn = (params: {
@@ -95,7 +102,12 @@ export interface ICommand {
 	alias: (name: string) => this;
 }
 
-export interface ICommandOptions {}
+export interface ICommandOptions {
+	required?: boolean;
+	default?: ParsedOption;
+	validator?: CaporalValidator;
+	hidden?: boolean;
+}
 
 class CommandImpl implements ICommand {
 	_ctx: Command;
@@ -135,10 +147,7 @@ export const program = new ProgramImpl();
  * Validator.
  */
 
-type ValidatorFn = unknown;
-type ValidatorType = 'NUMBER' | 'ARRAY' | 'BOOLEAN' | 'STRING';
-
-export const Validator: Record<ValidatorType, ValidatorFn> = {
+export const Validator: Record<'NUMBER' | 'ARRAY' | 'BOOLEAN' | 'STRING', CaporalValidator> = {
 	NUMBER: _program.NUMBER,
 	ARRAY: _program.ARRAY,
 	BOOLEAN: _program.BOOLEAN,

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -85,6 +85,13 @@ export interface TextureCompressOptions {
 	 * Sharp encoder is provided. Default: false.
 	 */
 	nearLossless?: boolean;
+
+	/**
+	 * Attempts to avoid processing images that could exceed memory or other other
+	 * limits, throwing an error instead. Default: true.
+	 * @experimental
+	 */
+	limitInputPixels?: boolean;
 }
 
 export type CompressTextureOptions = Omit<TextureCompressOptions, 'pattern' | 'formats' | 'slots'>;
@@ -99,6 +106,7 @@ export const TEXTURE_COMPRESS_DEFAULTS: Omit<TextureCompressOptions, 'resize' | 
 	effort: undefined,
 	lossless: false,
 	nearLossless: false,
+	limitInputPixels: true,
 };
 
 /**
@@ -319,7 +327,8 @@ async function _encodeWithSharp(
 			break;
 	}
 
-	const instance = encoder(srcImage).toFormat(dstFormat, encoderOptions);
+	const limitInputPixels = options.limitInputPixels;
+	const instance = encoder(srcImage, { limitInputPixels }).toFormat(dstFormat, encoderOptions);
 
 	if (options.resize) {
 		const srcSize = ImageUtils.getSize(srcImage, _srcMimeType)!;


### PR DESCRIPTION
Provides an experimental flag on the CLI and textureCompress() function, disabling Sharp's limits on input image size. By default Sharp will not process anything >=16k. For the time being, the `--limit-input-pixels` flag is hidden from the CLI help output.

See:

https://sharp.pixelplumbing.com/api-constructor
