### PR TITLE
perf(functions): Add a compact step to quantize()

### DIFF
--- a/packages/functions/src/quantize.ts
+++ b/packages/functions/src/quantize.ts
@@ -25,6 +25,8 @@ import type { Volume } from '@gltf-transform/extensions';
 import { prune } from './prune.js';
 import { assignDefaults, createTransform } from './utils.js';
 import { sortPrimitiveWeights } from './sort-primitive-weights.js';
+import { getPrimitiveVertexCount, VertexCountMethod } from './get-vertex-count.js';
+import { compactPrimitive } from './compact-primitive.js';
 
 const NAME = 'quantize';
 
@@ -128,6 +130,11 @@ export function quantize(_options: QuantizeOptions = QUANTIZE_DEFAULTS): Transfo
 			}
 
 			for (const prim of mesh.listPrimitives()) {
+				const renderCount = getPrimitiveVertexCount(prim, VertexCountMethod.RENDER);
+				const uploadCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
+				if (renderCount < uploadCount / 2) {
+					compactPrimitive(prim);
+				}
 				quantizePrimitive(doc, prim, nodeTransform!, options);
 				for (const target of prim.listTargets()) {
 					quantizePrimitive(doc, target, nodeTransform!, options);


### PR DESCRIPTION
Currently `quantize()` quantizes each attribute, without regard for indices. This change adds a `compactPrimitive(prim)` step for any primitives with <50% vertex stream utilization.

Times for quantizing the sparsely-indexed oval.gltf:

- before: 156.85s
- after: 8.74s

Related:

- https://github.com/donmccurdy/glTF-Transform/issues/1315
- https://github.com/donmccurdy/glTF-Transform/issues/1133