### PR TITLE
fix(io): Handle duplicate URIs on read/write (v2)

### DIFF
--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -184,8 +184,24 @@ export class WriterContext {
 		} else {
 			const extension = ImageUtils.mimeTypeToExtension(texture.getMimeType());
 			imageDef.uri = this.imageURIGenerator.createURI(texture, extension);
-			this.jsonDoc.resources[imageDef.uri] = data;
+			this.assignResourceURI(imageDef.uri, data);
 		}
+	}
+
+	public assignResourceURI(uri: string, data: Uint8Array): void {
+		const resources = this.jsonDoc.resources;
+
+		// https://github.com/KhronosGroup/glTF/issues/2446
+		if (uri in resources && data !== resources[uri]) {
+			throw new Error(`Resource URI "${uri}" already assigned to different data.`);
+		}
+
+		if (uri in resources) {
+			this.logger.warn(`Duplicate resource URI, "${uri}".`);
+			return;
+		}
+
+		resources[uri] = data;
 	}
 
 	/**

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -184,16 +184,21 @@ export class WriterContext {
 		} else {
 			const extension = ImageUtils.mimeTypeToExtension(texture.getMimeType());
 			imageDef.uri = this.imageURIGenerator.createURI(texture, extension);
-			this.assignResourceURI(imageDef.uri, data);
+			this.assignResourceURI(imageDef.uri, data, false);
 		}
 	}
 
-	public assignResourceURI(uri: string, data: Uint8Array): void {
+	public assignResourceURI(uri: string, data: Uint8Array, isConflictFatal: boolean): void {
 		const resources = this.jsonDoc.resources;
 
 		// https://github.com/KhronosGroup/glTF/issues/2446
 		if (uri in resources && data !== resources[uri]) {
-			throw new Error(`Resource URI "${uri}" already assigned to different data.`);
+			const msg = `Resource URI "${uri}" already assigned to different data.`;
+			if (isConflictFatal) {
+				throw new Error(msg);
+			} else {
+				this.logger.warn(msg);
+			}
 		}
 
 		if (uri in resources) {

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -188,13 +188,13 @@ export class WriterContext {
 		}
 	}
 
-	public assignResourceURI(uri: string, data: Uint8Array, isConflictFatal: boolean): void {
+	public assignResourceURI(uri: string, data: Uint8Array, throwOnConflict: boolean): void {
 		const resources = this.jsonDoc.resources;
 
 		// https://github.com/KhronosGroup/glTF/issues/2446
 		if (uri in resources && data !== resources[uri]) {
 			const msg = `Resource URI "${uri}" already assigned to different data.`;
-			if (isConflictFatal) {
+			if (throwOnConflict) {
 				throw new Error(msg);
 			} else {
 				this.logger.warn(msg);

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -192,21 +192,24 @@ export class WriterContext {
 		const resources = this.jsonDoc.resources;
 
 		// https://github.com/KhronosGroup/glTF/issues/2446
-		if (uri in resources && data !== resources[uri]) {
-			const msg = `Resource URI "${uri}" already assigned to different data.`;
-			if (throwOnConflict) {
-				throw new Error(msg);
-			} else {
-				this.logger.warn(msg);
-			}
+		if (!(uri in resources)) {
+			resources[uri] = data;
+			return;
 		}
 
-		if (uri in resources) {
+		if (data === resources[uri]) {
 			this.logger.warn(`Duplicate resource URI, "${uri}".`);
 			return;
 		}
 
-		resources[uri] = data;
+		const conflictMessage = `Resource URI "${uri}" already assigned to different data.`;
+
+		if (!throwOnConflict) {
+			this.logger.warn(conflictMessage);
+			return;
+		}
+
+		throw new Error(conflictMessage);
 	}
 
 	/**

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -437,9 +437,11 @@ export class GLTFWriter {
 			.filter((extension) => extension.prewriteTypes.includes(PropertyType.BUFFER))
 			.forEach((extension) => extension.prewrite(context, PropertyType.BUFFER));
 
-		const hasBinaryResources =
-			root.listAccessors().length > 0 || root.listTextures().length > 0 || context.otherBufferViews.size > 0;
-		if (hasBinaryResources && root.listBuffers().length === 0) {
+		const needsBuffer =
+			root.listAccessors().length > 0 ||
+			context.otherBufferViews.size > 0 ||
+			(root.listTextures().length > 0 && options.format === Format.GLB);
+		if (needsBuffer && root.listBuffers().length === 0) {
 			throw new Error('Buffer required for Document resources, but none was found.');
 		}
 
@@ -552,7 +554,7 @@ export class GLTFWriter {
 
 				// Write buffer views to buffer.
 				bufferDef.byteLength = bufferByteLength;
-				jsonDoc.resources[uri] = BufferUtils.concat(buffers);
+				context.assignResourceURI(uri, BufferUtils.concat(buffers));
 			}
 
 			json.buffers!.push(bufferDef);

--- a/packages/core/src/io/writer.ts
+++ b/packages/core/src/io/writer.ts
@@ -554,7 +554,7 @@ export class GLTFWriter {
 
 				// Write buffer views to buffer.
 				bufferDef.byteLength = bufferByteLength;
-				context.assignResourceURI(uri, BufferUtils.concat(buffers));
+				context.assignResourceURI(uri, BufferUtils.concat(buffers), true);
 			}
 
 			json.buffers!.push(bufferDef);

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -240,14 +240,15 @@ test('write duplicate buffer URIs', async (t) => {
 
 	// https://github.com/KhronosGroup/glTF/issues/2446
 	const document = new Document();
-	const buffer1 = document.createBuffer().setURI('scene.bin');
-	const buffer2 = document.createBuffer().setURI('scene.bin');
+	const buffer1 = document.createBuffer().setURI('a.bin');
+	const buffer2 = document.createBuffer().setURI('a.bin');
 	document.createAccessor().setBuffer(buffer1).setArray(new Float32Array(10).fill(1));
 	document.createAccessor().setBuffer(buffer2).setArray(new Float32Array(10).fill(2));
 
+	// Buffers with the same name and different content must throw.
 	await t.throwsAsync(() => io.writeJSON(document), { message: /Resource URI/i }, 'duplicate buffer URIs');
 
-	buffer2.setURI('aux.bin');
+	buffer2.setURI('b.bin');
 
 	t.truthy(await io.writeJSON(document), 'unique buffer URIs');
 });
@@ -257,12 +258,11 @@ test('write duplicate image URIs', async (t) => {
 
 	// https://github.com/KhronosGroup/glTF/issues/2446
 	const document = new Document();
-	const image1 = document.createTexture().setImage(new Uint8Array(2)).setURI('color.png');
+	document.createTexture().setImage(new Uint8Array(2)).setURI('color.png');
 	document.createTexture().setImage(new Uint8Array(1)).setURI('color.png');
 
-	await t.throwsAsync(() => io.writeJSON(document), { message: /Resource URI/i }, 'duplicate image URIs');
-
-	image1.setURI('normal.png');
-
-	t.truthy(await io.writeJSON(document), 'unique image URIs');
+	// Textures with the same name and different content are, for now, allowed.
+	// TODO(v5): Consider whether duplicates should be handled more strictly.
+	// See https://github.com/donmccurdy/glTF-Transform/issues/1513.
+	t.truthy(await io.writeJSON(document), 'duplicate image URIs');
 });

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -179,3 +179,90 @@ test('glb with unknown chunk', async (t) => {
 	const node = document.getRoot().listNodes()[0];
 	t.is(node.getName(), 'RootNode', 'parses nodes');
 });
+
+test('read duplicate buffer URIs', async (t) => {
+	const io = await createPlatformIO();
+
+	// https://github.com/KhronosGroup/glTF/issues/2446
+	// https://github.com/donmccurdy/glTF-Transform/issues/1513
+	const jsonDocument: JSONDocument = {
+		json: {
+			asset: { version: '2.0' },
+			buffers: [
+				{ uri: 'scene.bin', byteLength: 20 },
+				{ uri: 'scene.bin', byteLength: 20 },
+			],
+		},
+		resources: { 'scene.bin': new Uint8Array(20) },
+	};
+
+	const document = await io.readJSON(jsonDocument);
+
+	const bufferURIs = document
+		.getRoot()
+		.listBuffers()
+		.map((buffer) => buffer.getURI());
+
+	t.deepEqual(bufferURIs, ['scene.bin', 'scene.bin'], 'removes duplicate buffer URIs');
+});
+
+test('read duplicate image URIs', async (t) => {
+	const io = await createPlatformIO();
+
+	// https://github.com/KhronosGroup/glTF/issues/2446
+	// https://github.com/donmccurdy/glTF-Transform/issues/1513
+	const image = new Uint8Array(20);
+	const jsonDocument: JSONDocument = {
+		json: {
+			asset: { version: '2.0' },
+			images: [{ uri: 'color.png' }, { uri: 'color.png' }],
+		},
+		resources: { 'color.png': image },
+	};
+
+	const document = await io.readJSON(jsonDocument);
+
+	const imageURIs = document
+		.getRoot()
+		.listTextures()
+		.map((texture) => texture.getURI());
+	const images = document
+		.getRoot()
+		.listTextures()
+		.map((texture) => texture.getImage());
+
+	t.deepEqual(imageURIs, ['color.png', 'color.png'], 'loads duplicate image URIs');
+	t.deepEqual(images, [image, image], 'loads duplicate image data');
+});
+
+test('write duplicate buffer URIs', async (t) => {
+	const io = await createPlatformIO();
+
+	// https://github.com/KhronosGroup/glTF/issues/2446
+	const document = new Document();
+	const buffer1 = document.createBuffer().setURI('scene.bin');
+	const buffer2 = document.createBuffer().setURI('scene.bin');
+	document.createAccessor().setBuffer(buffer1).setArray(new Float32Array(10).fill(1));
+	document.createAccessor().setBuffer(buffer2).setArray(new Float32Array(10).fill(2));
+
+	await t.throwsAsync(() => io.writeJSON(document), { message: /Resource URI/i }, 'duplicate buffer URIs');
+
+	buffer2.setURI('aux.bin');
+
+	t.truthy(await io.writeJSON(document), 'unique buffer URIs');
+});
+
+test('write duplicate image URIs', async (t) => {
+	const io = await createPlatformIO();
+
+	// https://github.com/KhronosGroup/glTF/issues/2446
+	const document = new Document();
+	const image1 = document.createTexture().setImage(new Uint8Array(2)).setURI('color.png');
+	document.createTexture().setImage(new Uint8Array(1)).setURI('color.png');
+
+	await t.throwsAsync(() => io.writeJSON(document), { message: /Resource URI/i }, 'duplicate image URIs');
+
+	image1.setURI('normal.png');
+
+	t.truthy(await io.writeJSON(document), 'unique image URIs');
+});


### PR DESCRIPTION
Partially restores #1511, this time without changes to the reading process. While writing, a warning is logged if two resources share the same URI. If the two textures sharing a URI are not identical, an warning is logged. If two buffers sharing a URI are not identical, an error is thrown.

- fixes #1509
- fixes #1513

This clarifies but does not technically fix #1509, the extra buffers must be removed. Exporting to .glb would do that automatically.