### PR TITLE
chore(functions): Rename vertex count method 'GPU' to 'UPLOAD'

### DIFF
--- a/packages/functions/src/get-vertex-count.ts
+++ b/packages/functions/src/get-vertex-count.ts
@@ -40,7 +40,7 @@ export enum VertexCountMethod {
 	 * attributes are pre-processed to a known buffer layout, and the client is
 	 * optimized for that buffer layout, this total will be optimistic.
 	 */
-	GPU = 'gpu',
+	UPLOAD = 'upload',
 
 	/**
 	 * Expected number of vertices uploaded to the GPU, assuming that a client
@@ -48,7 +48,7 @@ export enum VertexCountMethod {
 	 * attribute {@link Accessor Accessors} shared by multiple primitives, but
 	 * never uploading the same mesh or primitive to GPU memory more than once.
 	 */
-	GPU_NAIVE = 'gpu-naive',
+	UPLOAD_NAIVE = 'upload-naive',
 
 	/**
 	 * Total number of unique vertices represented, considering all attributes of
@@ -57,6 +57,7 @@ export enum VertexCountMethod {
 	 * optimization opportunities.
 	 *
 	 * @hidden TODO(feat): Not yet implemented.
+	 * @internal
 	 */
 	DISTINCT = 'distinct',
 
@@ -67,6 +68,7 @@ export enum VertexCountMethod {
 	 * optimization opportunities.
 	 *
 	 * @hidden TODO(feat): Not yet implemented.
+	 * @internal
 	 */
 	DISTINCT_POSITION = 'distinct-position',
 
@@ -127,9 +129,9 @@ function _getSubtreeVertexCount(node: Node | Scene, method: VertexCountMethod): 
 				_sum(nonInstancedMeshes.map((mesh) => getMeshVertexCount(mesh, method))) +
 				_sum(instancedMeshes.map(([batch, mesh]) => batch * getMeshVertexCount(mesh, method)))
 			);
-		case VertexCountMethod.GPU_NAIVE:
+		case VertexCountMethod.UPLOAD_NAIVE:
 			return _sum(uniqueMeshes.map((mesh) => getMeshVertexCount(mesh, method)));
-		case VertexCountMethod.GPU:
+		case VertexCountMethod.UPLOAD:
 			return _sum(uniquePositions.map((attribute) => attribute.getCount()));
 		case VertexCountMethod.DISTINCT:
 		case VertexCountMethod.DISTINCT_POSITION:
@@ -155,9 +157,9 @@ export function getMeshVertexCount(mesh: Mesh, method: VertexCountMethod): numbe
 	switch (method) {
 		case VertexCountMethod.RENDER:
 		case VertexCountMethod.RENDER_CACHED:
-		case VertexCountMethod.GPU_NAIVE:
+		case VertexCountMethod.UPLOAD_NAIVE:
 			return _sum(prims.map((prim) => getPrimitiveVertexCount(prim, method)));
-		case VertexCountMethod.GPU:
+		case VertexCountMethod.UPLOAD:
 			return _sum(uniquePositions.map((attribute) => attribute.getCount()));
 		case VertexCountMethod.DISTINCT:
 		case VertexCountMethod.DISTINCT_POSITION:
@@ -182,8 +184,8 @@ export function getPrimitiveVertexCount(prim: Primitive, method: VertexCountMeth
 			return indices ? indices.getCount() : position.getCount();
 		case VertexCountMethod.RENDER_CACHED:
 			return indices ? new Set(indices.getArray()).size : position.getCount();
-		case VertexCountMethod.GPU_NAIVE:
-		case VertexCountMethod.GPU:
+		case VertexCountMethod.UPLOAD_NAIVE:
+		case VertexCountMethod.UPLOAD:
 			return position.getCount();
 		case VertexCountMethod.DISTINCT:
 		case VertexCountMethod.DISTINCT_POSITION:

--- a/packages/functions/src/inspect.ts
+++ b/packages/functions/src/inspect.ts
@@ -37,8 +37,8 @@ function listScenes(doc: Document): InspectPropertyReport<InspectSceneReport> {
 				bboxMin: toPrecision(sceneBounds.min),
 				bboxMax: toPrecision(sceneBounds.max),
 				renderVertexCount: getSceneVertexCount(scene, VertexCountMethod.RENDER),
-				gpuVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD),
-				gpuNaiveVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE),
+				uploadVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD),
+				uploadNaiveVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE),
 			};
 		});
 	return { properties: scenes };
@@ -243,8 +243,8 @@ export interface InspectSceneReport {
 	bboxMin: number[];
 	bboxMax: number[];
 	renderVertexCount: number;
-	gpuVertexCount: number;
-	gpuNaiveVertexCount: number;
+	uploadVertexCount: number;
+	uploadNaiveVertexCount: number;
 }
 
 export interface InspectMeshReport {

--- a/packages/functions/src/inspect.ts
+++ b/packages/functions/src/inspect.ts
@@ -37,8 +37,8 @@ function listScenes(doc: Document): InspectPropertyReport<InspectSceneReport> {
 				bboxMin: toPrecision(sceneBounds.min),
 				bboxMax: toPrecision(sceneBounds.max),
 				renderVertexCount: getSceneVertexCount(scene, VertexCountMethod.RENDER),
-				gpuVertexCount: getSceneVertexCount(scene, VertexCountMethod.GPU),
-				gpuNaiveVertexCount: getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE),
+				gpuVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD),
+				gpuNaiveVertexCount: getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE),
 			};
 		});
 	return { properties: scenes };
