### PR TITLE
deps(core): Update to property-graph v3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
 		"path": false
 	},
 	"dependencies": {
-		"property-graph": "^2.0.0"
+		"property-graph": "^3.0.0"
 	},
 	"mangle": {
 		"regex": "^_"

--- a/packages/core/test/properties/property.test.ts
+++ b/packages/core/test/properties/property.test.ts
@@ -30,3 +30,36 @@ test('internal arrays', async (t) => {
 
 	t.deepEqual(node.getTranslation(), [0, 0, 0], 'unchanged by external mutation');
 });
+
+test('listParents', async (t) => {
+	const document = new Document();
+	const root = document.getRoot();
+	const nodeA = document.createNode('NodeA');
+	const nodeB = document.createNode('NodeB');
+	const sceneA = document.createScene('SceneA').addChild(nodeA).addChild(nodeB);
+	const sceneB = document.createScene('SceneB').addChild(nodeA).addChild(nodeB);
+	root.setDefaultScene(sceneA);
+
+	t.deepEqual(root.listParents(), []);
+	t.deepEqual(sceneA.listParents(), [root]);
+	t.deepEqual(nodeA.listParents(), [root, sceneA, sceneB]);
+	t.deepEqual(nodeB.listParents(), [root, sceneA, sceneB]);
+});
+
+test('listChildren', async (t) => {
+	const document = new Document();
+	const root = document.getRoot();
+	const nodeA = document.createNode('NodeA');
+	const nodeB = document.createNode('NodeB');
+	const sceneA = document.createScene('SceneA').addChild(nodeA).addChild(nodeB);
+	const sceneB = document.createScene('SceneB').addChild(nodeA).addChild(nodeB);
+	root.setDefaultScene(sceneA);
+
+	const graph = document.getGraph();
+
+	t.deepEqual(graph.listChildren(root), [nodeA, nodeB, sceneA, sceneB]);
+	t.deepEqual(graph.listChildren(sceneA), [nodeA, nodeB]);
+	t.deepEqual(graph.listChildren(sceneB), [nodeA, nodeB]);
+	t.deepEqual(graph.listChildren(nodeA), []);
+	t.deepEqual(graph.listChildren(nodeB), []);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,7 +1976,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gltf-transform/core@workspace:packages/core"
   dependencies:
-    property-graph: "npm:^2.0.0"
+    property-graph: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -11117,10 +11117,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"property-graph@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "property-graph@npm:2.0.0"
-  checksum: 10c0/77648bd8111c5414024653142c68059997197a9384b3733767faa0cc43a4c1dace7f85dfd7ba1035df539969a8fc56c7039dfaed9fd1ca2430618b4ef0e657a6
+"property-graph@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "property-graph@npm:3.0.0"
+  checksum: 10c0/689c5377535db079f506e8715761e83adeb7aa25b59de91518b45a22718c6f33edffea2c27bf3c12b484156ef457cead97cdbb163624e47641c8afda26c8f74d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates to `property-graph` v3.0.0. Primary changes in this `property-graph` release are:

- https://github.com/donmccurdy/property-graph/pull/170
- https://github.com/donmccurdy/property-graph/pull/171
- https://github.com/donmccurdy/property-graph/pull/172

For glTF Transform, this means that GraphEdge objects (used internally, but not part of documented public glTF Transform APIs) no longer dispatch events. Events remain unchanged on GraphNode subclasses, like Property, Node, Material, Mesh, etc.

Related:

- Fixes #1537
- Improves #1527