### PR TITLE
chore: replace glob with native node:fs globSync

### DIFF
--- a/packages/core/test/io/node-io.test.ts
+++ b/packages/core/test/io/node-io.test.ts
@@ -1,10 +1,10 @@
+import { globSync } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { createPlatformIO, Environment, environment, logger } from '@gltf-transform/test-utils';
 import test from 'ava';
-import { glob } from 'glob';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -28,7 +28,7 @@ test('read glb', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
 	const io = (await createPlatformIO()) as NodeIO;
 	let count = 0;
-	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.glb'))) {
+	for await (const inputURI of globSync(resolve(__dirname, '../in/**/*.glb'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
 		const document = io.read(inputURI);
 
@@ -42,7 +42,7 @@ test('read gltf', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
 	const io = (await createPlatformIO()) as NodeIO;
 	let count = 0;
-	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.gltf'))) {
+	for await (const inputURI of globSync(resolve(__dirname, '../in/**/*.gltf'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
 		const document = await io.read(inputURI);
 
@@ -56,7 +56,7 @@ test('read glb http', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
 	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
 	let count = 0;
-	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.glb'))) {
+	for await (const inputURI of globSync(resolve(__dirname, '../in/**/*.glb'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
 		const document = await io.read(basepath);
 
@@ -70,7 +70,7 @@ test('read gltf http', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
 	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
 	let count = 0;
-	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.gltf'))) {
+	for await (const inputURI of globSync(resolve(__dirname, '../in/**/*.gltf'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
 		const document = await io.read(basepath);
 
@@ -84,7 +84,7 @@ test('write glb', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
 	const io = (await createPlatformIO()) as NodeIO;
 	let count = 0;
-	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.gltf'))) {
+	for await (const inputURI of globSync(resolve(__dirname, '../in/**/*.gltf'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
 		const outputURI = resolve(__dirname, `../out/${basepath}`);
 		const document = await io.read(inputURI);
@@ -101,7 +101,7 @@ test('write gltf', async (t) => {
 	if (environment !== Environment.NODE) return t.pass();
 	const io = (await createPlatformIO()) as NodeIO;
 	let count = 0;
-	for await (const inputURI of glob.sync(resolve(__dirname, '../in/**/*.glb'))) {
+	for await (const inputURI of globSync(resolve(__dirname, '../in/**/*.glb'))) {
 		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
 		const outputURI = resolve(__dirname, `../out/${basepath}`);
 		const document = await io.read(inputURI);

--- a/scripts/validate.cjs
+++ b/scripts/validate.cjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const glob = require('glob');
+const fs = require('node:fs');
+const path = require('node:path');
 const validator = require('gltf-validator');
 
 const verbose = process.argv.indexOf('--verbose') > 0;
@@ -53,8 +52,8 @@ const validateURI = (uri) => {
 	pending.push(promise);
 };
 
-glob.sync(path.join(__dirname, '../packages/*/test/out/**/*.glb')).forEach(validateURI);
-glob.sync(path.join(__dirname, '../packages/*/test/out/**/*.gltf')).forEach(validateURI);
+fs.globSync(path.join(__dirname, '../packages/*/test/out/**/*.glb')).forEach(validateURI);
+fs.globSync(path.join(__dirname, '../packages/*/test/out/**/*.gltf')).forEach(validateURI);
 
 Promise.all(pending)
 	.catch(() => true)


### PR DESCRIPTION
## Summary

- Replace `glob` package usage with native `node:fs` `globSync` in `scripts/validate.cjs` and `packages/core/test/io/node-io.test.ts`
- Modernize `require('fs')` / `require('path')` to `require('node:fs')` / `require('node:path')` in the validate script

The `glob` package was never listed as a direct dependency — it was accessed via hoisting from transitive dependencies. Native `fs.globSync` (available since Node.js 22) provides the same functionality with zero external dependencies, and CI already tests on Node.js v22+.

Closes #1800