### PR TITLE
fix(cli): optimize ignores --prune-attributes in palette()

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -367,7 +367,16 @@ commands or using the scripting API.
 		const transforms: Transform[] = [dedup()];
 
 		if (opts.instance) transforms.push(instance({ min: opts.instanceMin }));
-		if (opts.palette) transforms.push(palette({ min: opts.paletteMin }));
+
+		if (opts.palette) {
+			transforms.push(
+				palette({
+					min: opts.paletteMin,
+					keepAttributes: !opts.pruneAttributes
+				})
+			);
+		}
+
 		if (opts.flatten) transforms.push(flatten());
 		if (opts.join) transforms.push(join());
 		if (opts.weld) transforms.push(weld());

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -372,8 +372,8 @@ commands or using the scripting API.
 			transforms.push(
 				palette({
 					min: opts.paletteMin,
-					keepAttributes: !opts.pruneAttributes
-				})
+					keepAttributes: !opts.prune || !opts.pruneAttributes,
+				}),
 			);
 		}
 

--- a/packages/functions/src/palette.ts
+++ b/packages/functions/src/palette.ts
@@ -27,6 +27,12 @@ export interface PaletteOptions {
 	 */
 	min?: number;
 	/**
+	 * Whether to keep unused vertex attributes, such as UVs without an assigned
+	 * texture. If kept, unused UV coordinates may prevent palette texture
+	 * creation. Default: false.
+	 */
+	keepAttributes?: boolean;
+	/**
 	 * Whether to perform cleanup steps after completing the operation. Recommended, and enabled by
 	 * default. Cleanup removes temporary resources created during the operation, but may also remove
 	 * pre-existing unused or duplicate resources in the {@link Document}. Applications that require
@@ -40,6 +46,7 @@ export interface PaletteOptions {
 export const PALETTE_DEFAULTS: Required<PaletteOptions> = {
 	blockSize: 4,
 	min: 5,
+	keepAttributes: false,
 	cleanup: true,
 };
 
@@ -88,14 +95,16 @@ export function palette(_options: PaletteOptions = PALETTE_DEFAULTS): Transform 
 		const root = document.getRoot();
 
 		// Find and remove unused TEXCOORD_n attributes.
-		await document.transform(
-			prune({
-				propertyTypes: [PropertyType.ACCESSOR],
-				keepAttributes: false,
-				keepIndices: true,
-				keepLeaves: true,
-			}),
-		);
+		if (!options.keepAttributes) {
+			await document.transform(
+				prune({
+					propertyTypes: [PropertyType.ACCESSOR],
+					keepAttributes: false,
+					keepIndices: true,
+					keepLeaves: true,
+				}),
+			);
+		}
 
 		const prims = new Set<Primitive>();
 		const materials = new Set<Material>();

--- a/packages/functions/src/prune.ts
+++ b/packages/functions/src/prune.ts
@@ -76,15 +76,23 @@ export const PRUNE_DEFAULTS: Required<PruneOptions> = {
  * Example:
  *
  * ```javascript
+ * import { PropertyType } from '@gltf-transform/core';
+ * import { prune } from '@gltf-transform/functions';
+ *
  * document.getRoot().listMaterials(); // → [Material, Material]
  *
- * await document.transform(prune());
+ * await document.transform(
+ * 	prune({
+ * 		propertyTypes: [PropertyType.MATERIAL],
+ * 		keepExtras: true
+ * 	})
+ * );
  *
  * document.getRoot().listMaterials(); // → [Material]
  * ```
  *
- * Use {@link PruneOptions} to control what content should be pruned. For example, you can preserve
- * empty objects in the scene hierarchy using the option `keepLeaves`.
+ * By default, pruning will aggressively remove most unused resources. Use
+ * {@link PruneOptions} to limit what is considered for pruning.
  *
  * @category Transforms
  */


### PR DESCRIPTION
When specifying `--no-prune` or `--no-prune-attributes` flags on the optimize command, ensure that the palette() step doesn't prune attributes either.