@@ -83,7 +83,7 @@ function listMeshes(doc: Document): InspectPropertyReport<InspectMeshReport> {
 				mode: Array.from(new Set(modes)),
 				meshPrimitives: mesh.listPrimitives().length,
 				glPrimitives: glPrimitives,
-				vertices: getMeshVertexCount(mesh, VertexCountMethod.GPU),
+				vertices: getMeshVertexCount(mesh, VertexCountMethod.UPLOAD),
 				indices: Array.from(meshIndices).sort(),
 				attributes: Array.from(semantics).sort(),
 				instances: instances,

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -168,11 +168,11 @@ export function simplifyPrimitive(prim: Primitive, _options: SimplifyOptions): P
 			break;
 	}
 
-	// (1) If primitive contains more vertices than it needs, compact before simplification.
+	// (1) If primitive draws <50% of its vertex stream, compact before simplification.
 
-	const attributeVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.GPU);
-	const indexedVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.RENDER_CACHED);
-	if (attributeVertexCount / indexedVertexCount > 5) {
+	const uploadVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
+	const renderVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.RENDER);
+	if (renderVertexCount < uploadVertexCount / 2) {
 		const indices = prim.getIndices()!.getArray()!;
 		const [remap, unique] = simplifier.compactMesh(new Uint32Array(indices)); // overwrites indices!
 		compactPrimitive(prim, remap, unique);

--- a/packages/functions/test/get-vertex-count.test.ts
+++ b/packages/functions/test/get-vertex-count.test.ts
@@ -4,7 +4,7 @@ import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import { getSceneVertexCount, VertexCountMethod } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-const { RENDER, RENDER_CACHED, GPU, GPU_NAIVE, UNUSED } = VertexCountMethod;
+const { RENDER, RENDER_CACHED, UPLOAD, UPLOAD_NAIVE, UNUSED } = VertexCountMethod;
 
 test('render', async (t) => {
 	const document = new Document().setLogger(logger);
@@ -26,20 +26,20 @@ test('render-cached', async (t) => {
 
 test('gpu-naive', async (t) => {
 	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), GPU_NAIVE), 32 * 4, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), GPU_NAIVE), 32 * 2, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), GPU_NAIVE), 32, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), GPU_NAIVE), 32 * 2, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), GPU_NAIVE), 32 * 2, 'unused');
+	t.is(getSceneVertexCount(createSceneBasic(document), UPLOAD_NAIVE), 32 * 4, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), UPLOAD_NAIVE), 32 * 2, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), UPLOAD_NAIVE), 32, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD_NAIVE), 32 * 2, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), UPLOAD_NAIVE), 32 * 2, 'unused');
 });
 
 test('gpu', async (t) => {
 	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), GPU), 32 * 4, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), GPU), 32, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), GPU), 32, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), GPU), 32, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), GPU), 32, 'unused');
+	t.is(getSceneVertexCount(createSceneBasic(document), UPLOAD), 32 * 4, 'basic');
+	t.is(getSceneVertexCount(createSceneIndexed(document), UPLOAD), 32, 'indexed');
+	t.is(getSceneVertexCount(createSceneInstanced(document), UPLOAD), 32, 'instanced');
+	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD), 32, 'mixed attributes');
+	t.is(getSceneVertexCount(createSceneUnused(document), UPLOAD), 32, 'unused');
 });
 
 test('unused', async (t) => {

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -43,12 +43,12 @@ test('welded', async (t) => {
 	const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
 	const scene = document.getRoot().getDefaultScene()!;
 
-	const srcCount = getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE);
+	const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
 	const srcBounds = roundBbox(getBounds(scene), 2);
 
 	await document.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
 
-	const dstCount = getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE);
+	const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
 	const dstBounds = roundBbox(getBounds(scene), 2);
 
 	t.truthy((srcCount - dstCount) / srcCount > 0.45, '>=45% reduction');
@@ -61,12 +61,12 @@ test('unwelded', async (t) => {
 	const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
 	const scene = document.getRoot().getDefaultScene()!;
 
-	const srcCount = getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE);
+	const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
 	const srcBounds = roundBbox(getBounds(scene), 2);
 
 	await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
 
-	const dstCount = getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE);
+	const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
 	const dstBounds = roundBbox(getBounds(scene), 2);
 
 	t.truthy((srcCount - dstCount) / srcCount > 0.45, '>=45% reduction');
@@ -96,12 +96,12 @@ test('shared accessors', async (t) => {
 	const nodeB = document.createNode('B').setTranslation([-5, 0, 0]).setMesh(meshB);
 	scene.addChild(nodeA).addChild(nodeB);
 
-	const srcCount = getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE);
+	const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
 	const srcBounds = roundBbox(getBounds(scene), 2);
 
 	await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
 
-	const dstCount = getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE);
+	const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
 	const dstBounds = roundBbox(getBounds(scene), 2);
 
 	t.truthy((srcCount - dstCount) / srcCount > 0.5, '>=50% reduction');
@@ -126,7 +126,7 @@ test('degenerate', async (t) => {
 	t.true(mesh.isDisposed(), 'mesh disposed');
 	t.true(node.isDisposed(), 'node disposed');
 	t.false(scene.isDisposed(), 'scene kept');
-	t.is(getSceneVertexCount(scene, VertexCountMethod.GPU_NAIVE), 0, '0 vertices');
+	t.is(getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE), 0, '0 vertices');
 });
 
 test('torus', async (t) => {


### PR DESCRIPTION
I think this should be clearer; last chance to change it before v4.

Changes:

- VertexCountMethod.GPU -> VertexCountMethod.UPLOAD
- VertexCountMethod.GPU_NAIVE -> VertexCountMethod.UPLOAD_NAIVE
