### PR TITLE
Update `ArrayBuffer` types to support TypeScript 5.9

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1063,6 +1063,8 @@ compute MikkTSpace tangents at runtime.
 	.action(({ args, options, logger }) =>
 		Session.create(io, logger, args.input, args.output).transform(
 			unweld(),
+			// @ts-expect-error
+			// TODO: Update the types here for TypeScript 5.9: https://github.com/donmccurdy/mikktspace-wasm
 			tangents({ generateTangents: mikktspace.generateTangents, ...options }),
 			weld(),
 		),

--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -247,7 +247,7 @@ export const toktx = function (options: ETC1SOptions | UASTCOptions): Transform 
 					logger.debug(`${prefix}: Resizing ${srcSize.join('x')} → ${dstSize.join('x')}px`);
 					instance.resize(dstSize[0], dstSize[1], { fit: 'fill', kernel: options.resizeFilter });
 
-					srcImage = BufferUtils.toView(await instance.toBuffer());
+					srcImage = BufferUtils.toView((await instance.toBuffer()) as Buffer<ArrayBuffer>);
 					srcExtension = 'png';
 					srcMimeType = 'image/png';
 				}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -81,7 +81,13 @@ export const GLB_BUFFER = '@glb.bin';
  * Abstraction representing any one of the typed array classes supported by glTF and JavaScript.
  * @hidden
  */
-export type TypedArray = Float32Array | Uint32Array | Uint16Array | Uint8Array | Int16Array | Int8Array;
+export type TypedArray =
+	| Float32Array<ArrayBuffer>
+	| Uint32Array<ArrayBuffer>
+	| Uint16Array<ArrayBuffer>
+	| Uint8Array<ArrayBuffer>
+	| Int16Array<ArrayBuffer>
+	| Int8Array<ArrayBuffer>;
 
 /**
  * Abstraction representing the typed array constructors supported by glTF and JavaScript.

--- a/packages/core/src/io/deno-io.ts
+++ b/packages/core/src/io/deno-io.ts
@@ -42,9 +42,15 @@ export class DenoIO extends PlatformIO {
 		this._path = path as Path;
 	}
 
-	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array>;
+	protected async readURI(
+		uri: string,
+		type: 'view',
+	): Promise<Uint8Array<ArrayBuffer>>;
 	protected async readURI(uri: string, type: 'text'): Promise<string>;
-	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string> {
+	protected async readURI(
+		uri: string,
+		type: 'view' | 'text',
+	): Promise<Uint8Array<ArrayBuffer> | string> {
 		switch (type) {
 			case 'view':
 				return Deno.readFile(uri);

--- a/packages/core/src/io/node-io.ts
+++ b/packages/core/src/io/node-io.ts
@@ -81,9 +81,9 @@ export class NodeIO extends PlatformIO {
 		return this;
 	}
 
-	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array>;
+	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array<ArrayBuffer>>;
 	protected async readURI(uri: string, type: 'text'): Promise<string>;
-	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string> {
+	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array<ArrayBuffer> | string> {
 		await this.init();
 		if (HTTPUtils.isAbsoluteURL(uri)) {
 			if (!this._fetchEnabled || !this._fetch) {

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -71,9 +71,15 @@ export abstract class PlatformIO {
 	 * Abstract.
 	 */
 
-	protected abstract readURI(uri: string, type: 'view'): Promise<Uint8Array>;
+	protected abstract readURI(
+		uri: string,
+		type: 'view',
+	): Promise<Uint8Array<ArrayBuffer>>;
 	protected abstract readURI(uri: string, type: 'text'): Promise<string>;
-	protected abstract readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string>;
+	protected abstract readURI(
+		uri: string,
+		type: 'view' | 'text',
+	): Promise<Uint8Array | string>;
 
 	protected abstract resolve(base: string, path: string): string;
 	protected abstract dirname(uri: string): string;
@@ -253,7 +259,7 @@ export abstract class PlatformIO {
 	}
 
 	/** Internal version of binaryToJSON; does not warn about external resources. */
