### PR TITLE
feat(core,cli): Rename --allow-http to --allow-net

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1719,11 +1719,11 @@ file sizes.
 		Session.create(io, logger, args.input, args.output).transform(sparse(options as unknown as SparseOptions)),
 	);
 
-program.option('--allow-http', 'Allows reads from HTTP requests.', {
+program.option('--allow-net', 'Allows reads from network requests.', {
 	default: false,
 	validator: Validator.BOOLEAN,
 	action: ({ options }) => {
-		if (options.allowHttp) io.setAllowHTTP(true);
+		if (options.allowNet) io.setAllowNetwork(true);
 	},
 });
 program.option('--vertex-layout <layout>', 'Vertex buffer layout preset.', {

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -28,15 +28,15 @@ import { HTTPUtils } from '../utils/index.js';
  * const glb = await io.writeBinary(document); // Document → Uint8Array
  * ```
  *
- * By default, NodeIO can only read/write paths on disk. To enable HTTP requests, provide a Fetch
+ * By default, NodeIO can only read/write paths on disk. To enable network requests, provide a Fetch
  * API implementation (such as [`node-fetch`](https://www.npmjs.com/package/node-fetch)) and enable
- * {@link NodeIO.setAllowHTTP setAllowHTTP}. HTTP requests may optionally be configured with
+ * {@link NodeIO.setAllowNetwork setAllowNetwork}. Network requests may optionally be configured with
  * [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters) parameters.
  *
  * ```typescript
  * import fetch from 'node-fetch';
  *
- * const io = new NodeIO(fetch, {headers: {...}}).setAllowHTTP(true);
+ * const io = new NodeIO(fetch, {headers: {...}}).setAllowNetwork(true);
  *
  * const document = await io.read('https://example.com/path/to/model.glb');
  * ```
@@ -55,7 +55,7 @@ export class NodeIO extends PlatformIO {
 	/**
 	 * Constructs a new NodeIO service. Instances are reusable. By default, only NodeIO can only
 	 * read/write paths on disk. To enable HTTP requests, provide a Fetch API implementation and
-	 * enable {@link NodeIO.setAllowHTTP setAllowHTTP}.
+	 * enable {@link NodeIO.setAllowNetwork setAllowNetwork}.
 	 *
 	 * @param fetch Implementation of Fetch API.
 	 * @param fetchConfig Configuration object for Fetch API.
@@ -75,7 +75,7 @@ export class NodeIO extends PlatformIO {
 		});
 	}
 
-	public setAllowHTTP(allow: boolean): this {
+	public setAllowNetwork(allow: boolean): this {
 		if (allow && !this._fetch) {
 			throw new Error('NodeIO requires a Fetch API implementation for HTTP requests.');
 		}

--- a/packages/core/test/io/node-io.test.ts
+++ b/packages/core/test/io/node-io.test.ts
@@ -52,7 +52,7 @@ test('read gltf', async (t) => {
 
 test('read glb http', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
-	const io = new NodeIO(fetch).setLogger(logger).setAllowHTTP(true);
+	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
 	let count = 0;
 	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.glb'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
@@ -66,7 +66,7 @@ test('read glb http', async (t) => {
 
 test('read gltf http', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
-	const io = new NodeIO(fetch).setLogger(logger).setAllowHTTP(true);
+	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
 	let count = 0;
 	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.gltf'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);


### PR DESCRIPTION
Matches Deno, and avoids any confusion that this is related to HTTP vs. HTTPS.