### PR TITLE
fix (texture-basisu): edge case causes crashing on non textured model

### DIFF
--- a/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
+++ b/packages/extensions/src/khr-texture-basisu/texture-basisu.ts
@@ -140,7 +140,7 @@ export class KHRTextureBasisu extends Extension {
 				}
 			});
 		}
-		
+
 		return this;
 	}
 


### PR DESCRIPTION
Non-textured models that require basisu crashes with "Cannot read properties of undefined (reading 'forEach')"