### PR TITLE
feat(functions): Add 'chromaSubsampling' option to textureCompress

### DIFF
--- a/packages/functions/src/get-texture-color-space.ts
+++ b/packages/functions/src/get-texture-color-space.ts
@@ -23,7 +23,7 @@ const SRGB_PATTERN = /color|emissive|diffuse/i;
  * getTextureColorSpace(normalTexture); // → null
  * ```
  */
-export function getTextureColorSpace(texture: Texture): string | null {
+export function getTextureColorSpace(texture: Texture): 'srgb' | null {
 	const graph = texture.getGraph();
 	const edges = graph.listParentEdges(texture);
 	const isSRGB = edges.some((edge) => {

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -171,7 +171,6 @@ export function textureCompress(_options: TextureCompressOptions): Transform {
 			textures.map(async (texture, textureIndex) => {
 				const slots = listTextureSlots(texture);
 				const channels = getTextureChannelMask(texture);
-				const colorSpace = getTextureColorSpace(texture);
 				const textureLabel =
 					texture.getURI() ||
 					texture.getName() ||
@@ -205,9 +204,7 @@ export function textureCompress(_options: TextureCompressOptions): Transform {
 				const srcImage = texture.getImage()!;
 				const srcByteLength = srcImage.byteLength;
 
-				const chromaSubsampling = options.chromaSubsampling || (colorSpace === 'srgb' ? '4:2:0' : '4:4:4');
-
-				await compressTexture(texture, { ...options, chromaSubsampling });
+				await compressTexture(texture, options);
 
 				const dstImage = texture.getImage()!;
 				const dstByteLength = dstImage.byteLength;
@@ -275,14 +272,16 @@ export async function compressTexture(texture: Texture, _options: CompressTextur
 
 	const srcURI = texture.getURI();
 	const srcFormat = getFormat(texture);
+	const colorSpace = getTextureColorSpace(texture);
 	const dstFormat = options.targetFormat || srcFormat;
 	const srcMimeType = texture.getMimeType();
 	const dstMimeType = `image/${dstFormat}`;
+	const chromaSubsampling = options.chromaSubsampling || (colorSpace === 'srgb' ? '4:2:0' : '4:4:4');
 
 	const srcImage = texture.getImage()!;
 	const dstImage = encoder
-		? await _encodeWithSharp(srcImage, srcMimeType, dstMimeType, options)
-		: await _encodeWithNdarrayPixels(srcImage, srcMimeType, dstMimeType, options);
+		? await _encodeWithSharp(srcImage, srcMimeType, dstMimeType, { ...options, chromaSubsampling })
+		: await _encodeWithNdarrayPixels(srcImage, srcMimeType, dstMimeType, { ...options, chromaSubsampling });
 
 	const srcByteLength = srcImage.byteLength;
 	const dstByteLength = dstImage.byteLength;

--- a/packages/functions/src/texture-compress.ts
+++ b/packages/functions/src/texture-compress.ts
@@ -91,7 +91,7 @@ export interface TextureCompressOptions {
 	 * Allows lower resolution for chroma than for luma, reducing file size. For
 	 * non-color textures such as normal maps, the chroma/luma distinction does
 	 * not apply, and chroma subsampling should be disabled. Options are '4:4:4'
-	 * (off) and '4:2:0' (on). WebP and AVIF only. Default: auto.
+	 * (off) and '4:2:0' (on). JPEG and AVIF only. Default: auto.
 	 */
 	chromaSubsampling?: '4:2:0' | '4:4:4';
 

--- a/packages/functions/test/texture-compress.test.ts
+++ b/packages/functions/test/texture-compress.test.ts
@@ -50,7 +50,16 @@ test('size increase', async (t) => {
 	const document = new Document().setLogger(logger);
 	const texture = document.createTexture('AVIF').setImage(ORIGINAL_AVIF).setMimeType('image/avif');
 	await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i, targetFormat: 'avif' }));
-	t.deepEqual(calls, [['toFormat', ['avif', { quality: undefined, effort: undefined, lossless: false, chromaSubsampling: '4:4:4' }]]], '1 call');
+	t.deepEqual(
+		calls,
+		[
+			[
+				'toFormat',
+				['avif', { quality: undefined, effort: undefined, lossless: false, chromaSubsampling: '4:4:4' }],
+			],
+		],
+		'1 call',
+	);
 	t.is(texture.getImage(), ORIGINAL_AVIF, 'file size not increased');
 });
 

--- a/packages/functions/test/texture-compress.test.ts
+++ b/packages/functions/test/texture-compress.test.ts
@@ -50,7 +50,7 @@ test('size increase', async (t) => {
 	const document = new Document().setLogger(logger);
 	const texture = document.createTexture('AVIF').setImage(ORIGINAL_AVIF).setMimeType('image/avif');
 	await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i, targetFormat: 'avif' }));
-	t.deepEqual(calls, [['toFormat', ['avif', { quality: undefined, effort: undefined, lossless: false }]]], '1 call');
+	t.deepEqual(calls, [['toFormat', ['avif', { quality: undefined, effort: undefined, lossless: false, chromaSubsampling: '4:4:4' }]]], '1 call');
 	t.is(texture.getImage(), ORIGINAL_AVIF, 'file size not increased');
 });
 
@@ -64,7 +64,7 @@ test('original formats', async (t) => {
 	t.deepEqual(
 		calls,
 		[
-			['toFormat', ['jpeg', { quality: undefined }]],
+			['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
 			['toFormat', ['png', { quality: undefined, effort: undefined }]],
 		],
 		'2 calls',
@@ -112,8 +112,8 @@ test('jpeg', async (t) => {
 	t.deepEqual(
 		calls,
 		[
-			['toFormat', ['jpeg', { quality: undefined }]],
-			['toFormat', ['jpeg', { quality: undefined }]],
+			['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
+			['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
 		],
 		'2 calls',
 	);


### PR DESCRIPTION
Default will be '4:2:0' for color textures and '4:4:4' for non-color textures. Available for JPEG and AVIF only, at this time. Not currently exposed on the CLI, as the defaults are expected to be enough in most cases, but could be added in the future.

- Fixes #1710 

#### PR Dependency Tree


* **PR #1713** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)