### PR TITLE
fix(core): Allow GLB with unknown chunk without BIN chunk

### DIFF
--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -280,7 +280,9 @@ export abstract class PlatformIO {
 
 		const binChunkHeader = new Uint32Array(glb.buffer, glb.byteOffset + binByteOffset, 2);
 		if (binChunkHeader[1] !== ChunkType.BIN) {
-			throw new Error('Expected GLB BIN in second chunk.');
+			// Allow GLB files without BIN chunk, but with unknown chunk
+			// Spec: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#chunks-overview
+			return { json, resources: {} };
 		}
 
 		const binByteLength = binChunkHeader[0];


### PR DESCRIPTION
From the [`4.4. Binary glTF Layout`](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#binary-gltf-layout) section of gltf spec, it says in [`4.4.3.1. Overview`:](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#chunks-overview)
> Client implementations **MUST** ignore chunks with unknown types to enable glTF extensions to reference additional chunks with new types following the first two chunks.

In `Table 1. Chunk types ` of spec, the `Occurrences` of BIN chunk is `0 or 1`, marking BIN chunk optional, so a model without a BIN chunk but with unknown chunk is valid from the spec.

This should fix https://github.com/donmccurdy/glTF-Transform/issues/1454