### PR TITLE
fix(functions): Group meshopt-compressed accessors by parent

### DIFF
--- a/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
+++ b/packages/extensions/src/ext-meshopt-compression/meshopt-compression.ts
@@ -5,6 +5,7 @@ import {
 	Extension,
 	GLB_BUFFER,
 	GLTF,
+	Property,
 	PropertyType,
 	ReaderContext,
 	WriterContext,
@@ -278,9 +279,22 @@ export class EXTMeshoptCompression extends Extension {
 		const json = context.jsonDoc.json;
 		const encoder = this._encoder!;
 		const options = this._encoderOptions;
+		const graph = this.document.getGraph();
 
 		const fallbackBuffer = this.document.createBuffer(); // Disposed on write.
 		const fallbackBufferIndex = this.document.getRoot().listBuffers().indexOf(fallbackBuffer);
+
+		let nextID = 1;
+		const parentToID = new Map<Property, number>();
+		const getParentID = (property: Property): number => {
+			for (const parent of graph.listParents(property)) {
+				if (parent.propertyType === PropertyType.ROOT) continue;
+				let id = parentToID.get(property);
+				if (id === undefined) parentToID.set(property, (id = nextID++));
+				return id;
+			}
+			return -1;
+		};
 
 		this._encoderFallbackBuffer = fallbackBuffer;
 		this._encoderBufferViews = {};
@@ -296,6 +310,7 @@ export class EXTMeshoptCompression extends Extension {
 			if (accessor.getSparse()) continue;
 
 			const usage = context.getAccessorUsage(accessor);
+			const parentID = context.accessorUsageGroupedByParent.has(usage) ? getParentID(accessor) : null;
 			const mode = getMeshoptMode(accessor, usage);
 			const filter =
 				options.method === EncoderMethod.FILTER
@@ -309,7 +324,7 @@ export class EXTMeshoptCompression extends Extension {
 			const bufferIndex = this.document.getRoot().listBuffers().indexOf(buffer);
 
 			// Buffer view grouping key.
-			const key = [usage, mode, filter.filter, byteStride, bufferIndex].join(':');
+			const key = [usage, parentID, mode, filter.filter, byteStride, bufferIndex].join(':');
 
 			let bufferView = this._encoderBufferViews[key];
 			let bufferViewData = this._encoderBufferViewData[key];

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -1,6 +1,6 @@
 import path, { dirname } from 'path';
 import test from 'ava';
-import { Document, NodeIO, getBounds, Format, Primitive } from '@gltf-transform/core';
+import { Document, NodeIO, getBounds, Format, Primitive, VertexLayout } from '@gltf-transform/core';
 import { EXTMeshoptCompression, KHRMeshQuantization } from '@gltf-transform/extensions';
 import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
 import { fileURLToPath } from 'url';
@@ -103,6 +103,99 @@ test('encoding sparse', async (t) => {
 	t.is(rtMarker.getSparse(), true, '_SPARSE sparse (round trip)');
 	t.deepEqual(Array.from(rtPosition.getArray()), positionArray, 'POSITION array');
 	t.deepEqual(Array.from(rtMarker.getArray()), sparseArray, '_SPARSE array');
+});
+
+test('encoding grouped buffer views', async (t) => {
+	const io = await createEncoderIO();
+
+	const document = new Document();
+	const buffer = document.createBuffer();
+	const positionA = document.createAccessor().setType('VEC3').setArray(new Uint16Array(12)).setBuffer(buffer);
+	const positionB = document.createAccessor().setType('VEC3').setArray(new Uint16Array(12)).setBuffer(buffer);
+	const primA = document.createPrimitive().setAttribute('POSITION', positionA);
+	const primB = document.createPrimitive().setAttribute('POSITION', positionB);
+	const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
+	const node = document.createNode().setMesh(mesh);
+	const scene = document.createScene().addChild(node);
+	document.getRoot().setDefaultScene(scene);
+	document.createExtension(EXTMeshoptCompression).setRequired(true);
+
+	const { json } = await io.writeJSON(document);
+
+	t.deepEqual(
+		json.meshes,
+		[
+			{
+				primitives: [
+					{ attributes: { POSITION: 0 }, mode: 4 },
+					{ attributes: { POSITION: 1 }, mode: 4 },
+				],
+			},
+		],
+		'primitives',
+	);
+
+	t.deepEqual(
+		json.buffers,
+		[
+			{
+				uri: 'buffer.bin',
+				byteLength: 88,
+			},
+			{
+				byteLength: 64,
+				extensions: {
+					EXT_meshopt_compression: {
+						fallback: true,
+					},
+				},
+			},
+		],
+		'buffers',
+	);
+
+	t.deepEqual(
+		json.bufferViews,
+		[
+			{
+				buffer: 1,
+				byteLength: 32,
+				byteOffset: 0,
+				byteStride: 8,
+				extensions: {
+					EXT_meshopt_compression: {
+						buffer: 0,
+						byteLength: 41,
+						byteOffset: 0,
+						byteStride: 8,
+						count: 4,
+						filter: undefined,
+						mode: 'ATTRIBUTES',
+					},
+				},
+				target: 34962,
+			},
+			{
+				buffer: 1,
+				byteLength: 32,
+				byteOffset: 32,
+				byteStride: 8,
+				extensions: {
+					EXT_meshopt_compression: {
+						buffer: 0,
+						byteLength: 41,
+						byteOffset: 44,
+						byteStride: 8,
+						count: 4,
+						filter: undefined,
+						mode: 'ATTRIBUTES',
+					},
+				},
+				target: 34962,
+			},
+		],
+		'buffer views',
+	);
 });
 
 async function createEncoderIO(): Promise<NodeIO> {

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -1,6 +1,6 @@
 import path, { dirname } from 'path';
 import test from 'ava';
-import { Document, NodeIO, getBounds, Format, Primitive, VertexLayout } from '@gltf-transform/core';
+import { Document, NodeIO, getBounds, Format, Primitive } from '@gltf-transform/core';
 import { EXTMeshoptCompression, KHRMeshQuantization } from '@gltf-transform/extensions';
 import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
By default, glTF Transform groups accessors into buffer views by their parent mesh primitives. Currently the Meshopt encoding implementation does not do that grouping, and for consistency it should. If there's a compelling reason to allow buffer views to be unified rather than grouped, that can potentially be added as a new option on the I/O class that isn't specific to Meshopt.

- Fixes #1362