### PR TITLE
option to not weld - just do draco

### DIFF
--- a/packages/functions/src/draco.ts
+++ b/packages/functions/src/draco.ts
@@ -6,6 +6,7 @@ import { weld } from './weld.js';
 const NAME = 'draco';
 
 export interface DracoOptions {
+	skipWeld?: boolean;
 	method?: 'edgebreaker' | 'sequential';
 	encodeSpeed?: number;
 	decodeSpeed?: number;
@@ -18,6 +19,7 @@ export interface DracoOptions {
 }
 
 export const DRACO_DEFAULTS: Required<DracoOptions> = {
+	skipWeld: false,
 	method: 'edgebreaker',
 	encodeSpeed: 5,
 	decodeSpeed: 5,
@@ -64,7 +66,9 @@ export function draco(_options: DracoOptions = DRACO_DEFAULTS): Transform {
 	const options = assignDefaults(DRACO_DEFAULTS, _options);
 
 	return createTransform(NAME, async (document: Document): Promise<void> => {
-		await document.transform(weld());
+		if (!options.skipWeld) {
+			await document.transform(weld());
+		}
 		document
 			.createExtension(KHRDracoMeshCompression)
 			.setRequired(true)


### PR DESCRIPTION
<img width="431" height="171" alt="image" src="https://github.com/user-attachments/assets/11bac8bc-627a-4b82-b39c-d8ced23c1144" />
We have this scenario where we don't want to remove unused stuff, but still want the mesh to be compressed with Draco.
So, we need Draco to not weld at the start of a Draco compression.
