### PR TITLE
fix(cli): Fix KTX texture resizing in 'optimize', 'etc1s', and 'uastc' commands

### DIFF
--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -36,7 +36,7 @@ export * from './transform-mesh.js';
 export * from './transform-primitive.js';
 export * from './unlit.js';
 export * from './unpartition.js';
-export { getGLPrimitiveCount, isTransformPending, createTransform } from './utils.js';
+export { getGLPrimitiveCount, isTransformPending, createTransform, fitWithin, fitPowerOfTwo } from './utils.js';
 export * from './unweld.js';
 export * from './vertex-color-space.js';
 export * from './weld.js';


### PR DESCRIPTION
Changes:

- BREAKING CHANGE: Adds required 'encoder' in toktx()
- BREAKING CHANGE: Removes 'powerOfTwo' from toktx()
- Fixes texture resizing in 'optimize', 'etc1s', and 'uastc' CLI commands, under the new KTX Software v4.3.0 release

Relatetd:

- Fixes https://github.com/donmccurdy/glTF-Transform/issues/1307
- Fixes https://github.com/donmccurdy/glTF-Transform/issues/1348