### PR TITLE
chore(deps): Update to property-graph v4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "path": false
   },
   "dependencies": {
-    "property-graph": "^4.0.0-alpha.3"
+    "property-graph": "^4.0.0"
   },
   "mangle": {
     "regex": "^_"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,7 +1707,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@gltf-transform/core@workspace:packages/core"
   dependencies:
-    property-graph: "npm:^4.0.0-alpha.3"
+    property-graph: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -10502,10 +10502,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"property-graph@npm:^4.0.0-alpha.3":
-  version: 4.0.0-alpha.3
-  resolution: "property-graph@npm:4.0.0-alpha.3"
-  checksum: 10c0/08967ba1134907f4bd92cb7dab17b053fd6c3eac19dc13f1855aa5f3798aab1b11ec5cf7b02b1702b146a1e6e14944776be88bfd38de8fd2f7cd42292faf508b
+"property-graph@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "property-graph@npm:4.0.0"
+  checksum: 10c0/912047db311a903ec062c11681879998397a60fc6e723a475cb0956ecb6769d72792f0e653bc9a0ea7d5409b13eb03d5b3134ff8a03640d1c3614b4d3145c158
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes:

- `property-graph` is now ESM-only
- Modernized `property-graph` build process and devDependencies 

#### PR Dependency Tree


* **PR #1754** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)