### PR TITLE
feat(cli): Add ktxdecompress command

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -61,6 +61,7 @@ import {
 	Filter,
 	Mode,
 	UASTC_DEFAULTS,
+	ktxdecompress,
 	ktxfix,
 	merge,
 	toktx,
@@ -1480,6 +1481,18 @@ for textures where the quality is sufficient.`.trim(),
 			toktx({ ...options, encoder, mode, pattern, slots }),
 		);
 	});
+
+// KTXDECOMPRESS
+ktxdecompress
+program
+	.command('ktxdecompress', 'KTX + Basis texture decompression')
+	.help(`
+		Decompresses KTX2 textures in KTX2 format, converting to PNG.
+		Intended for debugging, or to resolve compatibility issues in
+		software that doesn't support KTX2 textures.`.trim())
+	.argument('<input>', INPUT_DESC)
+	.argument('<output>', OUTPUT_DESC)
+	.action(({ args, logger }) => Session.create(io, logger, args.input, args.output).transform(ktxdecompress()));
 
 // KTXFIX
 program

--- a/packages/cli/src/transforms/index.ts
+++ b/packages/cli/src/transforms/index.ts
@@ -1,3 +1,4 @@
+export * from './ktxdecompress.js';
 export * from './ktxfix.js';
 export * from './merge.js';
 export * from './toktx.js';

--- a/packages/cli/src/transforms/ktxdecompress.ts
+++ b/packages/cli/src/transforms/ktxdecompress.ts
@@ -1,0 +1,114 @@
+import fs, { rm } from 'fs/promises';
+import { join } from 'path';
+import os from 'os';
+import tmp from 'tmp';
+import pLimit from 'p-limit';
+
+import { uuid, Document, FileUtils, ImageUtils, Transform } from '@gltf-transform/core';
+import { KHRTextureBasisu } from '@gltf-transform/extensions';
+import { createTransform } from '@gltf-transform/functions';
+import { spawn, formatBytes, waitExit } from '../util.js';
+import { checkKTXSoftware } from './toktx.js';
+
+const NUM_CPUS = os.cpus().length || 1; // microsoft/vscode#112122
+
+interface KTXDecompressOptions {
+	jobs?: number;
+	/**
+	 * Whether to clean up temporary files created during texture compression. See
+	 * verbose log output for temporary file paths. Default: true.
+	 */
+	cleanup?: boolean;
+}
+
+const KTX_DECOMPRESS_DEFAULTS: KTXDecompressOptions = {
+	// See: https://github.com/donmccurdy/glTF-Transform/pull/389#issuecomment-1089842185
+	jobs: 2 * NUM_CPUS,
+	cleanup: true,
+};
+
+export const ktxdecompress = function (options: KTXDecompressOptions = KTX_DECOMPRESS_DEFAULTS): Transform {
+	options = { ...KTX_DECOMPRESS_DEFAULTS, ...options };
+
+	return createTransform('ktxdecompress', async (doc: Document): Promise<void> => {
+		const logger = doc.getLogger();
+
+		// Confirm recent version of KTX-Software is installed.
+		await checkKTXSoftware(logger);
+
+		// Create workspace. Avoid 'unsafeCleanup' and 'setGracefulCleanup', which
+		// are not working as expected and are slated for removal:
+		// https://github.com/raszi/node-tmp/pull/281
+		const batchPrefix = uuid();
+		const batchDir = tmp.dirSync({ prefix: 'gltf-transform-' });
+
+		const basisuExtension = doc.createExtension(KHRTextureBasisu);
+
+		const limit = pLimit(options.jobs!);
+		const textures = doc.getRoot().listTextures();
+		const promises = textures.map((texture, textureIndex) =>
+			limit(async () => {
+				const textureLabel =
+					texture.getURI() ||
+					texture.getName() ||
+					`${textureIndex + 1}/${doc.getRoot().listTextures().length}`;
+				const prefix = `ktx:texture(${textureLabel})`;
+
+				const srcMimeType = texture.getMimeType();
+				if (srcMimeType !== 'image/ktx2') return;
+
+				const srcImage = texture.getImage()!;
+				const srcExtension = texture.getURI()
+					? FileUtils.extension(texture.getURI())
+					: ImageUtils.mimeTypeToExtension(srcMimeType);
+				const srcSize = texture.getSize();
+				const srcBytes = srcImage ? srcImage.byteLength : null;
+
+				if (!srcImage || !srcSize || !srcBytes) {
+					logger.warn(`${prefix}: Skipping, unreadable texture.`);
+					return;
+				}
+
+				// PREPARE: Create temporary in/out paths for the 'ktx' CLI tool, and determine
+				// necessary command-line flags.
+
+				const srcPath = join(batchDir.name, `${batchPrefix}_${textureIndex}.${srcExtension}`);
+				const dstPath = join(batchDir.name, `${batchPrefix}_${textureIndex}.png`);
+
+				await fs.writeFile(srcPath, srcImage);
+
+				// COMPRESS: Run `ktx create` CLI tool.
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const [status, _stdout, stderr] = await waitExit(spawn('ktx', ['extract', srcPath, dstPath]));
+
+				if (status !== 0) {
+					logger.error(`${prefix}: Failed → \n\n${stderr.toString()}`);
+				} else {
+					// PACK: Replace image data in the glTF asset.
+					texture.setImage(await fs.readFile(dstPath)).setMimeType('image/png');
+					if (texture.getURI()) {
+						texture.setURI(FileUtils.basename(texture.getURI()) + '.png');
+					}
+				}
+
+				const dstBytes = texture.getImage()!.byteLength;
+				logger.debug(`${prefix}: ${formatBytes(srcBytes)} → ${formatBytes(dstBytes)} bytes`);
+			}),
+		);
+
+		await Promise.all(promises);
+
+		if (options.cleanup) {
+			await rm(batchDir.name, { recursive: true });
+		}
+
+		const usesKTX2 = doc
+			.getRoot()
+			.listTextures()
+			.some((t) => t.getMimeType() === 'image/ktx2');
+
+		if (!usesKTX2) {
+			basisuExtension.dispose();
+		}
+	});
+};

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -414,7 +414,7 @@ function createParams(
 	return params;
 }
 
-async function checkKTXSoftware(logger: ILogger): Promise<string> {
+export async function checkKTXSoftware(logger: ILogger): Promise<string> {
 	if (!(await commandExists('ktx')) && !process.env.CI) {
 		throw new Error(
 			`Command "ktx" not found. Please install KTX-Software ${KTX_SOFTWARE_VERSION_MIN}+, ` +


### PR DESCRIPTION
Adds support for decompressing KTX2 textures to PNG. Depends on KTX-Software CLI (`ktx extract in.ktx2 out.png`), as a cross-platform implementation is currently blocked by issues discussed in https://github.com/donmccurdy/glTF-Transform/issues/591.

Usage:

```bash
gltf-transform ktxdecompress in.glb out.glb
```

- Fixes https://github.com/donmccurdy/glTF-Transform/issues/591