### PR TITLE
Add spliceNode function to reparent an entire scene or subtree

### DIFF
--- a/packages/functions/src/splice-node.ts
+++ b/packages/functions/src/splice-node.ts
@@ -1,0 +1,28 @@
+import { Scene, Node } from '@gltf-transform/core';
+
+/**
+ * Create a new node as child of the target {@link Scene} or {@link Node}.
+ * Its existing children will be reparented under the new node.
+ *
+ * Example:
+ *
+ * ```javascript
+ * import { transformScene } from '@gltf-transform/functions';
+ *
+ * let scene = document.getRoot().getDefaultScene()
+ * // rotate the entire scene a quarter turn around the y axis
+ * spliceNode(scene).setRotation([0, Math.SQRT1_2, 0, Math.SQRT1_2]);
+ * ```
+ *
+ * @param parent Node or Scene whose children to reroot
+ * @returns The new parent node
+ */
+export function spliceNode(parent: Scene | Node): Node {
+	const newNode = new Node(parent.getGraph());
+	for (const child of parent.listChildren()) {
+		if (child.getSkin()) continue;
+		newNode.addChild(child);
+	}
+	parent.addChild(newNode);
+	return newNode;
+}


### PR DESCRIPTION
This is inspired by https://github.com/donmccurdy/glTF-Transform/issues/1530#issuecomment-2414064338. In particular, instead of a `transformScene` function, this creates a new `Node` to which you can apply transforms.