### PR TITLE
🐛(view/material): fix emissiveIntensity when requesting material's threejs obj

### DIFF
--- a/packages/view/src/subjects/MaterialSubject.ts
+++ b/packages/view/src/subjects/MaterialSubject.ts
@@ -433,6 +433,16 @@ export class MaterialSubject extends Subject<MaterialDef, Material> {
 		if (normalScale !== target.normalScale.x) {
 			target.normalScale.setScalar(normalScale);
 		}
+
+		// KHR_materials_emissive_strength
+		const emissiveStrength = def.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
+		if (emissiveStrength) {
+			if (emissiveStrength.getEmissiveStrength() !== target.emissiveIntensity) {
+				target.emissiveIntensity = emissiveStrength.getEmissiveStrength();
+			}
+		} else {
+			target.emissiveIntensity = 1.0;
+		}
 	}
 
 	private _updatePhysical(target: MeshPhysicalMaterial) {
@@ -472,16 +482,6 @@ export class MaterialSubject extends Subject<MaterialDef, Material> {
 			}
 		} else {
 			target.clearcoat = 0;
-		}
-
-		// KHR_materials_emissive_strength
-		const emissiveStrength = def.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
-		if (emissiveStrength) {
-			if (emissiveStrength.getEmissiveStrength() !== target.emissiveIntensity) {
-				target.emissiveIntensity = emissiveStrength.getEmissiveStrength();
-			}
-		} else {
-			target.emissiveIntensity = 1.0;
 		}
 
 		// KHR_materials_ior


### PR DESCRIPTION
Fixes https://github.com/donmccurdy/glTF-Transform/issues/1689

In case of `KHR_materials_emissive_strength`, `getShadingModel` returns to be a standard material but currently, `emissiveIntensity` doesn't update unless its a physical material. I've updated it to compute `emissiveIntensity` for a standard material.