### PR TITLE
fix(functions): Handle vertex count increase when draco compressing uint8 indices

### DIFF
--- a/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/draco-mesh-compression.ts
@@ -281,8 +281,10 @@ export class KHRDracoMeshCompression extends Extension {
 
 			// In rare cases Draco increases vertex count, requiring a larger index component type.
 			// https://github.com/donmccurdy/glTF-Transform/issues/1370
-			if (encodedPrim.numVertices > 65534 && indicesDef.componentType !== Accessor.ComponentType.UNSIGNED_INT) {
+			if (encodedPrim.numVertices > 65534 && Accessor.getComponentSize(indicesDef.componentType) <= 2) {
 				indicesDef.componentType = Accessor.ComponentType.UNSIGNED_INT;
+			} else if (encodedPrim.numVertices > 254 && Accessor.getComponentSize(indicesDef.componentType) <= 1) {
+				indicesDef.componentType = Accessor.ComponentType.UNSIGNED_SHORT;
 			}
 
 			// Create attribute definitions, update count.

--- a/packages/test-utils/src/create-torus-primitive.ts
+++ b/packages/test-utils/src/create-torus-primitive.ts
@@ -123,12 +123,22 @@ export function createTorusKnotPrimitive(
 
 	// build geometry
 
-	return document
+	const prim = document
 		.createPrimitive()
 		.setIndices(document.createAccessor().setArray(new Uint32Array(indices)))
 		.setAttribute('POSITION', document.createAccessor().setType('VEC3').setArray(new Float32Array(vertices)))
 		.setAttribute('NORMAL', document.createAccessor().setType('VEC3').setArray(new Float32Array(normals)))
 		.setAttribute('TEXCOORD_0', document.createAccessor().setType('VEC2').setArray(new Float32Array(uvs)));
+
+	// assign buffer
+
+	const buffer = document.getRoot().listBuffers()[0] || document.createBuffer();
+
+	for (const attribute of prim.listAttributes()) {
+		attribute.setBuffer(buffer);
+	}
+
+	return prim;
 }
 
 /** Calculates the current position on the torus curve. */


### PR DESCRIPTION
- fixes #1553

I've been unable to contrive a simple test mesh that increases vertex count across the 255 vertex limit for uint8/uint16, but would gladly add a unit test for this if possible.