### PR TITLE
chore(functions): Remove lossy weld

### DIFF
--- a/packages/functions/src/compact-primitive.ts
+++ b/packages/functions/src/compact-primitive.ts
@@ -1,6 +1,5 @@
 import { Accessor, Document, Primitive, TypedArray, TypedArrayConstructor } from '@gltf-transform/core';
 import { createIndicesEmpty, deepListAttributes, shallowCloneAccessor } from './utils.js';
-import { cleanPrimitive } from './clean-primitive.js';
 import { VertexCountMethod, getPrimitiveVertexCount } from './get-vertex-count.js';
 
 /** @hidden */
@@ -46,10 +45,6 @@ export function compactPrimitive(prim: Primitive, remap: TypedArray, dstVertexCo
 	for (const srcAttribute of srcAttributesPrev) {
 		if (srcAttribute.listParents().length === 1) srcAttribute.dispose();
 	}
-
-	// Clean up degenerate topology.
-
-	cleanPrimitive(prim);
 
 	return prim;
 }

--- a/packages/functions/src/convert-primitive-mode.ts
+++ b/packages/functions/src/convert-primitive-mode.ts
@@ -25,7 +25,7 @@ export function convertPrimitiveToLines(prim: Primitive): void {
 
 	// Ensure indexed primitive.
 	if (!prim.getIndices()) {
-		weldPrimitive(prim, { tolerance: 0 });
+		weldPrimitive(prim);
 	}
 
 	// Allocate indices new GL primitives.
@@ -89,7 +89,7 @@ export function convertPrimitiveToTriangles(prim: Primitive): void {
 
 	// Ensure indexed primitive.
 	if (!prim.getIndices()) {
-		weldPrimitive(prim, { tolerance: 0 });
+		weldPrimitive(prim);
 	}
 
 	// Allocate indices new GL primitives.

--- a/packages/functions/src/draco.ts
+++ b/packages/functions/src/draco.ts
@@ -40,7 +40,7 @@ export const DRACO_DEFAULTS: DracoOptions = {
 export function draco(_options: DracoOptions = DRACO_DEFAULTS): Transform {
 	const options = { ...DRACO_DEFAULTS, ..._options } as Required<DracoOptions>;
 	return createTransform(NAME, async (document: Document): Promise<void> => {
-		await document.transform(weld({ tolerance: 0 }));
+		await document.transform(weld());
 		document
 			.createExtension(KHRDracoMeshCompression)
 			.setRequired(true)

--- a/packages/functions/src/hash-table.ts
+++ b/packages/functions/src/hash-table.ts
@@ -4,7 +4,7 @@ import { deepListAttributes } from './utils.js';
 /** Flags 'empty' values in a Uint32Array index. */
 export const EMPTY_U32 = 2 ** 32 - 1;
 
-export class HashTable {
+export class VertexStream {
 	private attributes: { u8: Uint8Array; byteStride: number; paddedByteStride: number }[] = [];
 
 	/** Temporary vertex views in 4-byte-aligned memory. */
@@ -86,18 +86,18 @@ function murmurHash2(h: number, key: Uint32Array): number {
 export function hashLookup(
 	table: Uint32Array,
 	buckets: number,
-	hash: HashTable,
+	stream: VertexStream,
 	key: number,
 	empty = EMPTY_U32,
 ): number {
 	const hashmod = buckets - 1;
-	const hashval = hash.hash(key);
+	const hashval = stream.hash(key);
 	let bucket = hashval & hashmod;
 
 	for (let probe = 0; probe <= hashmod; probe++) {
 		const item = table[bucket];
 
-		if (item === empty || hash.equal(item, key)) {
+		if (item === empty || stream.equal(item, key)) {
 			return bucket;
 		}
 

--- a/packages/functions/src/transform-primitive.ts
+++ b/packages/functions/src/transform-primitive.ts
@@ -144,7 +144,7 @@ function applyTangentMatrix(matrix: mat4, attribute: Accessor, indices: Uint32Ar
 
 function reversePrimitiveWindingOrder(prim: Primitive) {
 	if (prim.getMode() !== Primitive.Mode.TRIANGLES) return;
-	if (!prim.getIndices()) weldPrimitive(prim, { tolerance: 0 });
+	if (!prim.getIndices()) weldPrimitive(prim);
 
 	const indices = prim.getIndices()!;
 	for (let i = 0, il = indices.getCount(); i < il; i += 3) {

--- a/packages/functions/src/weld.ts
+++ b/packages/functions/src/weld.ts
@@ -1,10 +1,10 @@
-import { Accessor, Document, Primitive, PropertyType, Transform, vec3 } from '@gltf-transform/core';
+import { Document, Primitive, PropertyType, Transform } from '@gltf-transform/core';
 import { dedup } from './dedup.js';
 import { prune } from './prune.js';
-import { EMPTY_U32, HashTable, hashLookup } from './hash-table.js';
-import { ceilPowerOfTwo, createIndices, createTransform, formatDeltaOp } from './utils.js';
+import { EMPTY_U32, VertexStream, hashLookup } from './hash-table.js';
+import { ceilPowerOfTwo, createTransform, formatDeltaOp } from './utils.js';
 import { compactPrimitive } from './compact-primitive.js';
-import { remapPrimitive } from './remap-primitive.js';
+import { VertexCountMethod, getPrimitiveVertexCount } from './get-vertex-count.js';
 
 /**
  * CONTRIBUTOR NOTES
@@ -43,29 +43,20 @@ import { remapPrimitive } from './remap-primitive.js';
  * - (3) 660s
  * - (4) 5s exhaustive, 1.5s non-exhaustive
  * - (5) 0.2s
+ *
+ * As of April 2024, the lossy weld was removed, leaving only approach #5. An
+ * upcoming Meshoptimizer release will include a simplifyWithAttributes
+ * function allowing simplification with weighted consideration of vertex
+ * attributes, which I hope to support. With that, weld() may remain faster,
+ * simpler, and more maintainable.
  */
 
 const NAME = 'weld';
 
-const Tolerance = {
-	DEFAULT: 0,
-	TEXCOORD: 0.0001, // [0, 1]
-	COLOR: 0.01, // [0, 1]
-	NORMAL: 0.05, // [-1, 1], ±3º
-	JOINTS: 0.0, // [0, ∞]
-	WEIGHTS: 0.01, // [0, ∞]
-};
-
 /** Options for the {@link weld} function. */
 export interface WeldOptions {
-	/** Tolerance for vertex positions, as a fraction of primitive AABB. */
-	tolerance?: number;
-	/** Tolerance for vertex normals, in radians. */
-	toleranceNormal?: number;
 	/** Whether to overwrite existing indices. */
 	overwrite?: boolean;
-	/** Enables a more thorough, but slower, search for vertices to weld. */
-	exhaustive?: boolean;
 	/**
 	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
 	 * default. Cleanup removes temporary resources created during the operation, but may also remove
@@ -78,48 +69,30 @@ export interface WeldOptions {
 }
 
 export const WELD_DEFAULTS: Required<WeldOptions> = {
-	tolerance: Tolerance.DEFAULT,
-	toleranceNormal: Tolerance.NORMAL,
 	overwrite: true,
-	exhaustive: false, // donmccurdy/glTF-Transform#886
 	cleanup: true,
 };
 
 /**
- * Welds {@link Primitive Primitives}, merging similar vertices. When merged
- * and indexed, data is shared more efficiently between vertices. File size can
- * be reduced, and the GPU uses the vertex cache more efficiently.
- *
- * When welding, the 'tolerance' threshold determines which vertices qualify for
- * welding based on distance between the vertices as a fraction of the primitive's
- * bounding box (AABB). For example, tolerance=0.01 welds vertices within +/-1%
- * of the AABB's longest dimension. Other vertex attributes are also compared
- * during welding, with attribute-specific thresholds. For `tolerance=0`, welding
- * requires bitwise-equality and completes much faster.
- *
- * To preserve visual appearance consistently with non-zero `tolerance`, use low
- * `toleranceNormal` thresholds around 0.1 (±3º). To pre-processing a scene
- * before simplification or LOD creation, consider higher thresholds around 0.5 (±30º).
+ * Welds {@link Primitive Primitives}, merging bitwise identical vertices. When
+ * merged and indexed, data is shared more efficiently between vertices. File size
+ * can be reduced, and the GPU uses the vertex cache more efficiently.
  *
  * Example:
  *
  * ```javascript
- * import { weld } from '@gltf-transform/functions';
+ * import { weld, getSceneVertexCount, VertexCountMethod } from '@gltf-transform/functions';
  *
- * // Lossless and fast.
+ * const scene = document.getDefaultScene();
+ * const srcVertexCount = getSceneVertexCount(scene, VertexCountMethod.GPU);
  * await document.transform(weld());
- *
- * // Lossy and slower.
- * await document.transform(weld({ tolerance: 0.001, toleranceNormal: 0.5 }));
- *
- * // Lossy and slowest, maximizing vertex count reduction.
- * await document.transform(weld({ tolerance: 0.001, toleranceNormal: 0.5, exhaustive: true }));
+ * const dstVertexCount = getSceneVertexCount(scene, VertexCountMethod.GPU);
  * ```
  *
  * @category Transforms
  */
 export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
-	const options = expandWeldOptions(_options);
+	const options = { ...WELD_DEFAULTS, ..._options };
 
 	return createTransform(NAME, async (doc: Document): Promise<void> => {
 		const logger = doc.getLogger();
@@ -128,7 +101,9 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 			for (const prim of mesh.listPrimitives()) {
 				weldPrimitive(prim, options);
 
-				if (isPrimEmpty(prim)) prim.dispose();
+				if (getPrimitiveVertexCount(prim, VertexCountMethod.RENDER) === 0) {
+					prim.dispose();
+				}
 			}
 
 			if (mesh.listPrimitives().length === 0) mesh.dispose();
@@ -152,54 +127,42 @@ export function weld(_options: WeldOptions = WELD_DEFAULTS): Transform {
 }
 
 /**
- * Welds a {@link Primitive}, merging similar vertices. When merged and
- * indexed, data is shared more efficiently between vertices. File size can
+ * Welds a {@link Primitive}, merging bitwise identical vertices. When merged
+ * and indexed, data is shared more efficiently between vertices. File size can
  * be reduced, and the GPU uses the vertex cache more efficiently.
- *
- * When welding, the 'tolerance' threshold determines which vertices qualify for
- * welding based on distance between the vertices as a fraction of the primitive's
- * bounding box (AABB). For example, tolerance=0.01 welds vertices within +/-1%
- * of the AABB's longest dimension. Other vertex attributes are also compared
- * during welding, with attribute-specific thresholds. For `tolerance=0`, welding
- * requires bitwise-equality and completes much faster.
  *
  * Example:
  *
  * ```javascript
- * import { weldPrimitive } from '@gltf-transform/functions';
+ * import { weldPrimitive, getMeshVertexCount, VertexCountMethod } from '@gltf-transform/functions';
  *
  * const mesh = document.getRoot().listMeshes()
  * 	.find((mesh) => mesh.getName() === 'Gizmo');
  *
+ * const srcVertexCount = getMeshVertexCount(mesh, VertexCountMethod.GPU);
+ *
  * for (const prim of mesh.listPrimitives()) {
- *   weldPrimitive(prim, {tolerance: 0});
+ *   weldPrimitive(prim);
  * }
+ *
+ * const dstVertexCount = getMeshVertexCount(mesh, VertexCountMethod.GPU);
  * ```
  */
 export function weldPrimitive(prim: Primitive, _options: WeldOptions = WELD_DEFAULTS): void {
 	const graph = prim.getGraph();
 	const document = Document.fromGraph(graph)!;
-	const options = expandWeldOptions(_options);
+	const logger = document.getLogger();
+	const options = { ...WELD_DEFAULTS, ..._options };
 
-	if (prim.getIndices() && !_options.overwrite) return;
+	if (prim.getIndices() && !options.overwrite) return;
 	if (prim.getMode() === Primitive.Mode.POINTS) return;
 
-	if (_options.tolerance === 0) {
-		_weldPrimitiveStrict(document, prim);
-	} else {
-		_weldPrimitive(document, prim, options);
-	}
-}
-
-/** @internal Weld and merge, combining vertices that are bitwise-equal. */
-function _weldPrimitiveStrict(document: Document, prim: Primitive): void {
-	const logger = document.getLogger();
 	const srcVertexCount = prim.getAttribute('POSITION')!.getCount();
 	const srcIndices = prim.getIndices();
 	const srcIndicesArray = srcIndices?.getArray();
 	const srcIndicesCount = srcIndices ? srcIndices.getCount() : srcVertexCount;
 
-	const hash = new HashTable(prim);
+	const stream = new VertexStream(prim);
 	const tableSize = ceilPowerOfTwo(srcVertexCount + srcVertexCount / 4);
 	const table = new Uint32Array(tableSize).fill(EMPTY_U32);
 	const writeMap = new Uint32Array(srcVertexCount).fill(EMPTY_U32); // oldIndex → newIndex
@@ -212,7 +175,7 @@ function _weldPrimitiveStrict(document: Document, prim: Primitive): void {
 		const srcIndex = srcIndicesArray ? srcIndicesArray[i] : i;
 		if (writeMap[srcIndex] !== EMPTY_U32) continue;
 
-		const hashIndex = hashLookup(table, tableSize, hash, srcIndex, EMPTY_U32);
+		const hashIndex = hashLookup(table, tableSize, stream, srcIndex, EMPTY_U32);
 		const dstIndex = table[hashIndex];
 
 		if (dstIndex === EMPTY_U32) {
@@ -226,193 +189,4 @@ function _weldPrimitiveStrict(document: Document, prim: Primitive): void {
 	logger.debug(`${NAME}: ${formatDeltaOp(srcVertexCount, dstVertexCount)} vertices.`);
 
 	compactPrimitive(prim, writeMap, dstVertexCount);
-}
-
-/** @internal Weld and merge, combining vertices within tolerance. */
-function _weldPrimitive(document: Document, prim: Primitive, options: Required<WeldOptions>): void {
-	const logger = document.getLogger();
-
-	const srcPosition = prim.getAttribute('POSITION')!;
-	const srcIndices = prim.getIndices() || document.createAccessor().setArray(createIndices(srcPosition.getCount()));
-	const uniqueIndices = new Uint32Array(new Set(srcIndices.getArray()!)).sort();
-
-	// (1) Compute per-attribute tolerance and spatial grid for vertices.
-
-	const attributeTolerance: Record<string, number> = {};
-	for (const semantic of prim.listSemantics()) {
-		const attribute = prim.getAttribute(semantic)!;
-		attributeTolerance[semantic] = getAttributeTolerance(semantic, attribute, options);
-	}
-
-	logger.debug(`${NAME}: Tolerance thresholds: ${formatKV(attributeTolerance)}`);
-
-	// (2) Build the lookup grid.
-
-	const posA: vec3 = [0, 0, 0];
-	const posB: vec3 = [0, 0, 0];
-
-	const grid = {} as Record<string, number[]>;
-	const cellSize = attributeTolerance.POSITION;
-
-	for (let i = 0; i < uniqueIndices.length; i++) {
-		srcPosition.getElement(uniqueIndices[i], posA);
-		const key = getGridKey(posA, cellSize);
-		grid[key] = grid[key] || [];
-		grid[key].push(uniqueIndices[i]);
-	}
-
-	// (3) Compare and identify vertices to weld.
-
-	const srcMaxIndex = uniqueIndices[uniqueIndices.length - 1];
-	const weldMap = createIndices(srcMaxIndex + 1); // oldIndex → oldCommonIndex
-	const writeMap = new Uint32Array(uniqueIndices.length).fill(EMPTY_U32); // oldIndex → newIndex
-
-	const srcVertexCount = srcPosition.getCount();
-	let dstVertexCount = 0;
-
-	for (let i = 0; i < uniqueIndices.length; i++) {
-		const a = uniqueIndices[i];
-		srcPosition.getElement(a, posA);
-
-		const cellKeys = options.exhaustive ? getGridNeighborhoodKeys(posA, cellSize) : [getGridKey(posA, cellSize)];
-
-		cells: for (const cellKey of cellKeys) {
-			if (!grid[cellKey]) continue cells; // May occur in exhaustive search.
-
-			neighbors: for (const j of grid[cellKey]) {
-				const b = weldMap[j];
-
-				// Only weld to lower indices, preventing two-way match.
-				if (a <= b) continue neighbors;
-
-				srcPosition.getElement(b, posB);
-
-				// Weld if base attributes and morph target attributes match.
-				const isBaseMatch = prim.listSemantics().every((semantic) => {
-					const attribute = prim.getAttribute(semantic)!;
-					const tolerance = attributeTolerance[semantic];
-					return compareAttributes(attribute, a, b, tolerance, semantic);
-				});
-				const isTargetMatch = prim.listTargets().every((target) => {
-					return target.listSemantics().every((semantic) => {
-						const attribute = target.getAttribute(semantic)!;
-						const tolerance = attributeTolerance[semantic];
-						return compareAttributes(attribute, a, b, tolerance, semantic);
-					});
-				});
-
-				if (isBaseMatch && isTargetMatch) {
-					weldMap[a] = b;
-					break cells;
-				}
-			}
-		}
-
-		// Output the vertex if we didn't find a match, else record the index of the match. Because
-		// we iterate vertices in ascending order, and only match to lower indices, we're
-		// guaranteed the source vertex for a weld has already been marked for output.
-		if (weldMap[a] === a) {
-			writeMap[a] = dstVertexCount++;
-		} else {
-			writeMap[a] = writeMap[weldMap[a]];
-		}
-	}
-
-	logger.debug(`${NAME}: ${formatDeltaOp(srcVertexCount, dstVertexCount)} vertices.`);
-
-	remapPrimitive(prim, writeMap, dstVertexCount);
-}
-
-const _a = [] as number[];
-const _b = [] as number[];
-
-/** Computes a per-attribute tolerance, based on domain and usage of the attribute. */
-function getAttributeTolerance(semantic: string, attribute: Accessor, options: Required<WeldOptions>): number {
-	// Attributes like NORMAL and COLOR_# do not vary in range like POSITION,
-	// so do not apply the given tolerance factor to these attributes.
-	if (semantic === 'NORMAL' || semantic === 'TANGENT') return options.toleranceNormal;
-	if (semantic.startsWith('COLOR_')) return Tolerance.COLOR;
-	if (semantic.startsWith('TEXCOORD_')) return Tolerance.TEXCOORD;
-	if (semantic.startsWith('JOINTS_')) return Tolerance.JOINTS;
-	if (semantic.startsWith('WEIGHTS_')) return Tolerance.WEIGHTS;
-
-	_a.length = _b.length = 0;
-	attribute.getMinNormalized(_a);
-	attribute.getMaxNormalized(_b);
-	const diff = _b.map((bi, i) => bi - _a[i]);
-	const range = Math.max(...diff);
-	return options.tolerance * range;
-}
-
-/** Compares two vertex attributes against a tolerance threshold. */
-function compareAttributes(attribute: Accessor, a: number, b: number, tolerance: number, _semantic: string): boolean {
-	attribute.getElement(a, _a);
-	attribute.getElement(b, _b);
-	for (let i = 0, il = attribute.getElementSize(); i < il; i++) {
-		if (Math.abs(_a[i] - _b[i]) > tolerance) {
-			return false;
-		}
-	}
-	return true;
-}
-
-function formatKV(kv: Record<string, unknown>): string {
-	return Object.entries(kv)
-		.map(([k, v]) => `${k}=${v}`)
-		.join(', ');
-}
-
-// Order to search nearer cells first.
-const CELL_OFFSETS = [0, -1, 1];
-
-function getGridNeighborhoodKeys(p: vec3, cellSize: number): string[] {
-	const keys = [] as string[];
-	const _p = [0, 0, 0] as vec3;
-	for (const i of CELL_OFFSETS) {
-		for (const j of CELL_OFFSETS) {
-			for (const k of CELL_OFFSETS) {
-				_p[0] = p[0] + i * cellSize;
-				_p[1] = p[1] + j * cellSize;
-				_p[2] = p[2] + k * cellSize;
-				keys.push(getGridKey(_p, cellSize));
-			}
-		}
-	}
-	return keys;
-}
-
-function getGridKey(p: vec3, cellSize: number): string {
-	const cellX = Math.round(p[0] / cellSize);
-	const cellY = Math.round(p[1] / cellSize);
-	const cellZ = Math.round(p[2] / cellSize);
-	return cellX + ':' + cellY + ':' + cellZ;
-}
-
-function expandWeldOptions(_options: WeldOptions): Required<WeldOptions> {
-	const options = { ...WELD_DEFAULTS, ..._options } as Required<WeldOptions>;
-
-	if (options.tolerance < 0 || options.tolerance > 0.1) {
-		throw new Error(`${NAME}: Requires 0 <= tolerance <= 0.1`);
-	}
-
-	if (options.toleranceNormal < 0 || options.toleranceNormal > Math.PI / 2) {
-		throw new Error(`${NAME}: Requires 0 <= toleranceNormal <= ${(Math.PI / 2).toFixed(2)}`);
-	}
-
-	if (options.tolerance > 0) {
-		options.tolerance = Math.max(options.tolerance, Number.EPSILON);
-		options.toleranceNormal = Math.max(options.toleranceNormal, Number.EPSILON);
-	}
-
-	return options;
-}
-
-/**
- * For purposes of welding, we consider a primitive to be 'empty' or degenerate
- * if (1) it has an index, and (2) that index is empty. In some cases
- * (mode=POINTS) the index may be missing — this is outside the scope of welding.
- */
-function isPrimEmpty(prim: Primitive): boolean {
-	const indices = prim.getIndices();
-	return !!indices && indices.getCount() === 0;
 }


### PR DESCRIPTION
- BREAKING CHANGE: weld is now lossless, and does not accept tolerance options.

Avoids having to maintain two versions of weld(), the lossless version is vastly faster. Future updates to Meshoptimizer will include simplifyWithAttributes (#1335), which I hope will provide a better approach for joining vertices despite differences in vertex attributes, and allowing weld() to remain a faster, more focused, and more maintainable method.

I spent some time trying other approaches — like #1356, trying to consolidate the two methods. But that got complicated quickly. If I were trying that again, I think I'd take an approach similar to #1356 but have the QuantizedVertexStream class apply rounding when _reading_ each vertex, rather than iterating the vertex attributes up front. Then we need to rebuild the 'writeMap' after removing degenerate triangles, write a temporary index to the geometry without those triangles, then run it through compactPrimitive... it's just messier.

But I'm hoping a lossless weld is enough — that's all gltfpack appears to do for example. And when #1335 is available, that will be a (likely better) alternative for merging vertices that are not identical.

- #1315
- #1133