### PR TITLE
Add support for extras in samplerDef

### DIFF
--- a/packages/core/src/io/reader-context.ts
+++ b/packages/core/src/io/reader-context.ts
@@ -66,5 +66,8 @@ export class ReaderContext {
 		if (samplerDef.wrapT !== undefined) {
 			textureInfo.setWrapT(samplerDef.wrapT);
 		}
+		if (samplerDef.extras !== undefined) {
+			textureInfo.setSamplerExtras(samplerDef.extras);
+		}
 	}
 }

--- a/packages/core/src/io/writer-context.ts
+++ b/packages/core/src/io/writer-context.ts
@@ -102,6 +102,10 @@ export class WriterContext {
 			wrapT: textureInfo.getWrapT(),
 		} as GLTF.ISampler;
 
+		if (Object.keys(textureInfo.getSamplerExtras()).length > 0) {
+			samplerDef.extras = textureInfo.getSamplerExtras();
+		}
+
 		const samplerKey = JSON.stringify(samplerDef);
 		if (!this.samplerDefIndexMap.has(samplerKey)) {
 			this.samplerDefIndexMap.set(samplerKey, this.jsonDoc.json.samplers!.length);

--- a/packages/core/src/properties/texture-info.ts
+++ b/packages/core/src/properties/texture-info.ts
@@ -10,6 +10,7 @@ interface ITextureInfo extends IExtensibleProperty {
 	minFilter: GLTF.TextureMinFilter | null;
 	wrapS: GLTF.TextureWrapMode;
 	wrapT: GLTF.TextureWrapMode;
+	samplerExtras: Record<string, unknown>;
 }
 
 /**
@@ -85,6 +86,7 @@ export class TextureInfo extends ExtensibleProperty<ITextureInfo> {
 			minFilter: null,
 			wrapS: TextureInfo.WrapMode.REPEAT,
 			wrapT: TextureInfo.WrapMode.REPEAT,
+			samplerExtras: {},
 		});
 	}
 
@@ -148,5 +150,15 @@ export class TextureInfo extends ExtensibleProperty<ITextureInfo> {
 	/** Sets the T (V) wrapping mode for UVs used by the texture. */
 	public setWrapT(wrapT: GLTF.TextureWrapMode): this {
 		return this.set('wrapT', wrapT);
+	}
+
+	/** Returns the extras property of the sampler this texture info is mapped to. */
+	public getSamplerExtras(): Record<string, unknown> {
+		return this.get('samplerExtras');
+	}
+
+	/** Sets the extras property of the sampler this texture info is mapped to. */
+	public setSamplerExtras(extras: Record<string, unknown>): this {
+		return this.set('samplerExtras', extras) as this;
 	}
 }

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -113,6 +113,24 @@ test('textureInfo extras', async (t) => {
 	t.deepEqual(rtMaterial.getBaseColorTextureInfo()!.getExtras(), { textureInfoID: 12345 }, 'roundtrip');
 });
 
+test('sampler extras', async (t) => {
+	const io = await createPlatformIO();
+	const document = new Document();
+	document.createBuffer();
+	const texture = document
+		.createTexture('A')
+		.setExtras({ foo: 1, bar: 2 })
+		.setImage(new Uint8Array(10))
+		.setMimeType('image/png');
+	const material = document.createMaterial().setBaseColorTexture(texture);
+	material.getBaseColorTextureInfo()!.setSamplerExtras({ textureSamplerID: 12345 });
+	const doc2 = await io.readJSON(await io.writeJSON(document));
+	const rtMaterial = doc2.getRoot().listMaterials()[0];
+
+	t.deepEqual(material.getBaseColorTextureInfo()!.getSamplerExtras(), { textureSamplerID: 12345 }, 'storage');
+	t.deepEqual(rtMaterial.getBaseColorTextureInfo()!.getSamplerExtras(), { textureSamplerID: 12345 }, 'roundtrip');
+});
+
 test('padding', async (t) => {
 	// Ensure that buffer views are padded to 8-byte boundaries. See:
 	// https://github.com/KhronosGroup/glTF/issues/1935


### PR DESCRIPTION
Fixes #645
Related #646

Thanks for adding support for extras in TextureInfo earlier, but since there is a unique TextureInfo for an image attached to each material, its not ideal for storing three.js `Texture.userData`. It makes more sense to store them with either `Sampler` or `Texture` in glTF, otherwise it will be duplicated.

Since gltf-transform doesn't have a separate class for gltf Sampler, I have just added `samplerExtras` property  to TextureInfo, which is set like the other sampler properties. I am assuming it wont be cloned internally somewhere, so all TextureInfo share the same when the sampler is shared.

Since gltf-transform doesn't have a class that corresponds directly to Texture in glTF, we can also support extras there in the same way by adding it to Texture(which is glTF Image) as `textureExtras` or something.  

This is required as gltf files with extras in all Sampler, Texture and Image are valid and should be stored separately, otherwise the data is lost when opening and processing the files in different softwares/cli that use gltf-transform internally.

Open to any other ideas as well.

Thanks