### PR TITLE
Add `predicate` option to filter meshes in `join` function.

### DIFF
--- a/packages/functions/src/join.ts
+++ b/packages/functions/src/join.ts
@@ -53,12 +53,22 @@ export interface JoinOptions {
 	 * @experimental
 	 */
 	cleanup?: boolean;
+	/**
+	 * A filter function used to evaluate a condition on a given {@link Node Node}.
+	 * This function should return a boolean indicating whether the node
+	 * satisfies the provided condition.
+	 *
+	 * @param {Node} node - The node instance to be evaluated.
+	 * @returns {boolean} - The result of the evaluation; `true` if the condition is met, otherwise `false`.
+	 */
+	filter?: (node: Node) => boolean;
 }
 
 export const JOIN_DEFAULTS: Required<JoinOptions> = {
 	keepMeshes: false,
 	keepNamed: false,
 	cleanup: true,
+	filter: () => true,
 };
 
 /**
@@ -134,6 +144,9 @@ function _joinLevel(document: Document, parent: Node | Scene, options: Required<
 	const children = parent.listChildren();
 	for (let nodeIndex = 0; nodeIndex < children.length; nodeIndex++) {
 		const node = children[nodeIndex];
+
+		// Skip nodes not matching the filter.
+		if (!options.filter(node)) continue;
 
 		// Skip animated nodes.
 		const isAnimated = node.listParents().some((p) => p instanceof AnimationChannel);


### PR DESCRIPTION
The `predicate` function allows users to define a condition to filter meshes during the processing. It defaults to a function that always returns `true`, ensuring backward compatibility while providing more customization options.