### PR TITLE
perf(functions): Refactor dedup() using Property#toHash()

### DIFF
--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -8,6 +8,7 @@ import {
 	type Texture,
 	type Transform,
 } from '@gltf-transform/core';
+import { hashProperty } from './hash-property.js';
 import { assignDefaults, createTransform, deepListAttributes } from './utils.js';
 
 const NAME = 'dedup';
@@ -135,7 +136,7 @@ function dedupProperties<T extends Property>(
 	const duplicates = new Set<T>();
 
 	for (const src of srcProperties) {
-		const hash = src.toHash({ skip, cache, depth });
+		const hash = hashProperty(src, { skip, cache, depth });
 
 		// (1) If no properties have the same hash, keep 'src'.
 		if (!dstProperties.has(hash)) {

--- a/packages/functions/src/dedup.ts
+++ b/packages/functions/src/dedup.ts
@@ -1,11 +1,8 @@
 import {
 	type Accessor,
-	BufferUtils,
 	type Document,
 	type Material,
 	type Mesh,
-	Primitive,
-	type PrimitiveTarget,
 	type Property,
 	PropertyType,
 	Root,
@@ -13,7 +10,7 @@ import {
 	type Texture,
 	type Transform,
 } from '@gltf-transform/core';
-import { assignDefaults, createTransform, shallowEqualsArray } from './utils.js';
+import { assignDefaults, createTransform, deepListAttributes, shallowEqualsArray } from './utils.js';
 
 const NAME = 'dedup';
 
@@ -66,252 +63,188 @@ export function dedup(_options: DedupOptions = DEDUP_DEFAULTS): Transform {
 	return createTransform(NAME, (document: Document): void => {
 		const logger = document.getLogger();
 
-		if (propertyTypes.has(PropertyType.ACCESSOR)) dedupAccessors(document);
-		if (propertyTypes.has(PropertyType.TEXTURE)) dedupImages(document, options);
-		if (propertyTypes.has(PropertyType.MATERIAL)) dedupMaterials(document, options);
-		if (propertyTypes.has(PropertyType.MESH)) dedupMeshes(document, options);
-		if (propertyTypes.has(PropertyType.SKIN)) dedupSkins(document, options);
+		const cache = new Map<Property, number>();
+
+		// console.time('ACCESSOR');
+		if (propertyTypes.has(PropertyType.ACCESSOR)) dedupAccessors(document, cache);
+		// console.timeEnd('ACCESSOR');
+
+		// console.time('TEXTURE');
+		if (propertyTypes.has(PropertyType.TEXTURE)) dedupImages(document, cache, options);
+		// console.timeEnd('TEXTURE');
+
+		// console.time('MATERIAL');
+		if (propertyTypes.has(PropertyType.MATERIAL)) dedupMaterials(document, cache, options);
+		// console.timeEnd('MATERIAL');
+
+		// console.time('MESH');
+		if (propertyTypes.has(PropertyType.MESH)) dedupMeshes(document, cache, options);
+		// console.timeEnd('MESH');
+
+		// console.time('SKIN');
+		if (propertyTypes.has(PropertyType.SKIN)) dedupSkins(document, cache, options);
+		// console.timeEnd('SKIN');
 
 		logger.debug(`${NAME}: Complete.`);
 	});
 }
 
-function dedupAccessors(document: Document): void {
-	const logger = document.getLogger();
-
-	// Find all accessors used for mesh and animation data.
-	const indicesMap = new Map<string, Set<Accessor>>();
-	const attributeMap = new Map<string, Set<Accessor>>();
-	const inputMap = new Map<string, Set<Accessor>>();
-	const outputMap = new Map<string, Set<Accessor>>();
-
-	const meshes = document.getRoot().listMeshes();
-	meshes.forEach((mesh) => {
-		mesh.listPrimitives().forEach((primitive) => {
-			primitive.listAttributes().forEach((accessor) => hashAccessor(accessor, attributeMap));
-			hashAccessor(primitive.getIndices(), indicesMap);
-		});
-	});
-
-	for (const animation of document.getRoot().listAnimations()) {
-		for (const sampler of animation.listSamplers()) {
-			hashAccessor(sampler.getInput(), inputMap);
-			hashAccessor(sampler.getOutput(), outputMap);
-		}
-	}
-
-	// Add accessor to the appropriate hash group. Hashes are _non-unique_,
-	// intended to quickly compare everything accept the underlying array.
-	function hashAccessor(accessor: Accessor | null, group: Map<string, Set<Accessor>>): void {
-		if (!accessor) return;
-
-		const hash = [
-			accessor.getCount(),
-			accessor.getType(),
-			accessor.getComponentType(),
-			accessor.getNormalized(),
-			accessor.getSparse(),
-		].join(':');
-
-		let hashSet = group.get(hash);
-		if (!hashSet) group.set(hash, (hashSet = new Set<Accessor>()));
-		hashSet.add(accessor);
-	}
-
-	// Find duplicate accessors of a given type.
-	function detectDuplicates(accessors: Accessor[], duplicates: Map<Accessor, Accessor>): void {
-		for (let i = 0; i < accessors.length; i++) {
-			const a = accessors[i];
-			const aData = BufferUtils.toView(a.getArray()!);
-
-			if (duplicates.has(a)) continue;
-
-			for (let j = i + 1; j < accessors.length; j++) {
-				const b = accessors[j];
-
-				if (duplicates.has(b)) continue;
-
-				// Just compare the arrays — everything else was covered by the
-				// hash. Comparing uint8 views is faster than comparing the
-				// original typed arrays.
-				if (BufferUtils.equals(aData, BufferUtils.toView(b.getArray()!))) {
-					duplicates.set(b, a);
-				}
-			}
-		}
-	}
-
-	let total = 0;
-	const duplicates = new Map<Accessor, Accessor>();
-	for (const group of [attributeMap, indicesMap, inputMap, outputMap]) {
-		for (const hashGroup of group.values()) {
-			total += hashGroup.size;
-			detectDuplicates(Array.from(hashGroup), duplicates);
-		}
-	}
-
-	logger.debug(`${NAME}: Merged ${duplicates.size} of ${total} accessors.`);
-
-	// Dissolve duplicate vertex attributes and indices.
-	meshes.forEach((mesh) => {
-		mesh.listPrimitives().forEach((primitive) => {
-			primitive.listAttributes().forEach((accessor) => {
-				if (duplicates.has(accessor)) {
-					primitive.swap(accessor, duplicates.get(accessor) as Accessor);
-				}
-			});
-			const indices = primitive.getIndices();
-			if (indices && duplicates.has(indices)) {
-				primitive.swap(indices, duplicates.get(indices) as Accessor);
-			}
-		});
-	});
-
-	// Dissolve duplicate animation sampler inputs and outputs.
-	for (const animation of document.getRoot().listAnimations()) {
-		for (const sampler of animation.listSamplers()) {
-			const input = sampler.getInput();
-			const output = sampler.getOutput();
-			if (input && duplicates.has(input)) {
-				sampler.swap(input, duplicates.get(input) as Accessor);
-			}
-			if (output && duplicates.has(output)) {
-				sampler.swap(output, duplicates.get(output) as Accessor);
-			}
-		}
-	}
-
-	Array.from(duplicates.keys()).forEach((accessor) => accessor.dispose());
-}
-
-function dedupMeshes(document: Document, options: Required<DedupOptions>): void {
+function dedupAccessors(document: Document, cache: Map<Property, number>): void {
 	const logger = document.getLogger();
 	const root = document.getRoot();
 
-	// Create Reference -> ID lookup table.
-	const refs = new Map<Accessor | Material, number>();
-	root.listAccessors().forEach((accessor, index) => refs.set(accessor, index));
-	root.listMaterials().forEach((material, index) => refs.set(material, index));
+	const skip = new Set(['name', 'buffer']);
+	const duplicates = new Set<Accessor>();
 
-	// For each mesh, create a hashkey.
-	const numMeshes = root.listMeshes().length;
-	const uniqueMeshes = new Map<string, Mesh>();
+	// Group and merge by usage.
+	const usage = {
+		attribute: new Map<number, Accessor>(),
+		indices: new Map<number, Accessor>(),
+		input: new Map<number, Accessor>(),
+		output: new Map<number, Accessor>(),
+	};
+
+	for (const mesh of document.getRoot().listMeshes()) {
+		for (const prim of mesh.listPrimitives()) {
+			checkAccessor(prim.getIndices(), usage.indices);
+			for (const attribute of deepListAttributes(prim)) {
+				checkAccessor(attribute, usage.attribute);
+			}
+		}
+	}
+
+	for (const animation of document.getRoot().listAnimations()) {
+		for (const sampler of animation.listSamplers()) {
+			checkAccessor(sampler.getInput(), usage.input);
+			checkAccessor(sampler.getOutput(), usage.output);
+		}
+	}
+
+	// For each 'src' accessor, check if there's a duplicate 'dst' with the same usage. If so,
+	// replace references from src to dst, and mark src for disposal.
+	function checkAccessor(src: Accessor | null, usage: Map<number, Accessor>): void {
+		if (!src) return;
+
+		const hash = src.toHash(skip, cache);
+		const dst = usage.get(hash);
+		if (!dst) {
+			usage.set(hash, src);
+			return;
+		}
+
+		if (dst === src) {
+			return;
+		}
+
+		for (const parent of src.listParents()) {
+			if (parent !== root) {
+				parent.swap(src, dst);
+			}
+		}
+
+		duplicates.add(src);
+	}
+
+	logger.debug(`${NAME}: Removed ${duplicates.size} duplicate accessors.`);
+	for (const duplicate of duplicates) {
+		duplicate.dispose();
+	}
+}
+
+function dedupMeshes(document: Document, cache: Map<Property, number>, options: Required<DedupOptions>): void {
+	const logger = document.getLogger();
+	const root = document.getRoot();
+
+	const skip = new Set(options.keepUniqueNames ? [] : ['name']);
+	const meshes = new Map<number, Mesh>();
+	let duplicates = 0;
+
 	for (const src of root.listMeshes()) {
-		// For each mesh, create a hashkey.
-		const srcKeyItems = [];
-		for (const prim of src.listPrimitives()) {
-			srcKeyItems.push(createPrimitiveKey(prim, refs));
+		const hash = src.toHash(skip, cache);
+		const dst = meshes.get(hash);
+		if (!dst) {
+			meshes.set(hash, src);
+			continue;
 		}
 
-		// If another mesh exists with the same key, replace all instances with that, and dispose
-		// of the duplicate. If not, just cache it.
-		let meshKey = '';
-		if (options.keepUniqueNames) meshKey += src.getName() + ';';
-		meshKey += srcKeyItems.join(';');
-
-		if (uniqueMeshes.has(meshKey)) {
-			const targetMesh = uniqueMeshes.get(meshKey)!;
-			src.listParents().forEach((parent) => {
-				if (parent.propertyType !== PropertyType.ROOT) {
-					parent.swap(src, targetMesh);
-				}
-			});
-			src.dispose();
-		} else {
-			uniqueMeshes.set(meshKey, src);
-		}
-	}
-
-	logger.debug(`${NAME}: Merged ${numMeshes - uniqueMeshes.size} of ${numMeshes} meshes.`);
-}
-
-function dedupImages(document: Document, options: Required<DedupOptions>): void {
-	const logger = document.getLogger();
-	const root = document.getRoot();
-	const textures = root.listTextures();
-	const duplicates: Map<Texture, Texture> = new Map();
-
-	// Compare each texture to every other texture — O(n²) — and mark duplicates for replacement.
-	for (let i = 0; i < textures.length; i++) {
-		const a = textures[i];
-		const aData = a.getImage();
-
-		if (duplicates.has(a)) continue;
-
-		for (let j = i + 1; j < textures.length; j++) {
-			const b = textures[j];
-			const bData = b.getImage();
-
-			if (duplicates.has(b)) continue;
-
-			// URIs are intentionally not compared.
-			if (a.getMimeType() !== b.getMimeType()) continue;
-			if (options.keepUniqueNames && a.getName() !== b.getName()) continue;
-
-			const aSize = a.getSize();
-			const bSize = b.getSize();
-			if (!aSize || !bSize) continue;
-			if (aSize[0] !== bSize[0]) continue;
-			if (aSize[1] !== bSize[1]) continue;
-			if (!aData || !bData) continue;
-			if (BufferUtils.equals(aData, bData)) {
-				duplicates.set(b, a);
+		for (const parent of src.listParents()) {
+			if (parent !== root) {
+				parent.swap(src, dst);
 			}
 		}
+
+		src.dispose();
+		duplicates++;
 	}
 
-	logger.debug(`${NAME}: Merged ${duplicates.size} of ${root.listTextures().length} textures.`);
-
-	Array.from(duplicates.entries()).forEach(([src, dst]) => {
-		src.listParents().forEach((property) => {
-			if (!(property instanceof Root)) property.swap(src, dst);
-		});
-		src.dispose();
-	});
+	logger.debug(`${NAME}: Removed ${duplicates} duplicate meshes.`);
 }
 
-function dedupMaterials(document: Document, options: Required<DedupOptions>): void {
+function dedupImages(document: Document, cache: Map<Property, number>, options: Required<DedupOptions>): void {
 	const logger = document.getLogger();
 	const root = document.getRoot();
-	const materials = root.listMaterials();
-	const duplicates = new Map<Material, Material>();
-	const modifierCache = new Map<Material, boolean>();
+
+	const skip = new Set(['uri']);
+	if (!options.keepUniqueNames) skip.add('name');
+
+	const textures = new Map<number, Texture>();
+	let duplicates = 0;
+
+	for (const src of root.listTextures()) {
+		const hash = src.toHash(skip, cache);
+		const dst = textures.get(hash);
+		if (!dst) {
+			textures.set(hash, src);
+			continue;
+		}
+
+		for (const parent of src.listParents()) {
+			if (parent !== root) {
+				parent.swap(src, dst);
+			}
+		}
+
+		src.dispose();
+		duplicates++;
+	}
+
+	logger.debug(`${NAME}: Removed ${duplicates} duplicate textures.`);
+}
+
+function dedupMaterials(document: Document, cache: Map<Property, number>, options: Required<DedupOptions>): void {
+	const logger = document.getLogger();
+	const root = document.getRoot();
+
 	const skip = new Set<string>();
+	if (!options.keepUniqueNames) skip.add('name');
 
-	if (!options.keepUniqueNames) {
-		skip.add('name');
-	}
+	const modifierCache = new Map<Material, boolean>();
+	const materials = new Map<number, Material>();
+	let duplicates = 0;
 
-	// Compare each material to every other material — O(n²) — and mark duplicates for replacement.
-	for (let i = 0; i < materials.length; i++) {
-		const a = materials[i];
+	for (const src of root.listMaterials()) {
+		if (hasModifier(src, modifierCache)) continue;
 
-		if (duplicates.has(a)) continue;
-		if (hasModifier(a, modifierCache)) continue;
-
-		for (let j = i + 1; j < materials.length; j++) {
-			const b = materials[j];
-
-			if (duplicates.has(b)) continue;
-			if (hasModifier(b, modifierCache)) continue;
-
-			if (a.equals(b, skip)) {
-				duplicates.set(b, a);
-			}
+		const hash = src.toHash(skip, cache);
+		const dst = materials.get(hash);
+		if (!dst) {
+			materials.set(hash, src);
+			continue;
 		}
+
+		for (const parent of src.listParents()) {
+			parent.swap(src, dst);
+		}
+
+		src.dispose();
+		duplicates++;
 	}
 
-	logger.debug(`${NAME}: Merged ${duplicates.size} of ${materials.length} materials.`);
-
-	Array.from(duplicates.entries()).forEach(([src, dst]) => {
-		src.listParents().forEach((property) => {
-			if (!(property instanceof Root)) property.swap(src, dst);
-		});
-		src.dispose();
-	});
+	logger.debug(`${NAME}: Removed ${duplicates} duplicate materials.`);
 }
 
-function dedupSkins(document: Document, options: Required<DedupOptions>): void {
+// TODO: Use toHash().
+function dedupSkins(document: Document, cache: Map<Property, number>, options: Required<DedupOptions>): void {
 	const logger = document.getLogger();
 	const root = document.getRoot();
 	const skins = root.listSkins();
@@ -347,30 +280,6 @@ function dedupSkins(document: Document, options: Required<DedupOptions>): void {
 		});
 		src.dispose();
 	});
-}
-
-/** Generates a key unique to the content of a primitive or target. */
-function createPrimitiveKey(prim: Primitive | PrimitiveTarget, refs: Map<Accessor | Material, number>): string {
-	const primKeyItems = [];
-	for (const semantic of prim.listSemantics()) {
-		const attribute = prim.getAttribute(semantic)!;
-		primKeyItems.push(semantic + ':' + refs.get(attribute));
-	}
-	if (prim instanceof Primitive) {
-		const indices = prim.getIndices();
-		if (indices) {
-			primKeyItems.push('indices:' + refs.get(indices));
-		}
-		const material = prim.getMaterial();
-		if (material) {
-			primKeyItems.push('material:' + refs.get(material));
-		}
-		primKeyItems.push('mode:' + prim.getMode());
-		for (const target of prim.listTargets()) {
-			primKeyItems.push('target:' + createPrimitiveKey(target, refs));
-		}
-	}
-	return primKeyItems.join(',');
 }
 
 /**

--- a/packages/functions/src/utils.ts
+++ b/packages/functions/src/utils.ts
@@ -211,17 +211,6 @@ export function deepDisposePrimitive(prim: Primitive): void {
 	}
 }
 
-/** @hidden */
-export function shallowEqualsArray(a: ArrayLike<unknown> | null, b: ArrayLike<unknown> | null): boolean {
-	if (a == null && b == null) return true;
-	if (a == null || b == null) return false;
-	if (a.length !== b.length) return false;
-	for (let i = 0; i < a.length; i++) {
-		if (a[i] !== b[i]) return false;
-	}
-	return true;
-}
-
 /** Clones an {@link Accessor} without creating a copy of its underlying TypedArray data. */
 export function shallowCloneAccessor(document: Document, accessor: Accessor): Accessor {
 	return document

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -160,6 +160,28 @@ test('skins', async (t) => {
 	t.false(skinC.isDisposed(), 'keep skin C');
 });
 
+test('skins | joints', async (t) => {
+	// Skins may appear to be duplicates if compared only by "deep" equality,
+	// if each has the same number of joints, and the joint nodes have no
+	// distinguishing features. Ensure nodes are not 'interchangable'.
+	// Example: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/RecursiveSkeletons
+	const document = new Document();
+	const root = document.getRoot();
+	const boneA = document.createNode();
+	const boneB = document.createNode();
+	const boneC = document.createNode();
+	const boneD = document.createNode();
+	document.createScene().addChild(boneA).addChild(boneB).addChild(boneC).addChild(boneD);
+	const skinA = document.createSkin().addJoint(boneA).addJoint(boneB);
+	const skinB = document.createSkin().addJoint(boneC).addJoint(boneD);
+
+	await document.transform(dedup({ propertyTypes: [PropertyType.SKIN] }));
+
+	t.is(root.listSkins().length, 2, 'distinct but deeply-equal joints are not pruned');
+	t.false(skinA.isDisposed(), 'keep skin A');
+	t.false(skinB.isDisposed(), 'keep skin B');
+});
+
 test('textures', async (t) => {
 	const document = new Document();
 	const transmissionExt = document.createExtension(KHRMaterialsTransmission);

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -40,7 +40,7 @@ test('accessors - animation', (t) => {
 
 	t.is(document.getRoot().listAccessors().length, 7, 'has no effect when disabled');
 
-	dedup()(document);
+	dedup({ propertyTypes: [PropertyType.ACCESSOR] })(document);
 
 	t.is(document.getRoot().listAccessors().length, 4, 'prunes duplicate accessors');
 	t.truthy(sampler1.getInput() === a, 'sampler 1 input');
@@ -52,6 +52,12 @@ test('accessors - animation', (t) => {
 	t.truthy(sampler3.getOutput() !== b, 'no mixing input/output');
 	t.truthy(prim.getAttribute('POSITION') !== a, 'no mixing sampler/attribute');
 	t.truthy(prim.getAttribute('POSITION') !== b, 'no mixing sampler/attribute');
+
+	dedup({ propertyTypes: [PropertyType.ANIMATION_SAMPLER] })(document);
+
+	t.false(sampler1.isDisposed(), 'sampler 1 OK');
+	t.true(sampler2.isDisposed(), 'sampler 2 disposed');
+	t.false(sampler3.isDisposed(), 'sampler 3 OK');
 });
 
 test('materials', (t) => {


### PR DESCRIPTION
Refactor of the [`dedup`](https://gltf-transform.dev/modules/functions/functions/dedup) function, using `hashProperty` function (from https://github.com/donmccurdy/glTF-Transform/pull/1757) to avoid O(n<sup>2</sup>) iteration over properties.

Related:

- Fixes https://github.com/donmccurdy/glTF-Transform/issues/1722
- Fixes https://github.com/donmccurdy/glTF-Transform/issues/1708




#### PR Dependency Tree


* **PR #1757**
  * **PR #1760**
    * **PR #1761** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)