### PR TITLE
fix(functions): Avoid failure when Draco generates new accessors

### DIFF
--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -34,6 +34,7 @@ export interface WriterOptions {
  */
 export class GLTFWriter {
 	public static write(doc: Document, options: Required<WriterOptions>): JSONDocument {
+		const graph = doc.getGraph();
 		const root = doc.getRoot();
 		const json = {
 			asset: { generator: `glTF-Transform ${VERSION}`, ...root.getAsset() },
@@ -357,23 +358,6 @@ export class GLTFWriter {
 			return { buffers, byteLength };
 		}
 
-		/* Data use pre-processing. */
-
-		const accessorRefs = new Map<Accessor, GraphEdge<Property, Accessor>[]>();
-
-		// Gather all accessors, creating a map to look up their uses.
-		for (const ref of doc.getGraph().listEdges()) {
-			if (ref.getParent() === root) continue;
-
-			const child = ref.getChild();
-
-			if (child instanceof Accessor) {
-				const uses = accessorRefs.get(child) || [];
-				uses.push(ref as GraphEdge<Property, Accessor>);
-				accessorRefs.set(child, uses);
-			}
-		}
-
 		json.accessors = [];
 		json.bufferViews = [];
 
@@ -420,14 +404,14 @@ export class GLTFWriter {
 			if (context.accessorIndexMap.has(accessor)) return;
 
 			// Assign usage for core accessor usage types (explicit targets and implicit usage).
-			const accessorEdges = accessorRefs.get(accessor) || [];
 			const usage = context.getAccessorUsage(accessor);
 			context.addAccessorToUsageGroup(accessor, usage);
 
 			// For accessor usage that requires grouping by parent (vertex and instance
 			// attributes) organize buffer views accordingly.
 			if (groupByParent.has(usage)) {
-				accessorParents.set(accessor, accessorEdges[0].getParent());
+				const parent = graph.listParents(accessor).find((parent) => parent.propertyType !== PropertyType.ROOT)!;
+				accessorParents.set(accessor, parent);
 			}
 		});
 

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -9,9 +9,8 @@ import {
 } from '../constants.js';
 import type { Document } from '../document.js';
 import type { Extension } from '../extension.js';
-import type { GraphEdge } from 'property-graph';
 import type { JSONDocument } from '../json-document.js';
-import { Accessor, AnimationSampler, Camera, Material, Property } from '../properties/index.js';
+import { Accessor, AnimationSampler, Camera, Material } from '../properties/index.js';
 import type { GLTF } from '../types/gltf.js';
 import { BufferUtils, Logger, MathUtils } from '../utils/index.js';
 import { WriterContext } from './writer-context.js';


### PR DESCRIPTION
Draco compression will, in rare cases, require generating new accessors. That's not ideal — I'd much prefer that the I/O process not modify the input Document at all — but it is a current limitation in the encoding process.

Previously some other code in the general I/O pipeline assumed that the accessor list was known in advance, and caused failures when the accessor count changed later. This PR removes the assumption.

https://github.com/donmccurdy/glTF-Transform/blob/de19547de2659c605bba28531b26b7aa87d832bc/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts#L397-L413

Related:

- Fixes https://github.com/donmccurdy/glTF-Transform/issues/1342

Remaining:

- [ ] ~~possible to write a unit test for this?~~ too difficult to reproduce, tracking instead at https://github.com/donmccurdy/glTF-Transform/issues/1386