### PR TITLE
change log of prune when nothing is found to debug visibility

### DIFF
--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -241,7 +241,7 @@ export function prune(_options: PruneOptions = PRUNE_DEFAULTS): Transform {
 				.join(', ');
 			logger.info(`${NAME}: Removed types... ${str}`);
 		} else {
-			logger.info(`${NAME}: No unused properties found.`);
+			logger.debug(`${NAME}: No unused properties found.`);
 		}
 
 		logger.debug(`${NAME}: Complete.`);


### PR DESCRIPTION
Currently the prune is used internally in many functions and it 'spam' the log especially when No unused properties found : 

for example : 
```
resample: 0.83ms
prune: Removed types... Node (29)
flatten: 1.13ms
prune: No unused properties found.
weldVertices: 8.36ms
prune: No unused properties found.
prune: No unused properties found.
simplifyMesh: 11.40ms
//etc...
```

after this change : 
```
resample: 0.83ms
prune: Removed types... Node (29)
flatten: 1.13ms
weldVertices: 8.36ms
simplifyMesh: 11.40ms
//etc...
```