### PR TITLE
feat(functions): Add mergeDocuments, cloneDocument, copyToDocument, moveToDocument

### DIFF
--- a/benchmarks/tasks/clone.bench.ts
+++ b/benchmarks/tasks/clone.bench.ts
@@ -1,9 +1,10 @@
 import { Document } from '@gltf-transform/core';
+import { cloneDocument } from '@gltf-transform/functions';
 import { Size, Task } from '../constants';
 import { createLargeDocument } from '../utils';
 
 let _document: Document;
 
 export const tasks: Task[] = [
-	['clone', () => _document.clone(), { beforeAll: () => void (_document = createLargeDocument(Size.SM)) }],
+	['clone', () => cloneDocument(_document), { beforeAll: () => void (_document = createLargeDocument(Size.SM)) }],
 ];

--- a/packages/cli/src/transforms/merge.ts
+++ b/packages/cli/src/transforms/merge.ts
@@ -9,7 +9,7 @@ import {
 	Buffer,
 	PropertyType,
 } from '@gltf-transform/core';
-import { dedup, unpartition } from '@gltf-transform/functions';
+import { dedup, mergeDocuments, unpartition } from '@gltf-transform/functions';
 
 const NAME = 'merge';
 
@@ -41,7 +41,7 @@ const merge = (options: MergeOptions): Transform => {
 					.setMimeType(ImageUtils.extensionToMimeType(extension))
 					.setURI(basename + '.' + extension);
 			} else if (['gltf', 'glb'].includes(extension)) {
-				document.merge(renameScenes(basename, await io.read(path)));
+				mergeDocuments(document, renameScenes(basename, await io.read(path)));
 			} else {
 				throw new Error(`Unknown file extension: "${extension}".`);
 			}

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -133,63 +133,24 @@ export class Document {
 		return this;
 	}
 
-	/** Clones this Document, copying all resources within it. */
+	/**
+	 * Clones this Document, copying all resources within it.
+	 * @deprecated Use 'cloneDocument(document)' from '@gltf-transform/functions'.
+	 * @hidden
+	 * @internal
+	 */
 	public clone(): Document {
-		return new Document().setLogger(this._logger).merge(this);
+		throw new Error(`Use 'cloneDocument(source)' from '@gltf-transform/functions'.`);
 	}
 
