### PR TITLE
feat(extensions): Warn on unsupported preread/write types

### DIFF
--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -19,6 +19,16 @@ const DEFAULT_OPTIONS: ReaderOptions = {
 	dependencies: {},
 };
 
+const SUPPORTED_PREREAD_TYPES = new Set<string>([
+	PropertyType.BUFFER,
+	PropertyType.TEXTURE,
+	PropertyType.MATERIAL,
+	PropertyType.MESH,
+	PropertyType.PRIMITIVE,
+	PropertyType.NODE,
+	PropertyType.SCENE,
+]);
+
 /** @internal */
 export class GLTFReader {
 	public static read(jsonDoc: JSONDocument, _options: ReaderOptions = DEFAULT_OPTIONS): Document {
@@ -53,10 +63,21 @@ export class GLTFReader {
 
 		for (const Extension of options.extensions) {
 			if (extensionsUsed.includes(Extension.EXTENSION_NAME)) {
+				// Create extension.
 				const extension = document
 					.createExtension(Extension as unknown as new (doc: Document) => Extension)
 					.setRequired(extensionsRequired.includes(Extension.EXTENSION_NAME));
 
+				// Warn on unsupported preread hooks.
+				const unsupportedHooks = extension.prereadTypes.filter((type) => !SUPPORTED_PREREAD_TYPES.has(type));
+				if (unsupportedHooks.length) {
+					options.logger.warn(
+						`Preread hooks for some types (${unsupportedHooks.join()}), requested by extension ` +
+							`${extension.extensionName}, are unsupported. Please file an issue or a PR.`,
+					);
+				}
+
+				// Install dependencies.
 				for (const key of extension.readDependencies) {
 					extension.install(key, options.dependencies[key]);
 				}

--- a/packages/core/src/io/reader.ts
+++ b/packages/core/src/io/reader.ts
@@ -19,7 +19,7 @@ const DEFAULT_OPTIONS: ReaderOptions = {
 	dependencies: {},
 };
 
-const SUPPORTED_PREREAD_TYPES = new Set<string>([
+const SUPPORTED_PREREAD_TYPES = new Set<PropertyType>([
 	PropertyType.BUFFER,
 	PropertyType.TEXTURE,
 	PropertyType.MATERIAL,

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -27,7 +27,7 @@ export interface WriterOptions {
 	extensions?: (typeof Extension)[];
 }
 
-const SUPPORTED_PREWRITE_TYPES = new Set<string>([
+const SUPPORTED_PREWRITE_TYPES = new Set<PropertyType>([
 	PropertyType.ACCESSOR,
 	PropertyType.BUFFER,
 	PropertyType.MATERIAL,

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -27,6 +27,13 @@ export interface WriterOptions {
 	extensions?: (typeof Extension)[];
 }
 
+const SUPPORTED_PREWRITE_TYPES = new Set<string>([
+	PropertyType.ACCESSOR,
+	PropertyType.BUFFER,
+	PropertyType.MATERIAL,
+	PropertyType.MESH,
+]);
+
 /**
  * @internal
  * @hidden
@@ -65,6 +72,16 @@ export class GLTFWriter {
 		}
 
 		for (const extension of extensionsUsed) {
+			// Warn on unsupported prewrite hooks.
+			const unsupportedHooks = extension.prewriteTypes.filter((type) => !SUPPORTED_PREWRITE_TYPES.has(type));
+			if (unsupportedHooks.length) {
+				logger.warn(
+					`Prewrite hooks for some types (${unsupportedHooks.join()}), requested by extension ` +
+						`${extension.extensionName}, are unsupported. Please file an issue or a PR.`,
+				);
+			}
+
+			// Install dependencies.
 			for (const key of extension.writeDependencies) {
 				extension.install(key, options.dependencies[key]);
 			}


### PR DESCRIPTION
Extensions register prereadTypes/prewriteTypes for which their preread/prewrite hooks should run. Currently not all types are supported in hooks, and there's no warning when a hook is registered for an unsupported type. This PR adds warnings.