### PR TITLE
Add unwrap transform

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "tweakpane": "<4.0.0",
     "tweakpane-plugin-thumbnail-list": "^0.3.0",
     "typescript": "5.7.3",
-    "vite": "^6.1.0"
+    "vite": "^6.1.0",
+    "watlas": "^0.9.1"
   },
   "ava": {
     "extensions": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tweakpane-plugin-thumbnail-list": "^0.3.0",
     "typescript": "5.7.3",
     "vite": "^6.1.0",
-    "watlas": "^0.9.1"
+    "watlas": "^1.0.0"
   },
   "ava": {
     "extensions": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "spdx-correct": "~3.2.0",
     "strip-ansi": "~7.1.0",
     "tmp": "~0.2.3",
-    "watlas": "^0.9.1"
+    "watlas": "^1.0.0"
   },
   "files": [
     "bin/",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,8 @@
     "sharp": "~0.33.5",
     "spdx-correct": "~3.2.0",
     "strip-ansi": "~7.1.0",
-    "tmp": "~0.2.3"
+    "tmp": "~0.2.3",
+    "watlas": "^0.9.1"
   },
   "files": [
     "bin/",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import micromatch from 'micromatch';
 import { gzip } from 'node-gzip';
 import fetch from 'node-fetch'; // TODO(deps): Replace when v20 reaches end of maintenance.
 import mikktspace from 'mikktspace';
+import * as watlas from 'watlas';
 import { MeshoptEncoder, MeshoptSimplifier } from 'meshoptimizer';
 import { ready as resampleReady, resample as resampleWASM } from 'keyframe-resample';
 import { Logger, NodeIO, PropertyType, VertexLayout, vec2, Transform } from '@gltf-transform/core';
@@ -1089,7 +1090,7 @@ coordinates suitable for baking lightmaps or texture painting.
 	})
 	.action(({args, options, logger}) =>
 		Session.create(io, logger, args.input, args.output)
-			.transform(unwrap({...options}))
+			.transform(unwrap({watlas, ...options}))
 	);
 
 // REORDER

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1068,12 +1068,14 @@ compute MikkTSpace tangents at runtime.
 // UNWRAP
 program
 	.command('unwrap', 'Generate texcoords')
