### PR TITLE
fix(functions): Ensure quantize() creates required instance TRS attributes for EXT_mesh_gpu_instancing

### DIFF
--- a/packages/functions/test/quantize.test.ts
+++ b/packages/functions/test/quantize.test.ts
@@ -382,6 +382,11 @@ test('instancing', async (t) => {
 		[12.5, 12.5, 0, 13.5, 13.5, 1],
 		'batch translation includes quantization transform',
 	);
+	t.deepEqual(
+		Array.from(batch.getAttribute('SCALE').getArray()),
+		[2.5, 2.5, 2.5, 2.5, 2.5, 2.5],
+		'batch scale added to attributes',
+	);
 });
 
 test('volumetric materials', async (t) => {


### PR DESCRIPTION
Changes:

- Fixes #1584

Remaining:

- [x] unit tests