### PR TITLE
fix(functions): Remove side effects of no-op meshopt() and quantize() calls

### DIFF
--- a/packages/functions/src/meshopt.ts
+++ b/packages/functions/src/meshopt.ts
@@ -55,6 +55,10 @@ export function meshopt(_options: MeshoptOptions): Transform {
 		let patternTargets: RegExp;
 		let quantizeNormal = options.quantizeNormal;
 
+		if (document.getRoot().listAccessors().length === 0) {
+			return;
+		}
+
 		// IMPORTANT: Vertex attributes should be quantized in 'high' mode IFF they are
 		// _not_ filtered in 'packages/extensions/src/ext-meshopt-compression/encoder.ts'.
 		// Note that normals and tangents use octahedral filters, but _morph_ normals

--- a/packages/functions/test/meshopt.test.ts
+++ b/packages/functions/test/meshopt.test.ts
@@ -1,0 +1,27 @@
+import test from 'ava';
+import { Document } from '@gltf-transform/core';
+import { meshopt } from '@gltf-transform/functions';
+import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
+import { MeshoptEncoder } from 'meshoptimizer';
+
+test('basic', async (t) => {
+	const document = new Document().setLogger(logger);
+	document.createMesh().addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 6 }));
+
+	await document.transform(meshopt({ encoder: MeshoptEncoder }));
+
+	t.true(hasMeshopt(document), 'adds extension');
+});
+
+test('noop', async (t) => {
+	const document = new Document().setLogger(logger);
+	await document.transform(meshopt({ encoder: MeshoptEncoder }));
+
+	t.false(hasMeshopt(document), 'skips extension if no accessors found');
+});
+
+const hasMeshopt = (document: Document): boolean =>
+	document
+		.getRoot()
+		.listExtensionsUsed()
+		.some((ext) => ext.extensionName === 'EXT_meshopt_compression');

--- a/packages/functions/test/quantize.test.ts
+++ b/packages/functions/test/quantize.test.ts
@@ -16,6 +16,19 @@ import { EXTMeshGPUInstancing, KHRMaterialsVolume, Volume } from '@gltf-transfor
 import { quantize } from '@gltf-transform/functions';
 import { logger, round, roundBbox } from '@gltf-transform/test-utils';
 
+test('noop', async (t) => {
+	const document = new Document().setLogger(logger);
+	await document.transform(quantize());
+
+	t.false(
+		document
+			.getRoot()
+			.listExtensionsUsed()
+			.some((ext) => ext.extensionName === 'KHR_mesh_quantization'),
+		'skips extension',
+	);
+});
+
 test('exclusions', async (t) => {
 	const doc = new Document().setLogger(logger);
 	const prim = createPrimitive(doc);


### PR DESCRIPTION
In some cases meshopt() or quantize() may be called, but their extensions are not necessary. This may occur either because the model has no accessors, or because no primitives qualified for quantization. After this PR, extensions are not added to the document in these cases — it doesn't make sense to list KHR_mesh_quantization if there are no meshes, for example.