-	.help(`
+	.help(
+		`
 Generates texture coordinates for the given attribute set index.
 
 Uses xatlas (https://github.com/jpcy/xatlas) to generate unique texture
 coordinates suitable for baking lightmaps or texture painting.
-	`.trim())
+	`.trim(),
+	)
 	.argument('<input>', INPUT_DESC)
 	.argument('<output>', OUTPUT_DESC)
 	.option('--index <index>', 'Attribute set index. (ie: 1 generates TEXCOORD_1)', {
@@ -1088,9 +1090,8 @@ coordinates suitable for baking lightmaps or texture painting.
 		validator: [PropertyType.PRIMITIVE, PropertyType.MESH, PropertyType.SCENE],
 		default: UNWRAP_DEFAULTS.grouping,
 	})
-	.action(({args, options, logger}) =>
-		Session.create(io, logger, args.input, args.output)
-			.transform(unwrap({watlas, ...options}))
+	.action(({ args, options, logger }) =>
+		Session.create(io, logger, args.input, args.output).transform(unwrap({ watlas, ...options })),
 	);
 
 // REORDER

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1078,7 +1078,7 @@ coordinates suitable for baking lightmaps or texture painting.
 	)
 	.argument('<input>', INPUT_DESC)
 	.argument('<output>', OUTPUT_DESC)
-	.option('--index <index>', 'Attribute set index. (ie: 1 generates TEXCOORD_1)', {
+	.option('--texCoord <index>', 'Attribute set index (ie: 1 generates TEXCOORD_1)', {
 		validator: Validator.NUMBER,
 		default: 0,
 	})
@@ -1086,7 +1086,7 @@ coordinates suitable for baking lightmaps or texture painting.
 		validator: Validator.BOOLEAN,
 		default: false,
 	})
-	.option('--grouping <group>', 'Bounds for quantization grid.', {
+	.option('--grouping <group>', 'How geometry should be grouped into TexCoord atlases', {
 		validator: [PropertyType.PRIMITIVE, PropertyType.MESH, PropertyType.SCENE],
 		default: UNWRAP_DEFAULTS.grouping,
 	})

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -54,6 +54,8 @@ import {
 	MESHOPT_DEFAULTS,
 	TEXTURE_COMPRESS_SUPPORTED_FORMATS,
 	PRUNE_DEFAULTS,
+	unwrap,
+	UNWRAP_DEFAULTS,
 } from '@gltf-transform/functions';
 import { inspect } from './inspect.js';
 import {
@@ -1060,6 +1062,34 @@ compute MikkTSpace tangents at runtime.
 			tangents({ generateTangents: mikktspace.generateTangents, ...options }),
 			weld(),
 		),
+	);
+
+// UNWRAP
+program
+	.command('unwrap', 'Generate texcoords')
+	.help(`
+Generates texture coordinates for the given attribute set index.
+
+Uses xatlas (https://github.com/jpcy/xatlas) to generate unique texture
+coordinates suitable for baking lightmaps or texture painting.
+	`.trim())
+	.argument('<input>', INPUT_DESC)
+	.argument('<output>', OUTPUT_DESC)
+	.option('--index <index>', 'Attribute set index. (ie: 1 generates TEXCOORD_1)', {
+		validator: Validator.NUMBER,
+		default: 0,
+	})
+	.option('--overwrite', 'Overwrite existing vertex tangents', {
+		validator: Validator.BOOLEAN,
+		default: false,
+	})
+	.option('--grouping <group>', 'Bounds for quantization grid.', {
+		validator: ['primitive', 'mesh', 'scene'],
+		default: UNWRAP_DEFAULTS.grouping,
+	})
+	.action(({args, options, logger}) =>
+		Session.create(io, logger, args.input, args.output)
+			.transform(unwrap({...options}))
 	);
 
 // REORDER

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1084,7 +1084,7 @@ coordinates suitable for baking lightmaps or texture painting.
 		default: false,
 	})
 	.option('--grouping <group>', 'Bounds for quantization grid.', {
-		validator: ['primitive', 'mesh', 'scene'],
+		validator: [PropertyType.PRIMITIVE, PropertyType.MESH, PropertyType.SCENE],
 		default: UNWRAP_DEFAULTS.grouping,
 	})
 	.action(({args, options, logger}) =>

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -54,5 +54,6 @@ export {
 	fitPowerOfTwo,
 } from './utils.js';
 export * from './unweld.js';
+export * from './unwrap.js';
 export * from './vertex-color-space.js';
 export * from './weld.js';

--- a/packages/functions/src/unwrap.ts
+++ b/packages/functions/src/unwrap.ts
@@ -1,0 +1,319 @@
+import type { Document, Transform, TypedArray, Primitive, ILogger } from '@gltf-transform/core';
+import type { MainModule as WATLASMODULE, WAddMeshError, WMeshDecl, WAtlasResult } from './watlas/watlas';
+import { Accessor } from '@gltf-transform/core';
+import { createTransform } from './utils';
+import WAtlasModule, { WChartOptions, WPackOptions } from './watlas/watlas.js';
+
+const NAME = 'unwrap';
+
+/**
+ * Methods of grouping texcoords with the {@link unwrap} function.
+ *  - primitive: Each primitive is given it's own texcoord atlas.
+ *  - mesh: All primitive in a mesh share a texcoord atlas. (Default)
+ *  - scene: All primitives in the scene share a texcoord atlas.
+ */
+export type UnwrapGrouping = 'primitive' | 'mesh' | 'scene';
+
+/** Options for the {@link unwrap} function. */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface UnwrapOptions {
+  index?: number,
+  overwrite?: boolean,
+  grouping?: UnwrapGrouping,
+};
+
+export const UNWRAP_DEFAULTS: UnwrapOptions = {
+  index: 0,
+  overwrite: false,
+  grouping: 'mesh'
+};
+
+let WAtlasPromise: Promise<WATLASMODULE>;
+
+/**
+ * Generate new texcoords for all {@link Primitive}s. Useful for providing a
+ * base set of texcoords if none was included in the mesh or adding a second set
+ * of texcoords for things like AO or lightmapping. This operation may increase
+ * the number of vertices in a mesh.
+ *
+ * Example:
+ *
+ * ```ts
+ * import { unwrap } from '@gltf-transform/functions';
+ *
+ * // Generate a TEXCOORD_1 attribute for all primitives.
+ * await document.transform(unwrap({ index: 1, overwrite: true }));
+ * ```
+ */
+export function unwrap(_options: UnwrapOptions = UNWRAP_DEFAULTS): Transform {
+  const options = { ...UNWRAP_DEFAULTS, ..._options } as Required<UnwrapOptions>;
+
+  return createTransform(NAME, async (doc: Document): Promise<void> => {
+    if (!WAtlasPromise) {
+      WAtlasPromise = WAtlasModule();
+    }
+
+    const WATLAS = await WAtlasPromise;
+    const logger = doc.getLogger();
+
+    switch (options.grouping) {
+      case 'primitive': {
+        for (const mesh of doc.getRoot().listMeshes()) {
+          for (const prim of mesh.listPrimitives()) {
+            unwrapPrimitives([prim], options, logger, doc, WATLAS);
+          }
+        }
+        break;
+      }
+      case 'mesh': {
+        for (const mesh of doc.getRoot().listMeshes()) {
+          unwrapPrimitives(mesh.listPrimitives(), options, logger, doc, WATLAS);
+        }
+        break;
+      }
+      case 'scene': {
+        const scenePrims = [];
+        for (const mesh of doc.getRoot().listMeshes()) {
+          scenePrims.push(...mesh.listPrimitives());
+        }
+        unwrapPrimitives(scenePrims, options, logger, doc, WATLAS);
+        break;
+      }
+    }
+
+    logger.debug(`${NAME}: Complete.`);
+  });
+}
+
+function getMeshErrorString(WATLAS: WATLASMODULE, err: WAddMeshError) {
+  switch (err) {
+    case WATLAS.WAddMeshError.Success: return 'Success';
+    case WATLAS.WAddMeshError.Error: return 'Error';
+    case WATLAS.WAddMeshError.IndexOutOfRange: return 'IndexOutOfRange';
+    case WATLAS.WAddMeshError.InvalidFaceVertexCount: return 'InvalidFaceVertexCount';
+    case WATLAS.WAddMeshError.InvalidIndexCount: return 'InvalidIndexCount';
+    default: return 'Unknown';
+  }
+}
+
+function unwrapPrimitives(
+  primitives: Primitive[],
+  options: UnwrapOptions,
+  logger: ILogger,
+  doc: Document,
+  WATLAS: WATLASMODULE
+) {
+  const targetIndex = options.index ?? 0;
+  const targetAttribute = `TEXCOORD_${targetIndex}`;
+
+  const atlas = new WATLAS.WAtlas();
+
+  let meshCount = 0;
+  for (const prim of primitives) {
+    // Don't process primitives that already have the desired TEXCOORD index
+    // if overwrite is false.
+    if (!options.overwrite) {
+      const texcoord = prim.getAttribute(targetAttribute);
+      if (texcoord) continue;
+    }
+
+    // Always pass vertex position data
+    const position = prim.getAttribute('POSITION')!;
+    const positionData = getFloat32AttributeData(position, 3);
+
+    const meshDecl: Partial<WMeshDecl> = {
+      vertexCount: position.getCount(),
+      vertexPositionData: positionData.array,
+      vertexPositionStride: positionData.stride,
+    };
+
+    // Pass normal data if available to improve unwrapping
+    const normal = prim.getAttribute('NORMAL');
+    if (normal) {
+      const normalData = getFloat32AttributeData(normal, 3);
+      meshDecl.vertexNormalData = normalData.array;
+      meshDecl.vertexNormalStride = normalData.stride;
+    }
+
+    // Pass texcoord data from set 0 if it's available and not the set that
+    // is being generated.
+    if (options.index != 0) {
+      const texcoord = prim.getAttribute('TEXCOORD_0');
+      if (texcoord) {
+        const texcoordData = getFloat32AttributeData(texcoord, 2);
+        meshDecl.vertexUvData = texcoordData.array;
+        meshDecl.vertexUvStride = texcoordData.stride;
+      }
+    }
+
+    // Pass indices if available
+    const indices = prim.getIndices();
+    if (indices) {
+      meshDecl.indexData = indices.getArray();
+      meshDecl.indexCount = indices.getCount();
+      const indexType = indices.getComponentType();
+      switch (indexType) {
+        case Accessor.ComponentType.UNSIGNED_SHORT:
+          meshDecl.indexFormat = WATLAS.WIndexFormat.UInt16;
+          break;
+        case Accessor.ComponentType.UNSIGNED_INT:
+          meshDecl.indexFormat = WATLAS.WIndexFormat.UInt32;
+          break;
+        case Accessor.ComponentType.UNSIGNED_BYTE:
+          // Expand the Uint8 values into Uint16 for processing by xatlas
+          meshDecl.indexData = new Uint16Array(indices.getCount());
+          meshDecl.indexData.set(indices.getArray()!);
+          meshDecl.indexFormat = WATLAS.WIndexFormat.UInt16;
+          break;
+        default:
+          throw new Error(`${NAME}: Unsupported index type ${indexType}`);
+          return;
+      }
+    }
+
+    const result = atlas.addMesh(meshDecl as WMeshDecl);
+    if (result != WATLAS.WAddMeshError.Success) {
+      throw new Error(`${NAME}: Error adding mesh to atlas ${getMeshErrorString(WATLAS, result)}`);
+    }
+
+    meshCount++;
+  }
+
+  // Don't proceed if we skipped every primitive in this group.
+  if (meshCount == 0) {
+    return;
+  }
+
+  atlas.generate(
+    {} as WChartOptions,
+    {} as WPackOptions
+  );
+
+  const atlasResult: WAtlasResult = atlas.getResult();
+
+  // xatlas UVs are in texels, so they need to be normalized before saving to
+  // the glTF attribute.
+  const uScale = 1/atlasResult.width;
+  const vScale = 1/atlasResult.height;
+
+  if (atlasResult.meshCount != primitives.length) {
+    throw new Error(`${NAME}: Generated an unexpected number of atlas meshes. (got: ${atlasResult.meshCount}, expected: ${primitives.length})`);
+  }
+
+  for (let i = 0; i < atlasResult.meshCount; ++i) {
+    const prim = primitives[i];
+    const atlasMesh = atlasResult.meshes.get(i)!;
+
+    // Clean up previous TEXCOORD_* attribute, if there was any.
+    const oldTexcoord = prim.getAttribute(targetAttribute);
+    if (oldTexcoord) {
+      prim.setAttribute(targetAttribute, null);
+      if (oldTexcoord.listParents().length === 1) oldTexcoord.dispose();
+    }
+
+    // Remap Vertex attributes.
+    for (const srcAttribute of prim.listAttributes()) {
+      prim.swap(srcAttribute, remapAttribute(srcAttribute, atlasMesh));
+
+      // Clean up.
+      if (srcAttribute.listParents().length === 1) srcAttribute.dispose();
+    }
+
+    // Remap morph target vertex attributes.
+    for (const target of prim.listTargets()) {
+      for (const srcAttribute of target.listAttributes()) {
+        target.swap(srcAttribute, remapAttribute(srcAttribute, atlasMesh));
+
+        // Clean up.
+        if (srcAttribute.listParents().length === 1) srcAttribute.dispose();
+      }
+    }
+
+    // Add new TEXCOORD_* attribute.
+    const texcoord = doc.createAccessor()
+                        .setArray(new Float32Array(atlasMesh.vertexCount * 2))
+                        .setType('VEC2');
+    for (let j = 0; j < atlasMesh.vertexCount; ++j) {
+      const vertex = atlasMesh.vertexArray.get(j)!;
+      texcoord.setElement(j, [vertex.uv[0] * uScale, vertex.uv[1] * vScale]);
+    }
+    prim.setAttribute(targetAttribute, texcoord);
+
+    // The glTF spec says that if TEXCOORD_N (where N > 0) exists then
+    // TEXCOORD_N-1...TEXCOORD_0 must also exist. If any prior TEXCOORD
+    // attributes are missing, copy this attribute to satisfy that requirement.
+    for (let j = targetIndex-1; j >= 0; --j) {
+      const attibName = `TEXCOORD_${j}`;
+      if (!prim.getAttribute(attibName)) {
+        prim.setAttribute(attibName, texcoord);
+      }
+    }
+
+    // Update Indices.
+    const indexArray = new Uint32Array(atlasMesh.indexCount);
+    indexArray.set(atlasMesh.indexArray);
+
+    const newIndices = doc.createAccessor()
+                          .setArray(indexArray)
+                          .setType('SCALAR');
+
+    const indices = prim.getIndices();
+    if (indices) {
+      prim.swap(indices, newIndices);
+      if (indices.listParents().length === 1) indices.dispose();
+    } else {
+      prim.setIndices(newIndices);
+    }
+  }
+
+  atlas.delete();
+}
+
+// Returns a new attribute with the same values at as source attribute, but
+// re-ordered according to the vertex order output by xatlas to account for
+// vertex splitting.
+function remapAttribute(
+  srcAttribute: Accessor,
+  atlasMesh: any,
+): Accessor {
+  const dstAttribute = srcAttribute.clone();
+	const ArrayCtor = srcAttribute.getArray()!.constructor as new (len: number) => TypedArray;
+	dstAttribute.setArray(new ArrayCtor(atlasMesh.vertexCount * srcAttribute.getElementSize()));
+
+  const el: number[] = [];
+  for (let i = 0; i < atlasMesh.vertexCount; ++i) {
+    const vertex = atlasMesh.vertexArray.get(i);
+    dstAttribute.setElement(i, srcAttribute.getElement(vertex.xref, el));
+  }
+
+  return dstAttribute;
+}
+
+interface Float32AttributeData {
+  stride: number,
+  array: Float32Array,
+}
+
+// Returns the values of the given attribute as a Float32Array with the given
+// number of components per element
+function getFloat32AttributeData(srcAttribute: Accessor, minComponents: number): Float32AttributeData {
+  if (srcAttribute.getElementSize() >= minComponents &&
+      srcAttribute.getComponentType() == Accessor.ComponentType.FLOAT) {
+    return {
+      stride: srcAttribute.getElementSize() * Float32Array.BYTES_PER_ELEMENT,
+      array: srcAttribute.getArray()! as Float32Array,
+    }
+  }
+
+  const elementStride = Math.max(minComponents, srcAttribute.getElementSize())
+  const dstArray = new Float32Array(srcAttribute.getCount() * elementStride);
+  const el: number[] = [];
+  for (let i = 0; i < srcAttribute.getCount(); ++i) {
+    dstArray.set(srcAttribute.getElement(i, el), i * minComponents);
+  }
+
+  return {
+    stride: elementStride  * Float32Array.BYTES_PER_ELEMENT,
+    array: dstArray,
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,7 +1671,7 @@ __metadata:
     spdx-correct: "npm:~3.2.0"
     strip-ansi: "npm:~7.1.0"
     tmp: "npm:~0.2.3"
-    watlas: "npm:^0.9.1"
+    watlas: "npm:^1.0.0"
   bin:
     gltf-transform: ./bin/cli.js
   languageName: unknown
@@ -6655,7 +6655,7 @@ __metadata:
     tweakpane-plugin-thumbnail-list: "npm:^0.3.0"
     typescript: "npm:5.7.3"
     vite: "npm:^6.1.0"
-    watlas: "npm:^0.9.1"
+    watlas: "npm:^1.0.0"
   languageName: unknown
   linkType: soft
 
@@ -12785,10 +12785,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watlas@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "watlas@npm:0.9.1"
-  checksum: 10c0/5e285e46544c5bdfc6cd34e8f54de9156597d82974a887419587cb37909b5954aae88d9308b7f203b44604671a407115fc0bdc2c65faefb516ac635876b197d3
+"watlas@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "watlas@npm:1.0.0"
+  checksum: 10c0/6bb0aa41bc81d9fa4df652479fcc45dbcab0a83b790a31fa0fc880a941613ae89498014f591e57fb36548c7937d81734b7191f83297a96e195ee02f1422955b5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,7 @@ __metadata:
     spdx-correct: "npm:~3.2.0"
     strip-ansi: "npm:~7.1.0"
     tmp: "npm:~0.2.3"
+    watlas: "npm:^0.9.1"
   bin:
     gltf-transform: ./bin/cli.js
   languageName: unknown
@@ -6654,6 +6655,7 @@ __metadata:
     tweakpane-plugin-thumbnail-list: "npm:^0.3.0"
     typescript: "npm:5.7.3"
     vite: "npm:^6.1.0"
+    watlas: "npm:^0.9.1"
   languageName: unknown
   linkType: soft
 
@@ -12780,6 +12782,13 @@ __metadata:
   version: 3.0.1
   resolution: "walk-up-path@npm:3.0.1"
   checksum: 10c0/3184738e0cf33698dd58b0ee4418285b9c811e58698f52c1f025435a85c25cbc5a63fee599f1a79cb29ca7ef09a44ec9417b16bfd906b1a37c305f7aa20ee5bc
+  languageName: node
+  linkType: hard
+
+"watlas@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "watlas@npm:0.9.1"
+  checksum: 10c0/5e285e46544c5bdfc6cd34e8f54de9156597d82974a887419587cb37909b5954aae88d9308b7f203b44604671a407115fc0bdc2c65faefb516ac635876b197d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #792

Uses xatlas (https://github.com/jpcy/xatlas) to generate unique texture coordinates suitable for baking lightmaps or texture painting at the given attribute set index.

Also adds an associated `unwrap` CLI method.

This uses [my own WASM wrapper for xatlas](https://github.com/toji/watlas) (yes, yet another one) that mimics the underlying C++ API closely, exposing values like the vertex xref which are used to reconstruct all attributes after the texcoords are generated. Putting this PR together highlighted some quirks about how the wrapper works, so I'm gonna work on cleaning that up and pushing it to npm before marking this as a non-draft. Also need to add some tests for the new `unwrap` function here. I did want a chance to get some feedback on the implementation while I worked on that, though!

Happy to change up just about anything here to fit glTF-Transform conventions, address functionality concerns, etc. I'd really love to see this functionality added, as I would find it really useful and it sounds like other would too!