-	/** Merges the content of another Document into this one, without affecting the original. */
-	public merge(other: Document): this {
-		// 1. Attach extensions.
-		const thisExtensions: { [key: string]: Extension } = {};
-		for (const otherExtension of other.getRoot().listExtensionsUsed()) {
-			const thisExtension = this.createExtension(otherExtension.constructor as new (doc: Document) => Extension);
-			if (otherExtension.isRequired()) thisExtension.setRequired(true);
-			thisExtensions[thisExtension.extensionName] = thisExtension;
-		}
-
-		// 2. Preconfigure the Root and merge history.
-		const visited = new Set<Property>();
-		const propertyMap = new Map<Property, Property>();
-		visited.add(other._root);
-		propertyMap.set(other._root, this._root);
-
-		// 3. Create stub classes for every Property in other Document.
-		for (const edge of other._graph.listEdges()) {
-			for (const otherProp of [edge.getParent() as Property, edge.getChild() as Property]) {
-				if (visited.has(otherProp)) continue;
-
-				let thisProp: Property;
-				if (otherProp.propertyType === PropertyType.TEXTURE_INFO) {
-					// TextureInfo lifecycle is bound to a Material or ExtensionProperty.
-					thisProp = otherProp as Property;
-				} else {
-					// For other property types, create stub classes.
-					const PropertyClass = otherProp.constructor as new (g: Graph<Property>) => Property;
-					thisProp = new PropertyClass(this._graph);
-				}
-
-				propertyMap.set(otherProp as Property, thisProp);
-				visited.add(otherProp);
-			}
-		}
-
-		// 4. Assemble the edges between Properties.
-		const resolve = (p: Property): Property => {
-			const resolved = propertyMap.get(p);
-			if (!resolved) throw new Error('Could resolve property.');
-			return resolved;
-		};
-		for (const otherProp of visited) {
-			const thisProp = propertyMap.get(otherProp);
-			if (!thisProp) throw new Error('Could resolve property.');
-			// TextureInfo copy handled by Material or ExtensionProperty.
-			if (thisProp.propertyType !== PropertyType.TEXTURE_INFO) {
-				thisProp.copy(otherProp, resolve);
-			}
-		}
-
-		return this;
+	/**
+	 * Merges the content of another Document into this one, without affecting the original.
+	 * @deprecated Use 'mergeDocuments(target, source)' from '@gltf-transform/functions'.
+	 * @hidden
+	 * @internal
+	 */
+	public merge(_other: Document): this {
+		throw new Error(`Use 'mergeDocuments(target, source)' from '@gltf-transform/functions'.`);
 	}
 
 	/**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
 	Skin,
 	Texture,
 	TextureInfo,
+	PropertyResolver,
 	COPY_IDENTITY,
 } from './properties/index.js';
 export { Graph, GraphEdge, Ref, RefList, RefSet, RefMap } from 'property-graph';

--- a/packages/core/src/properties/property.ts
+++ b/packages/core/src/properties/property.ts
@@ -24,7 +24,7 @@ import {
 import type { UnknownRef } from '../utils/index.js';
 
 export type PropertyResolver<T extends Property> = (p: T) => T;
-export const COPY_IDENTITY: PropertyResolver<Property> = <T extends Property = Property>(t: T): T => t;
+export const COPY_IDENTITY = <T extends Property>(t: T): T => t;
 
 export interface IProperty {
 	name: string;

--- a/packages/core/src/properties/property.ts
+++ b/packages/core/src/properties/property.ts
@@ -24,7 +24,7 @@ import {
 import type { UnknownRef } from '../utils/index.js';
 
 export type PropertyResolver<T extends Property> = (p: T) => T;
-export const COPY_IDENTITY = <T extends Property>(t: T): T => t;
+export const COPY_IDENTITY: PropertyResolver<Property> = <T extends Property = Property>(t: T): T => t;
 
 export interface IProperty {
 	name: string;

--- a/packages/core/test/document.test.ts
+++ b/packages/core/test/document.test.ts
@@ -13,29 +13,6 @@ test('transform', async (t) => {
 	t.is(document.getRoot().listBuffers().length, 1, 'transform 2');
 });
 
-test('clone', (t) => {
-	const document1 = new Document();
-	document1.createMaterial('MyMaterial');
-	const rootNode = document1.createNode('A').addChild(document1.createNode('B').addChild(document1.createNode('C')));
-	document1.createScene('MyScene').addChild(rootNode);
-
-	const document2 = document1.clone();
-
-	t.is(document2.getRoot().listScenes()[0].getName(), 'MyScene', 'transfers scene');
-	t.is(document2.getRoot().listScenes()[0].listChildren().length, 1, 'transfers scene root node');
-	t.is(document2.getRoot().listNodes().length, 3, 'transfers nodes');
-	t.is(document2.getRoot().listNodes()[0].listChildren().length, 1, 'transfers node hierarchy (1/3)');
-	t.is(document2.getRoot().listNodes()[1].listChildren().length, 1, 'transfers node hierarchy (2/3)');
-	t.is(document2.getRoot().listNodes()[2].listChildren().length, 0, 'transfers node hierarchy (3/3)');
-	t.is(document2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'transfers material');
-	t.not(document2.getRoot().listScenes()[0], document1.getRoot().listScenes()[0], 'does not reference old scene');
-	t.not(
-		document2.getRoot().listMaterials()[0],
-		document1.getRoot().listMaterials()[0],
-		'does not reference old material',
-	);
-});
-
 test('defaults', (t) => {
 	// offering to the code coverage gods.
 	const document = new Document();

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 import { Document, Extension, ExtensionProperty, PropertyType, WriterContext } from '@gltf-transform/core';
+import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const EXTENSION_NAME = 'TEST_node_gizmo';
@@ -156,7 +157,7 @@ test('clone', (t) => {
 
 	let docClone: Document;
 	t.truthy(gizmo.clone(), 'clones gizmo');
-	t.truthy((docClone = document.clone()), 'clones document');
+	t.truthy((docClone = cloneDocument(document)), 'clones document');
 	t.truthy(docClone.getRoot().listNodes()[0].getExtension(EXTENSION_NAME), 'preserves gizmo');
 });
 

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 import { Document, MathUtils, mat4, vec3, vec4 } from '@gltf-transform/core';
+import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
 test('parent', (t) => {
@@ -153,7 +154,7 @@ test('getParentNode', (t) => {
 	t.is(srcNodeB.getParentNode(), srcNodeA, 'b.getParentNode()');
 	t.is(srcNodeC.getParentNode(), srcNodeA, 'c.getParentNode()');
 
-	const dstDocument = srcDocument.clone();
+	const dstDocument = cloneDocument(srcDocument);
 	const [dstNodeA, dstNodeB, dstNodeC] = dstDocument.getRoot().listNodes();
 
 	t.deepEqual(dstNodeA.listChildren(), [dstNodeB, dstNodeC], 'a.listChildren()');

--- a/packages/core/test/properties/root.test.ts
+++ b/packages/core/test/properties/root.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava';
 import { Document, JSONDocument } from '@gltf-transform/core';
+import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
 test('basic', (t) => {
@@ -26,7 +27,7 @@ test('basic', (t) => {
 	t.deepEqual(document.getRoot().listSkins(), [skin], 'listSkins()');
 	t.deepEqual(document.getRoot().listTextures(), [texture], 'listTextures()');
 
-	const root2 = document.clone().getRoot();
+	const root2 = cloneDocument(document).getRoot();
 	t.deepEqual(root2.listAccessors().length, 1, 'listAccessors()');
 	t.deepEqual(root2.listAnimations().length, 1, 'listAnimations()');
 	t.deepEqual(root2.listBuffers().length, 1, 'listBuffers()');
@@ -60,7 +61,7 @@ test('default scene', async (t) => {
 	root.setDefaultScene(sceneB);
 	t.is(root.getDefaultScene(), sceneB, 'default scene = B');
 
-	t.is(document.clone().getRoot().getDefaultScene().getName(), 'B', 'clone / copy persistence');
+	t.is(cloneDocument(document).getRoot().getDefaultScene().getName(), 'B', 'clone / copy persistence');
 
 	t.is(
 		(await io.readJSON(await io.writeJSON(document, {}))).getRoot().getDefaultScene().getName(),

--- a/packages/extensions/test/lights-punctual.test.ts
+++ b/packages/extensions/test/lights-punctual.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { Light, KHRLightsPunctual } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -69,7 +70,7 @@ test('copy', (t) => {
 		.setOuterConeAngle(0.75);
 	document.createNode().setExtension('KHR_lights_punctual', light);
 
-	const doc2 = document.clone();
+	const doc2 = cloneDocument(document);
 	const light2 = doc2.getRoot().listNodes()[0].getExtension<Light>('KHR_lights_punctual');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRLightsPunctual');
 	t.truthy(light2, 'copy light');

--- a/packages/extensions/test/materials-anisotropy.test.ts
+++ b/packages/extensions/test/materials-anisotropy.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { Anisotropy, KHRMaterialsAnisotropy } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -93,7 +94,7 @@ test('copy', (t) => {
 		.setAnisotropyTexture(document.createTexture('ABC'));
 	document.createMaterial().setExtension('KHR_materials_anisotropy', anisotropy);
 
-	const document2 = document.clone();
+	const document2 = cloneDocument(document);
 	const anisotropy2 = document2.getRoot().listMaterials()[0].getExtension<Anisotropy>('KHR_materials_anisotropy');
 	t.is(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsAnisotropy');
 	t.truthy(anisotropy2, 'copy Anisotropy');

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { Clearcoat, KHRMaterialsClearcoat } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -100,7 +101,7 @@ test('copy', (t) => {
 		.setClearcoatNormalTexture(doc.createTexture('ccnormal'));
 	doc.createMaterial().setExtension('KHR_materials_clearcoat', clearcoat);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const clearcoat2 = doc2.getRoot().listMaterials()[0].getExtension<Clearcoat>('KHR_materials_clearcoat');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsClearcoat');
 	t.truthy(clearcoat2, 'copy Clearcoat');

--- a/packages/extensions/test/materials-dispersion.test.ts
+++ b/packages/extensions/test/materials-dispersion.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { Dispersion, KHRMaterialsDispersion } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -42,7 +43,7 @@ test('copy', (t) => {
 	const dispersion = dispersionExtension.createDispersion().setDispersion(1.2);
 	document.createMaterial().setExtension('KHR_materials_dispersion', dispersion);
 
-	const document2 = document.clone();
+	const document2 = cloneDocument(document);
 	const dispersion2 = document2.getRoot().listMaterials()[0].getExtension<Dispersion>('KHR_materials_dispersion');
 	t.is(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsDispersion');
 	t.truthy(dispersion2, 'copy dispersion');

--- a/packages/extensions/test/materials-emissive-strength.test.ts
+++ b/packages/extensions/test/materials-emissive-strength.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { EmissiveStrength, KHRMaterialsEmissiveStrength } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -48,7 +49,7 @@ test('copy', (t) => {
 	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
 	doc.createMaterial().setExtension('KHR_materials_emissive_strength', emissiveStrength);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const emissiveStrength2 = doc2
 		.getRoot()
 		.listMaterials()[0]

--- a/packages/extensions/test/materials-ior.test.ts
+++ b/packages/extensions/test/materials-ior.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { IOR, KHRMaterialsIOR } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -38,7 +39,7 @@ test('copy', (t) => {
 	const ior = iorExtension.createIOR().setIOR(1.2);
 	doc.createMaterial().setExtension('KHR_materials_ior', ior);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const ior2 = doc2.getRoot().listMaterials()[0].getExtension<IOR>('KHR_materials_ior');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIOR');
 	t.truthy(ior2, 'copy IOR');

--- a/packages/extensions/test/materials-iridescence.test.ts
+++ b/packages/extensions/test/materials-iridescence.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsIridescence, Iridescence } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -72,7 +73,7 @@ test('copy', (t) => {
 		.setIridescenceThicknessTexture(doc.createTexture('iridescenceThickness'));
 	doc.createMaterial().setExtension('KHR_materials_iridescence', iridescence);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const iridescence2 = doc2.getRoot().listMaterials()[0].getExtension<Iridescence>('KHR_materials_iridescence');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIridescence');
 	t.truthy(iridescence2, 'copy Iridescence');

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsPBRSpecularGlossiness, PBRSpecularGlossiness } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -66,7 +67,7 @@ test('copy', (t) => {
 		.setSpecularGlossinessTexture(doc.createTexture('specGloss'));
 	doc.createMaterial().setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const specGloss2 = doc2
 		.getRoot()
 		.listMaterials()[0]

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsSheen, Sheen } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -57,7 +58,7 @@ test('copy', (t) => {
 		.setSheenColorTexture(doc.createTexture('sheen'));
 	doc.createMaterial().setExtension('KHR_materials_sheen', sheen);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const sheen2 = doc2.getRoot().listMaterials()[0].getExtension<Sheen>('KHR_materials_sheen');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSheen');
 	t.truthy(sheen2, 'copy Sheen');

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsSpecular, Specular } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -63,7 +64,7 @@ test('copy', (t) => {
 		.setSpecularColorTexture(doc.createTexture('specColor'));
 	doc.createMaterial().setExtension('KHR_materials_specular', specular);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const specular2 = doc2.getRoot().listMaterials()[0].getExtension<Specular>('KHR_materials_specular');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSpecular');
 	t.truthy(specular2, 'copy Specular');

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsTransmission, Transmission } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -56,7 +57,7 @@ test('copy', (t) => {
 		.setTransmissionTexture(doc.createTexture('trns'));
 	doc.createMaterial().setExtension('KHR_materials_transmission', transmission);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const transmission2 = doc2.getRoot().listMaterials()[0].getExtension<Transmission>('KHR_materials_transmission');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsTransmission');
 	t.truthy(transmission2, 'copy Transmission');

--- a/packages/extensions/test/materials-unlit.test.ts
+++ b/packages/extensions/test/materials-unlit.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -39,7 +40,7 @@ test('copy', (t) => {
 	const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
 	doc.createMaterial().setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsUnlit');
 	t.truthy(doc2.getRoot().listMaterials()[0].getExtension('KHR_materials_unlit'), 'copy Unlit');
 });

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsVolume, Volume } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -64,7 +65,7 @@ test('copy', (t) => {
 		.setAttenuationColor([1, 0, 0]);
 	doc.createMaterial().setExtension('KHR_materials_volume', volume);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const volume2 = doc2.getRoot().listMaterials()[0].getExtension<Volume>('KHR_materials_volume');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsVolume');
 	t.truthy(volume2, 'copy Volume');

--- a/packages/extensions/test/mesh-gpu-instancing.test.ts
+++ b/packages/extensions/test/mesh-gpu-instancing.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Accessor, Document, NodeIO } from '@gltf-transform/core';
 import { InstancedMesh, EXTMeshGPUInstancing } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -69,7 +70,7 @@ test('copy', (t) => {
 
 	doc.createNode().setExtension('EXT_mesh_gpu_instancing', batch);
 
-	const doc2 = doc.clone();
+	const doc2 = cloneDocument(doc);
 	const batch2 = doc2.getRoot().listNodes()[0].getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy EXTMeshGPUInstancing');
 	t.truthy(batch2, 'copy batch');

--- a/packages/extensions/test/mesh-quantization.test.ts
+++ b/packages/extensions/test/mesh-quantization.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, JSONDocument, NodeIO } from '@gltf-transform/core';
 import { KHRMeshQuantization } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
@@ -22,5 +23,5 @@ test('copy', (t) => {
 	const doc = new Document();
 	doc.createExtension(KHRMeshQuantization);
 
-	t.is(doc.clone().getRoot().listExtensionsUsed().length, 1, 'copy KHRMeshQuantization');
+	t.is(cloneDocument(doc).getRoot().listExtensionsUsed().length, 1, 'copy KHRMeshQuantization');
 });

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { Clearcoat, KHRMaterialsClearcoat, KHRTextureTransform, Transform } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
@@ -84,7 +85,7 @@ test('clone', (t) => {
 	srcMat.setOcclusionTexture(tex3);
 
 	// Clone the Document.
-	const dstDoc = srcDoc.clone();
+	const dstDoc = cloneDocument(srcDoc);
 
 	// Ensure source Document is unchanged.
 

--- a/packages/extensions/test/xmp.test.ts
+++ b/packages/extensions/test/xmp.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { Packet, KHRXMP } from '@gltf-transform/extensions';
+import { cloneDocument } from '@gltf-transform/functions';
 
 const MOCK_CONTEXT_URL = 'https://test.example/1.0/';
 
@@ -214,7 +215,7 @@ test('clone', async (t) => {
 	const packet1 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
 	document1.getRoot().setExtension('KHR_xmp_json_ld', packet1);
 	t.is(document1.getRoot().getExtension('KHR_xmp_json_ld'), packet1, 'sets packet');
-	const document2 = document1.clone();
+	const document2 = cloneDocument(document1);
 	const packet2 = document2.getRoot().getExtension('KHR_xmp_json_ld') as Packet;
 	t.truthy(packet2, 'clones packet');
 	t.deepEqual(packet1.toJSONLD(), packet2.toJSONLD(), 'equal packet');

--- a/packages/functions/src/document-utils.ts
+++ b/packages/functions/src/document-utils.ts
@@ -237,8 +237,6 @@ export function createDefaultPropertyResolver(target: Document, source: Document
 		if (!targetProp) {
 			if (sourceProp.propertyType === TEXTURE_INFO) {
 				// TextureInfo lifecycle is bound to a Material or ExtensionProperty.
-				// TODO(bug): TextureInfo in this mapping will be unhelpful to end-users! 🛑
-				// TODO(bug): How are TextureInfo extensions copied, moved, or merged? 🛑
 				targetProp = sourceProp;
 			} else {
 				// For other property types, create stub classes.

--- a/packages/functions/src/document-utils.ts
+++ b/packages/functions/src/document-utils.ts
@@ -1,0 +1,279 @@
+import { Document, Extension, Graph, Property, PropertyResolver, PropertyType } from '@gltf-transform/core';
+
+const { TEXTURE_INFO, ROOT } = PropertyType;
+type PropertyConstructor = new (g: Graph<Property>) => Property;
+
+const NO_TRANSFER_TYPES = new Set<string>([TEXTURE_INFO, ROOT]);
+
+/**
+ * Clones source {@link Document}, copying all properties and extensions within
+ * it. Source document remains unchanged, and the two may be modified
+ * independently after cloning.
+ *
+ * Example:
+ *
+ * ```javascript
+ *	import { cloneDocument } from '@gltf-transform/functions';
+ *
+ *	const targetDocument = cloneDocument(sourceDocument);
+ * ```
+ */
+export function cloneDocument(source: Document): Document {
+	const target = new Document().setLogger(source.getLogger());
+	const resolve = createDefaultPropertyResolver(target, source);
+	mergeDocuments(target, source, resolve);
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	target.getRoot().copy(source.getRoot(), resolve as any);
+	return target;
+}
+
+/**
+ * Merges contents of source {@link Document} into target Document, without
+ * modifying the source. Any extensions missing from the target document will
+ * be added. {@link Scene Scenes} and {@link Buffer Buffers} are not combined —
+ * the target Document may contain multiple scenes and buffers after this
+ * operation. These may be cleaned up manually (see {@link unpartition}),
+ * or document contents may be merged more granularly using
+ * {@link copyToDocument}.
+ *
+ * Example:
+ *
+ * ```javascript
+ *	import { mergeDocuments, unpartition } from '@gltf-transform/functions';
+ *
+ *	// Merge contents of sourceDocument into targetDocument.
+ *	mergeDocuments(targetDocument, sourceDocument);
+ *
+ *	// (Optional) Remove all but one Buffer from the target Document.
+ *	await targetDocument.transform(unpartition());
+ * ```
+ */
+export function mergeDocuments(
+	target: Document,
+	source: Document,
+	resolve?: PropertyResolver<Property>,
+): Map<Property, Property> {
+	resolve ||= createDefaultPropertyResolver(target, source);
+
+	for (const sourceExtension of source.getRoot().listExtensionsUsed()) {
+		const targetExtension = target.createExtension(sourceExtension.constructor as new (doc: Document) => Extension);
+		if (sourceExtension.isRequired()) targetExtension.setRequired(true);
+	}
+
+	return _copyToDocument(target, source, listProperties(source), resolve);
+}
+
+/**
+ * Moves the specified {@link Property Properties} from the source
+ * {@link Document} to the target Document, and removes them from the source
+ * Document. Dependencies of the source properties will be copied into the
+ * target Document, but not removed from the source Document. Returns a Map
+ * from source properties to their counterparts in the target Document.
+ * {@link Root} properties cannot be copied. {@link TextureInfo} properties
+ * cannot be given in the property list, but are handled automatically when
+ * copying a {@link Material}.
+ *
+ * Example:
+ *
+ * ```javascript
+ *	import { moveToDocument, prune } from '@gltf-transform/functions';
+ *
+ *	// Move all materials from sourceDocument to targetDocument.
+ *	const map = moveToDocument(targetDocument, sourceDocument, sourceDocument.listMaterials());
+ *
+ *	// Find the new counterpart of `sourceMaterial` in the target Document.
+ *	const targetMaterial = map.get(sourceMaterial);
+ *
+ *	// (Optional) Remove any resources (like Textures) that may now be unused
+ *	// in the source Document after their parent Materials have been moved.
+ *	await sourceDocument.transform(prune());
+ * ```
+ *
+ * Moving a {@link Mesh}, {@link Animation}, or another resource depending on
+ * a {@link Buffer} will create a copy of the source Buffer in the target
+ * Document. If the target Document should contain only one Buffer, call
+ * {@link unpartition} after moving properties.
+ *
+ * Repeated use of `moveToDocument` may create multiple copies of some
+ * resources, particularly shared dependencies like {@link Texture Textures} or
+ * {@link Accessor Accessors}. While duplicates can be cleaned up with
+ * {@link dedup}, it is also possible to prevent duplicates by creating and
+ * reusing the same resolver for all calls to `moveToDocument`:
+ *
+ * ```javascript
+ *	import { moveToDocument, createDefaultPropertyResolver } from '@gltf-transform/functions';
+ *
+ *	const resolve = createDefaultPropertyResolver(targetDocument, sourceDocument);
+ *
+ *	// Move materials individually, without creating duplicates of shared textures.
+ *	moveToDocument(targetDocument, sourceDocument, materialA, resolve);
+ *	moveToDocument(targetDocument, sourceDocument, materialB, resolve);
+ *	moveToDocument(targetDocument, sourceDocument, materialC, resolve);
+ * ```
+ *
+ * To copy properties without removing them from the source Document, see
+ * {@link copyToDocument}.
+ *
+ * @experimental
+ */
+export function moveToDocument(
+	target: Document,
+	source: Document,
+	sourceProperties: Property[],
+	resolve?: PropertyResolver<Property>,
+): Map<Property, Property> {
+	const targetProperties = copyToDocument(target, source, sourceProperties, resolve);
+
+	for (const property of sourceProperties) {
+		property.dispose();
+	}
+
+	return targetProperties;
+}
+
+/**
+ * Copies the specified {@link Property Properties} from the source
+ * {@link Document} to the target Document, leaving originals in the source
+ * Document. Dependencies of the source properties will also be copied into the
+ * target Document. Returns a Map from source properties to their counterparts
+ * in the target Document. {@link Root} properties cannot be copied.
+ * {@link TextureInfo} properties cannot be given in the property list, but are
+ * handled automatically when copying a {@link Material}.
+ *
+ * Example:
+ *
+ * ```javascript
+ *	import { copyToDocument } from '@gltf-transform/functions';
+ *
+ *	// Copy all materials from sourceDocument to targetDocument.
+ *	const map = copyToDocument(targetDocument, sourceDocument, sourceDocument.listMaterials());
+ *
+ *	// Find the new counterpart of `sourceMaterial` in the target Document.
+ *	const targetMaterial = map.get(sourceMaterial);
+ * ```
+ *
+ * Copying a {@link Mesh}, {@link Animation}, or another resource depending on
+ * a {@link Buffer} will create a copy of the source Buffer in the target
+ * Document. If the target Document should contain only one Buffer, call
+ * {@link unpartition} after copying properties.
+ *
+ * Repeated use of `copyToDocument` may create multiple copies of some
+ * resources, particularly shared dependencies like {@link Texture Textures} or
+ * {@link Accessor Accessors}. While duplicates can be cleaned up with
+ * {@link dedup}, it is also possible to prevent duplicates by creating and
+ * reusing the same resolver for all calls to `copyToDocument`:
+ *
+ * ```javascript
+ *	import { copyToDocument, createDefaultPropertyResolver } from '@gltf-transform/functions';
+ *
+ *	const resolve = createDefaultPropertyResolver(targetDocument, sourceDocument);
+ *
+ *	// Copy materials individually, without creating duplicates of shared textures.
+ *	copyToDocument(targetDocument, sourceDocument, materialA, resolve);
+ *	copyToDocument(targetDocument, sourceDocument, materialB, resolve);
+ *	copyToDocument(targetDocument, sourceDocument, materialC, resolve);
+ * ```
+ *
+ * To move properties to the target Document without leaving copies behind in
+ * the source Document, use {@link moveToDocument} or dispose the properties
+ * after copying.
+ *
+ * @experimental
+ */
+export function copyToDocument(
+	target: Document,
+	source: Document,
+	sourceProperties: Property[],
+	resolve?: PropertyResolver<Property>,
+): Map<Property, Property> {
+	const sourcePropertyDependencies = new Set<Property>();
+	for (const property of sourceProperties) {
+		if (NO_TRANSFER_TYPES.has(property.propertyType)) {
+			throw new Error(`Type "${property.propertyType}" cannot be transferred.`);
+		}
+
+		listPropertyDependencies(property, sourcePropertyDependencies);
+	}
+	return _copyToDocument(target, source, Array.from(sourcePropertyDependencies), resolve);
+}
+
+/** @internal */
+function _copyToDocument(
+	target: Document,
+	source: Document,
+	sourceProperties: Property[],
+	resolve?: PropertyResolver<Property>,
+): Map<Property, Property> {
+	resolve ||= createDefaultPropertyResolver(target, source);
+
+	// Create stub classes for every Property in other Document.
+	const propertyMap = new Map<Property, Property>([[source.getRoot(), target.getRoot()]]);
+	for (const sourceProp of sourceProperties) {
+		if (!propertyMap.has(sourceProp)) {
+			propertyMap.set(sourceProp, resolve(sourceProp));
+		}
+	}
+
+	// Assemble relationships between Properties.
+	for (const [otherProp, targetProp] of propertyMap.entries()) {
+		// TextureInfo copy handled by Material or ExtensionProperty. Remaining Root properties
+		// (name, asset, default scene, extras) are not overwritten in a merge.
+		if (targetProp.propertyType !== TEXTURE_INFO && targetProp.propertyType !== ROOT) {
+			targetProp.copy(otherProp, resolve);
+		}
+	}
+
+	return propertyMap;
+}
+
+/**
+ *
+ */
+export function createDefaultPropertyResolver(target: Document, source: Document): PropertyResolver<Property> {
+	const propertyMap = new Map<Property, Property>([[source.getRoot(), target.getRoot()]]);
+
+	return (sourceProp: Property): Property => {
+		let targetProp = propertyMap.get(sourceProp);
+		if (!targetProp) {
+			if (sourceProp.propertyType === TEXTURE_INFO) {
+				// TextureInfo lifecycle is bound to a Material or ExtensionProperty.
+				// TODO(bug): TextureInfo in this mapping will be unhelpful to end-users! 🛑
+				// TODO(bug): How are TextureInfo extensions copied, moved, or merged? 🛑
+				targetProp = sourceProp;
+			} else {
+				// For other property types, create stub classes.
+				const PropertyClass = sourceProp.constructor as PropertyConstructor;
+				targetProp = new PropertyClass(target.getGraph());
+			}
+			propertyMap.set(sourceProp, targetProp);
+		}
+		return targetProp;
+	};
+}
+
+/** @internal */
+function listPropertyDependencies(parent: Property, visited: Set<Property>): Set<Property> {
+	const graph = parent.getGraph();
+	const queue: Property[] = [parent];
+
+	let next: Property | undefined = undefined;
+	while ((next = queue.pop())) {
+		visited.add(next);
+		for (const child of graph.listChildren(next)) {
+			if (!visited.has(child)) {
+				queue.push(child);
+			}
+		}
+	}
+
+	return visited;
+}
+
+/** @internal */
+function listProperties(document: Document): Property[] {
+	const visited = new Set<Property>();
+	for (const edge of document.getGraph().listEdges()) {
+		visited.add(edge.getChild());
+	}
+	return Array.from(visited);
+}

--- a/packages/functions/src/document-utils.ts
+++ b/packages/functions/src/document-utils.ts
@@ -116,6 +116,17 @@ export function mergeDocuments(
  *	moveToDocument(targetDocument, sourceDocument, materialC, resolve);
  * ```
  *
+ * If the transferred properties include {@link ExtensionProperty ExtensionProperties},
+ * the associated {@link Extension Extensions} must be added to the target
+ * Document first:
+ *
+ * ```javascript
+ *	for (const sourceExtension of source.getRoot().listExtensionsUsed()) {
+ *		const targetExtension = target.createExtension(sourceExtension.constructor);
+ *		if (sourceExtension.isRequired()) targetExtension.setRequired(true);
+ *	}
+ * ```
+ *
  * To copy properties without removing them from the source Document, see
  * {@link copyToDocument}.
  *
@@ -177,6 +188,17 @@ export function moveToDocument(
  *	copyToDocument(targetDocument, sourceDocument, materialA, resolve);
  *	copyToDocument(targetDocument, sourceDocument, materialB, resolve);
  *	copyToDocument(targetDocument, sourceDocument, materialC, resolve);
+ * ```
+ *
+ * If the transferred properties include {@link ExtensionProperty ExtensionProperties},
+ * the associated {@link Extension Extensions} must be added to the target
+ * Document first:
+ *
+ * ```javascript
+ *	for (const sourceExtension of source.getRoot().listExtensionsUsed()) {
+ *		const targetExtension = target.createExtension(sourceExtension.constructor);
+ *		if (sourceExtension.isRequired()) targetExtension.setRequired(true);
+ *	}
  * ```
  *
  * To move properties to the target Document without leaving copies behind in

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -4,6 +4,13 @@ export * from './clear-node-transform.js';
 export * from './convert-primitive-mode.js';
 export * from './dedup.js';
 export { dequantize, dequantizePrimitive, DequantizeOptions } from './dequantize.js';
+export {
+	cloneDocument,
+	mergeDocuments,
+	copyToDocument,
+	moveToDocument,
+	createDefaultPropertyResolver,
+} from './document-utils.js';
 export * from './draco.js';
 export * from './flatten.js';
 export * from './get-bounds.js';

--- a/packages/functions/test/document-utils.test.ts
+++ b/packages/functions/test/document-utils.test.ts
@@ -1,0 +1,172 @@
+import test from 'ava';
+import { Document, Property } from '@gltf-transform/core';
+import { KHRMaterialsUnlit, KHRTextureTransform, Transform, Unlit } from '@gltf-transform/extensions';
+import { cloneDocument, copyToDocument, mergeDocuments, moveToDocument, prune } from '@gltf-transform/functions';
+import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
+
+test('cloneDocument', (t) => {
+	const document1 = new Document().setLogger(logger);
+	document1.createMaterial('MyMaterial');
+	const rootNode = document1.createNode('A').addChild(document1.createNode('B').addChild(document1.createNode('C')));
+	document1.createScene('MyScene').addChild(rootNode);
+
+	const document2 = cloneDocument(document1);
+
+	t.is(document2.getRoot().listScenes()[0].getName(), 'MyScene', 'transfers scene');
+	t.is(document2.getRoot().listScenes()[0].listChildren().length, 1, 'transfers scene root node');
+	t.is(document2.getRoot().listNodes().length, 3, 'transfers nodes');
+	t.is(document2.getRoot().listNodes()[0].listChildren().length, 1, 'transfers node hierarchy (1/3)');
+	t.is(document2.getRoot().listNodes()[1].listChildren().length, 1, 'transfers node hierarchy (2/3)');
+	t.is(document2.getRoot().listNodes()[2].listChildren().length, 0, 'transfers node hierarchy (3/3)');
+	t.is(document2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'transfers material');
+	t.not(document2.getRoot().listScenes()[0], document1.getRoot().listScenes()[0], 'does not reference old scene');
+	t.not(
+		document2.getRoot().listMaterials()[0],
+		document1.getRoot().listMaterials()[0],
+		'does not reference old material',
+	);
+});
+
+test('mergeDocuments - scenes', (t) => {
+	const targetDocument = new Document().setLogger(logger);
+	targetDocument.createScene('SceneA');
+	const sourceDocument = new Document().setLogger(logger);
+	sourceDocument.createScene('SceneB');
+
+	mergeDocuments(targetDocument, sourceDocument);
+
+	const toName = (prop: Property) => prop.getName();
+	t.deepEqual(targetDocument.getRoot().listScenes().map(toName), ['SceneA', 'SceneB'], 'target.scenes');
+	t.deepEqual(sourceDocument.getRoot().listScenes().map(toName), ['SceneB'], 'source.scenes');
+});
+
+test('mergeDocuments - generator', (t) => {
+	const targetDocument = new Document().setLogger(logger);
+	targetDocument.getRoot().getAsset().generator = 'GeneratorA';
+	const sourceDocument = new Document().setLogger(logger);
+	sourceDocument.getRoot().getAsset().generator = 'GeneratorB';
+
+	mergeDocuments(targetDocument, sourceDocument);
+
+	t.is(targetDocument.getRoot().getAsset().generator, 'GeneratorA', 'target.asset.generator');
+	t.is(sourceDocument.getRoot().getAsset().generator, 'GeneratorB', 'source.asset.generator');
+});
+
+test('copyToDocument - basic', async (t) => {
+	const srcDocument = new Document().setLogger(logger);
+	const dstDocument = new Document().setLogger(logger);
+
+	const srcPrim = createTorusKnotPrimitive(srcDocument, { tubularSegments: 6 });
+	const srcPosition = srcPrim.getAttribute('POSITION');
+	const srcMesh = srcDocument.createMesh('TorusMesh').addPrimitive(srcPrim);
+	const srcNode = srcDocument.createNode('TorusNode').setMesh(srcMesh);
+	const srcScene = srcDocument.createScene().addChild(srcNode);
+
+	const map = copyToDocument(dstDocument, srcDocument, [srcMesh]);
+	await srcDocument.transform(prune({ keepLeaves: true }));
+
+	t.false(srcPosition.isDisposed(), 'srcPosition ok');
+	t.false(srcPrim.isDisposed(), 'srcPrim ok');
+	t.false(srcMesh.isDisposed(), 'srcMesh ok');
+	t.false(srcNode.isDisposed(), 'srcNode ok');
+	t.false(srcScene.isDisposed(), 'srcScene ok');
+
+	const dstMesh = dstDocument.getRoot().listMeshes()[0];
+	const dstPrim = dstMesh.listPrimitives()[0];
+	const dstPosition = dstPrim.getAttribute('POSITION');
+
+	t.is(dstMesh.getName(), 'TorusMesh', 'dstMesh.name');
+	t.is(map.get(srcMesh), dstMesh, 'mesh <-> mesh');
+	t.is(map.get(srcPrim), dstPrim, 'prim <-> prim');
+	t.is(map.get(srcPosition), dstPosition, 'position <-> position');
+	t.is(map.has(srcNode), false, 'node <-> null');
+	t.is(map.has(srcScene), false, 'scene <-> null');
+});
+
+test('copyToDocument - unsupported', async (t) => {
+	const srcDocument = new Document().setLogger(logger);
+	const dstDocument = new Document().setLogger(logger);
+
+	const srcRoot = srcDocument.getRoot();
+	const srcTexture = srcDocument.createTexture();
+	const srcTextureInfo = srcDocument.createMaterial().setBaseColorTexture(srcTexture).getBaseColorTextureInfo()!;
+
+	t.throws(() => void copyToDocument(dstDocument, srcDocument, [srcRoot]));
+	t.throws(() => void copyToDocument(dstDocument, srcDocument, [srcTextureInfo]));
+});
+
+test('copyToDocument - material', async (t) => {
+	const srcDocument = new Document().setLogger(logger);
+	const dstDocument = new Document().setLogger(logger);
+
+	const unlitExtension = srcDocument.createExtension(KHRMaterialsUnlit);
+	const unlit = unlitExtension.createUnlit();
+
+	const transformExtension = srcDocument.createExtension(KHRTextureTransform);
+	const transform = transformExtension.createTransform().setScale([2, 2]);
+
+	dstDocument.createExtension(KHRMaterialsUnlit);
+	dstDocument.createExtension(KHRTextureTransform);
+
+	const srcTexture = srcDocument.createTexture();
+	const srcMaterial = srcDocument
+		.createMaterial()
+		.setBaseColorFactor([0.5, 0, 0, 1])
+		.setBaseColorTexture(srcTexture)
+		.setExtension('KHR_materials_unlit', unlit);
+	srcMaterial.getBaseColorTextureInfo()!.setExtension('KHR_texture_transform', transform);
+
+	copyToDocument(dstDocument, srcDocument, [srcMaterial]);
+
+	const dstMaterial = dstDocument.getRoot().listMaterials()[0];
+	const dstTextureInfo = dstMaterial.getBaseColorTextureInfo();
+	const dstTransform = dstTextureInfo.getExtension<Transform>('KHR_texture_transform');
+
+	t.deepEqual(dstMaterial.getBaseColorFactor(), [0.5, 0, 0, 1], 'baseColorFactor');
+	t.true(dstMaterial.getExtension('KHR_materials_unlit') instanceof Unlit, 'unlit');
+	t.true(dstTransform instanceof Transform, 'transform');
+	t.deepEqual(dstTransform.getScale(), [2, 2], 'transform.scale');
+});
+
+test('moveToDocument - basic', async (t) => {
+	const srcDocument = new Document().setLogger(logger);
+	const dstDocument = new Document().setLogger(logger);
+
+	const srcPrim = createTorusKnotPrimitive(srcDocument, { tubularSegments: 6 });
+	const srcPosition = srcPrim.getAttribute('POSITION');
+	const srcMesh = srcDocument.createMesh('TorusMesh').addPrimitive(srcPrim);
+	const srcNode = srcDocument.createNode('TorusNode').setMesh(srcMesh);
+	const srcScene = srcDocument.createScene().addChild(srcNode);
+
+	const map = moveToDocument(dstDocument, srcDocument, [srcMesh]);
+	await srcDocument.transform(prune({ keepLeaves: true }));
+
+	t.true(srcPosition.isDisposed(), 'srcPosition disposed');
+	t.true(srcPrim.isDisposed(), 'srcPrim disposed');
+	t.true(srcMesh.isDisposed(), 'srcMesh disposed');
+	t.false(srcNode.isDisposed(), 'srcNode ok');
+	t.false(srcScene.isDisposed(), 'srcScene ok');
+
+	const dstMesh = dstDocument.getRoot().listMeshes()[0];
+	const dstPrim = dstMesh.listPrimitives()[0];
+	const dstPosition = dstPrim.getAttribute('POSITION');
+
+	t.is(dstMesh.getName(), 'TorusMesh', 'dstMesh.name');
+	t.is(map.get(srcMesh), dstMesh, 'mesh <-> mesh');
+	t.is(map.get(srcPrim), dstPrim, 'prim <-> prim');
+	t.is(map.get(srcPosition), dstPosition, 'position <-> position');
+	t.is(map.has(srcNode), false, 'node <-> null');
+	t.is(map.has(srcScene), false, 'scene <-> null');
+});
+
+test('moveToDocument - unsupported', async (t) => {
+	const srcDocument = new Document().setLogger(logger);
+	const dstDocument = new Document().setLogger(logger);
+
+	const srcRoot = srcDocument.getRoot();
+	const srcTexture = srcDocument.createTexture();
+	const srcTextureInfo = srcDocument.createMaterial().setBaseColorTexture(srcTexture).getBaseColorTextureInfo()!;
+
+	t.throws(() => void moveToDocument(dstDocument, srcDocument, [srcRoot]));
+	t.throws(() => void moveToDocument(dstDocument, srcDocument, [srcTextureInfo]));
+});


### PR DESCRIPTION
Changes:

- BREAKING CHANGE: Removes `Document#merge` and `Document#clone` methods
- Adds `mergeDocuments(target, source)`
- Adds `cloneDocument(source)`
- Adds `copyToDocument(target, source, sourceProperties)`
- Adds `moveToDocument(target, source, sourceProperties)`

Example:

```javascript
import { copyToDocument } from '@gltf-transform/functions';

// Copy materials from sourceDocument to targetDocument.
const map = copyToDocument(
  targetDocument,
  sourceDocument,
  [sourceMaterialA, sourceMaterialB]
);

// Find counterpart of sourceMaterialA in targetDocument.
const targetMaterialA = map.get(sourceMaterialA);
```

Related:

- Fixes #924 
- Fixes #1363 
- Fixes #1367 