### PR TITLE
fix(view/lights): for spotlights, restore parent on its target

### DIFF
--- a/packages/view/src/pools/SingleUserPool.ts
+++ b/packages/view/src/pools/SingleUserPool.ts
@@ -1,5 +1,5 @@
 import { type Mesh as MeshDef, type Node as NodeDef, type Property as PropertyDef, uuid } from '@gltf-transform/core';
-import type { Object3D } from 'three';
+import { DirectionalLight, type Object3D, SpotLight } from 'three';
 import type { LightLike } from '../constants.js';
 import { Pool } from './Pool.js';
 
@@ -27,6 +27,14 @@ export class SingleUserPool<T extends Object3D> extends Pool<T, SingleUserParams
 		// any PrimitiveDef values (e.g. Mesh, Lines, Points) within it.
 		// Record the new outputs.
 		const dstObject = srcObject.clone();
+
+		// A clone of spot lights and directional lights clones its children and target separately, which results in duplicates.
+		if (dstObject instanceof SpotLight || dstObject instanceof DirectionalLight) {
+			dstObject.children[0]?.remove();
+			// Target is cloned but its parent needs to be restored to the cloned light.
+			dstObject.add(dstObject.target);
+		}
+
 		parallelTraverse(srcObject, dstObject, (base, variant) => {
 			if (base === srcObject) return; // Skip root; recorded elsewhere.
 			if ((srcObject as unknown as LightLike).isLight) return; // Skip light target.


### PR DESCRIPTION
Resolves #1490 

Target is added as a child to light. https://github.com/donmccurdy/glTF-Transform/blob/23e2bc6c2aae0dd7cdbb1cf589bfa125b6768426/packages/view/src/subjects/LightSubject.ts#L50
But when the lights are cloned here
https://github.com/donmccurdy/glTF-Transform/blob/23e2bc6c2aae0dd7cdbb1cf589bfa125b6768426/packages/view/src/pools/SingleUserPool.ts#L29, the corresponding clone in three.js https://github.com/mrdoob/three.js/blob/817a222f2d12baf44a38baf256bc9d4f65d82465/src/lights/SpotLight.js#L61 doesn't add a parent to target.