-	private _binaryToJSON(glb: Uint8Array): JSONDocument {
+	private _binaryToJSON(glb: Uint8Array<ArrayBuffer>): JSONDocument {
 		// Decode and verify GLB header.
 		if (!isGLB(glb)) {
 			throw new Error('Invalid glTF 2.0 binary.');

--- a/packages/core/src/io/platform-io.ts
+++ b/packages/core/src/io/platform-io.ts
@@ -152,7 +152,7 @@ export abstract class PlatformIO {
 	}
 
 	/** Converts a {@link Document} to a GLB-formatted Uint8Array. */
-	public async writeBinary(doc: Document): Promise<Uint8Array> {
+	public async writeBinary(doc: Document): Promise<Uint8Array<ArrayBuffer>> {
 		const { json, resources } = await this.writeJSON(doc, { format: Format.GLB });
 
 		const header = new Uint32Array([0x46546c67, 2, 12]);

--- a/packages/core/src/io/reader-context.ts
+++ b/packages/core/src/io/reader-context.ts
@@ -23,7 +23,7 @@ import type { GLTF } from '../types/gltf.js';
  */
 export class ReaderContext {
 	public buffers: Buffer[] = [];
-	public bufferViews: Uint8Array[] = [];
+	public bufferViews: Uint8Array<ArrayBuffer>[] = [];
 	public bufferViewBuffers: Buffer[] = [];
 	public accessors: Accessor[] = [];
 	public textures: Texture[] = [];

--- a/packages/core/src/io/web-io.ts
+++ b/packages/core/src/io/web-io.ts
@@ -38,9 +38,9 @@ export class WebIO extends PlatformIO {
 		this._fetchConfig = fetchConfig;
 	}
 
-	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array>;
+	protected async readURI(uri: string, type: 'view'): Promise<Uint8Array<ArrayBuffer>>;
 	protected async readURI(uri: string, type: 'text'): Promise<string>;
-	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array | string> {
+	protected async readURI(uri: string, type: 'view' | 'text'): Promise<Uint8Array<ArrayBuffer> | string> {
 		const response = await fetch(uri, this._fetchConfig);
 		switch (type) {
 			case 'view':

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -172,7 +172,7 @@ export class WriterContext {
 		return accessorDef;
 	}
 
-	public createImageData(imageDef: GLTF.IImage, data: Uint8Array, texture: Texture): void {
+	public createImageData(imageDef: GLTF.IImage, data: Uint8Array<ArrayBuffer>, texture: Texture): void {
 		if (this.options.format === Format.GLB) {
 			this.imageBufferViews.push(data);
 			imageDef.bufferView = this.jsonDoc.json.bufferViews!.length;
@@ -188,7 +188,7 @@ export class WriterContext {
 		}
 	}
 
-	public assignResourceURI(uri: string, data: Uint8Array, throwOnConflict: boolean): void {
+	public assignResourceURI(uri: string, data: Uint8Array<ArrayBuffer>, throwOnConflict: boolean): void {
 		const resources = this.jsonDoc.resources;
 
 		// https://github.com/KhronosGroup/glTF/issues/2446

--- a/packages/core/src/json-document.ts
+++ b/packages/core/src/json-document.ts
@@ -37,5 +37,5 @@ import type { GLTF } from './types/gltf.js';
  */
 export interface JSONDocument {
 	json: GLTF.IGLTF;
-	resources: { [s: string]: Uint8Array };
+	resources: { [s: string]: Uint8Array<ArrayBuffer> };
 }

--- a/packages/core/src/properties/texture.ts
+++ b/packages/core/src/properties/texture.ts
@@ -3,7 +3,7 @@ import { BufferUtils, FileUtils, ImageUtils } from '../utils/index.js';
 import { ExtensibleProperty, type IExtensibleProperty } from './extensible-property.js';
 
 interface ITexture extends IExtensibleProperty {
-	image: Uint8Array | null;
+	image: Uint8Array<ArrayBuffer> | null;
 	mimeType: string;
 	uri: string;
 }
@@ -79,7 +79,7 @@ export class Texture extends ExtensibleProperty<ITexture> {
 	 */
 
 	/** Returns the raw image data for this texture. */
-	public getImage(): Uint8Array | null {
+	public getImage(): Uint8Array<ArrayBuffer> | null {
 		return this.get('image');
 	}
 

--- a/packages/core/src/utils/buffer-utils.ts
+++ b/packages/core/src/utils/buffer-utils.ts
@@ -7,7 +7,7 @@ import type { TypedArray } from '../constants.js';
  */
 export class BufferUtils {
 	/** Creates a byte array from a Data URI. */
-	static createBufferFromDataURI(dataURI: string): Uint8Array {
+	static createBufferFromDataURI(dataURI: string): Uint8Array<ArrayBuffer> {
 		if (typeof Buffer === 'undefined') {
 			// Browser.
 			const byteString = atob(dataURI.split(',')[1]);
@@ -37,7 +37,7 @@ export class BufferUtils {
 	/**
 	 * Concatenates N byte arrays.
 	 */
-	static concat(arrays: Uint8Array[]): Uint8Array {
+	static concat(arrays: Uint8Array[]): Uint8Array<ArrayBuffer> {
 		let totalByteLength = 0;
 		for (const array of arrays) {
 			totalByteLength += array.byteLength;
@@ -108,18 +108,26 @@ export class BufferUtils {
 	 * ```
 	 *
 	 */
-	static toView(a: TypedArray, byteOffset = 0, byteLength: number = Infinity): Uint8Array {
-		return new Uint8Array(a.buffer, a.byteOffset + byteOffset, Math.min(a.byteLength, byteLength));
+	static toView(
+		a: TypedArray,
+		byteOffset = 0,
+		byteLength: number = Infinity,
+	): Uint8Array<ArrayBuffer> {
+		return new Uint8Array<ArrayBuffer>(
+			a.buffer,
+			a.byteOffset + byteOffset,
+			Math.min(a.byteLength, byteLength),
+		);
 	}
 
 	/** @internal */
 	static assertView(view: null): null;
-	static assertView(view: Uint8Array): Uint8Array;
-	static assertView(view: Uint8Array | null): Uint8Array | null;
-	static assertView(view: Uint8Array | null): Uint8Array | null {
+	static assertView(view: Uint8Array): Uint8Array<ArrayBuffer>;
+	static assertView(view: Uint8Array | null): Uint8Array<ArrayBuffer> | null;
+	static assertView(view: Uint8Array | null): Uint8Array<ArrayBuffer> | null {
 		if (view && !ArrayBuffer.isView(view)) {
 			throw new Error(`Method requires Uint8Array parameter; received "${typeof view}".`);
 		}
-		return view as Uint8Array;
+		return view as Uint8Array<ArrayBuffer>;
 	}
 }

--- a/packages/extensions/src/ext-meshopt-compression/encoder.ts
+++ b/packages/extensions/src/ext-meshopt-compression/encoder.ts
@@ -44,7 +44,7 @@ export function prepareAccessor(
 				result.byteStride = accessor.getElementSize() * 4;
 				result.componentType = FLOAT;
 				result.normalized = false;
-				result.array = encoder.encodeFilterExp(array, accessor.getCount(), result.byteStride, bits);
+				result.array = encoder.encodeFilterExp(array, accessor.getCount(), result.byteStride, bits) as Uint8Array<ArrayBuffer>;
 				break;
 
 			case MeshoptFilter.OCTAHEDRAL: // → four 8- or 16-bit normalized values.
@@ -52,14 +52,14 @@ export function prepareAccessor(
 				result.componentType = bits > 8 ? SHORT : BYTE;
 				result.normalized = true;
 				array = accessor.getElementSize() === 3 ? padNormals(array) : array;
-				result.array = encoder.encodeFilterOct(array, accessor.getCount(), result.byteStride, bits);
+				result.array = encoder.encodeFilterOct(array, accessor.getCount(), result.byteStride, bits) as Uint8Array<ArrayBuffer>;
 				break;
 
 			case MeshoptFilter.QUATERNION: // → four 16-bit normalized values.
 				result.byteStride = 8;
 				result.componentType = SHORT;
 				result.normalized = true;
-				result.array = encoder.encodeFilterQuat(array, accessor.getCount(), result.byteStride, bits);
+				result.array = encoder.encodeFilterQuat(array, accessor.getCount(), result.byteStride, bits) as Uint8Array<ArrayBuffer>;
 				break;
 
 			default:

--- a/packages/extensions/src/khr-draco-mesh-compression/decoder.ts
+++ b/packages/extensions/src/khr-draco-mesh-compression/decoder.ts
@@ -31,12 +31,12 @@ export function decodeGeometry(decoder: Decoder, data: Uint8Array): Mesh {
 	}
 }
 
-export function decodeIndex(decoder: Decoder, mesh: Mesh): Uint16Array | Uint32Array {
+export function decodeIndex(decoder: Decoder, mesh: Mesh): Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> {
 	const numFaces = mesh.num_faces();
 	const numIndices = numFaces * 3;
 
 	let ptr: number;
-	let indices: Uint16Array | Uint32Array;
+	let indices: Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer>;
 
 	if (mesh.num_points() <= 65534) {
 		const byteLength = numIndices * Uint16Array.BYTES_PER_ELEMENT;
@@ -70,7 +70,7 @@ export function decodeAttribute(
 
 	const ptr = decoderModule._malloc(byteLength);
 	decoder.GetAttributeDataArrayForAllPoints(mesh, attribute, dataType, byteLength, ptr);
-	const array: TypedArray = new ArrayCtor(decoderModule.HEAPF32.buffer, ptr, numValues).slice();
+	const array: TypedArray = new ArrayCtor(decoderModule.HEAPF32.buffer as ArrayBuffer, ptr, numValues).slice();
 	decoderModule._free(ptr);
 
 	return array;

--- a/packages/functions/src/compact-primitive.ts
+++ b/packages/functions/src/compact-primitive.ts
@@ -148,13 +148,13 @@ export function compactAttribute(
  * @hidden
  * @internal
  */
-function createCompactPlan(prim: Primitive): [Uint32Array, number] {
+function createCompactPlan(prim: Primitive): [Uint32Array<ArrayBuffer>, number] {
 	const srcVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
 
 	const indices = prim.getIndices();
 	const indicesArray = indices ? indices.getArray() : null;
 	if (!indices || !indicesArray) {
-		return [createIndices(srcVertexCount, 1_000_000) as Uint32Array, srcVertexCount];
+		return [createIndices(srcVertexCount, 1_000_000) as Uint32Array<ArrayBuffer>, srcVertexCount];
 	}
 
 	const remap = new Uint32Array(srcVertexCount).fill(EMPTY_U32);

--- a/packages/functions/src/dequantize.ts
+++ b/packages/functions/src/dequantize.ts
@@ -103,7 +103,7 @@ export function dequantizeAttributeArray(
 	srcArray: TypedArray,
 	componentType: GLTF.AccessorComponentType,
 	normalized: boolean,
-): Float32Array {
+): Float32Array<ArrayBuffer> {
 	const dstArray = new Float32Array(srcArray.length);
 
 	for (let i = 0, il = srcArray.length; i < il; i++) {

--- a/packages/functions/src/join-primitives.ts
+++ b/packages/functions/src/join-primitives.ts
@@ -63,7 +63,7 @@ export function joinPrimitives(prims: Primitive[], _options: JoinPrimitiveOption
 		}
 	}
 
-	const primRemaps = [] as Uint32Array[]; // remap[srcIndex] → dstIndex, by prim
+	const primRemaps = [] as Uint32Array<ArrayBuffer>[]; // remap[srcIndex] → dstIndex, by prim
 	const primVertexCounts = new Uint32Array(prims.length); // vertex count, by prim
 
 	let dstVertexCount = 0;

--- a/packages/functions/src/reorder.ts
+++ b/packages/functions/src/reorder.ts
@@ -87,7 +87,7 @@ export function reorder(_options: ReorderOptions): Transform {
 			// Update affected primitives.
 			for (const srcAttribute of plan.indicesToAttributes.get(srcIndices)) {
 				const dstAttribute = shallowCloneAccessor(document, srcAttribute);
-				compactAttribute(srcAttribute, srcIndices, remap, dstAttribute, unique);
+				compactAttribute(srcAttribute, srcIndices, remap as Uint32Array<ArrayBuffer>, dstAttribute, unique);
 
 				for (const prim of plan.indicesToPrimitives.get(srcIndices)) {
 					if (prim.getIndices() === srcIndices) {

--- a/packages/functions/src/simplify.ts
+++ b/packages/functions/src/simplify.ts
@@ -180,7 +180,7 @@ export function simplifyPrimitive(prim: Primitive, _options: SimplifyOptions): P
 
 	// (4) Assign subset of indexes; compact primitive.
 
-	prim.setIndices(shallowCloneAccessor(document, srcIndices).setArray(dstIndicesArray));
+	prim.setIndices(shallowCloneAccessor(document, srcIndices).setArray(dstIndicesArray as Uint32Array<ArrayBuffer>));
 	if (srcIndices.listParents().length === 1) srcIndices.dispose();
 	compactPrimitive(prim);
 
@@ -231,7 +231,7 @@ function _simplifyPoints(document: Document, prim: Primitive, options: Required<
 
 	for (const srcAttribute of deepListAttributes(prim)) {
 		const dstAttribute = shallowCloneAccessor(document, srcAttribute);
-		compactAttribute(srcAttribute, null, remap, dstAttribute, unique);
+		compactAttribute(srcAttribute, null, remap as Uint32Array<ArrayBuffer>, dstAttribute, unique);
 		deepSwapAttribute(prim, srcAttribute, dstAttribute);
 		if (srcAttribute.listParents().length === 1) srcAttribute.dispose();
 	}

--- a/packages/functions/src/tangents.ts
+++ b/packages/functions/src/tangents.ts
@@ -19,7 +19,7 @@ export interface TangentsOptions {
 	 * [mikktspace](https://github.com/donmccurdy/mikktspace-wasm) library, which is not
 	 * included by default.
 	 */
-	generateTangents?: (pos: Float32Array, norm: Float32Array, uv: Float32Array) => Float32Array;
+	generateTangents?: (pos: Float32Array, norm: Float32Array, uv: Float32Array) => Float32Array<ArrayBuffer>;
 	/** Whether to overwrite existing `TANGENT` attributes. */
 	overwrite?: boolean;
 }

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -338,7 +338,7 @@ async function _encodeWithSharp(
 		instance.resize(dstSize[0], dstSize[1], { fit: 'fill', kernel: options.resizeFilter });
 	}
 
-	return BufferUtils.toView(await instance.toBuffer());
+	return BufferUtils.toView((await instance.toBuffer()) as Buffer<ArrayBuffer>);
 }
 
 async function _encodeWithNdarrayPixels(

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -234,14 +234,14 @@ export function shallowCloneAccessor(document: Document, accessor: Accessor): Ac
 }
 
 /** @hidden */
-export function createIndices(count: number, maxIndex: number = count): Uint16Array | Uint32Array {
+export function createIndices(count: number, maxIndex: number = count): Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> {
 	const array = createIndicesEmpty(count, maxIndex);
 	for (let i = 0; i < array.length; i++) array[i] = i;
 	return array;
 }
 
 /** @hidden */
-export function createIndicesEmpty(count: number, maxIndex: number = count): Uint16Array | Uint32Array {
+export function createIndicesEmpty(count: number, maxIndex: number = count): Uint16Array<ArrayBuffer> | Uint32Array<ArrayBuffer> {
 	return maxIndex <= 65534 ? new Uint16Array(count) : new Uint32Array(count);
 }
 

--- a/packages/global.d.ts
+++ b/packages/global.d.ts
@@ -49,6 +49,6 @@ declare module 'gl-matrix/quat2' {
 /** Deno */
 
 declare const Deno: {
-	readFile: (path: string) => Promise<Uint8Array>;
+	readFile: (path: string) => Promise<Uint8Array<ArrayBuffer>>;
 	readTextFile: (path: string) => Promise<string>;
 };

--- a/packages/view/src/ImageProvider.ts
+++ b/packages/view/src/ImageProvider.ts
@@ -66,13 +66,13 @@ export class DefaultImageProvider implements ImageProvider {
 		const image = textureDef.getImage()!;
 		const mimeType = textureDef.getMimeType();
 
-		let texture = this._cache.get(image);
+		let texture = this._cache.get(image.buffer);
 
 		if (texture) return texture;
 
-		texture = mimeType === 'image/ktx2' ? await this._loadKTX2Image(image) : await this._loadImage(image, mimeType);
+		texture = mimeType === 'image/ktx2' ? await this._loadKTX2Image(image.buffer) : await this._loadImage(image.buffer, mimeType);
 
-		this._cache.set(image, texture);
+		this._cache.set(image.buffer, texture);
 		return texture;
 	}
 

--- a/packages/view/src/subjects/TextureSubject.ts
+++ b/packages/view/src/subjects/TextureSubject.ts
@@ -19,7 +19,7 @@ export class TextureSubject extends Subject<TextureDef, Texture> {
 			value.name = def.getName();
 		}
 
-		const image = def.getImage() as ArrayBuffer;
+		const image = def.getImage()?.buffer as ArrayBuffer;
 		if (image !== this._image) {
 			this._image = image;
 			if (this.value !== this._documentView.imageProvider.loadingTexture) {


### PR DESCRIPTION
When trying to upgrade a project from TypeScript v5.8 to v5.9, I hit the issue described here: https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#lib.d.ts-changes

This implements the suggested fix described there in order to make the library compatible with TypeScript 5.9.