### PR TITLE
chore(extensions): KHR_node_visibility has been ratified

### DIFF
--- a/packages/extensions/src/khr-node-visibility/node-visibility.ts
+++ b/packages/extensions/src/khr-node-visibility/node-visibility.ts
@@ -27,8 +27,6 @@ interface VisibilityDef {
  * // Assign to a Node.
  * node.setExtension('KHR_node_visibility', visibility);
  * ```
- *
- * @experimental KHR_node_visibility is not yet ratified by the Khronos Group.
  */
 export class KHRNodeVisibility extends Extension {
 	public static readonly EXTENSION_NAME: typeof KHR_NODE_VISIBILITY = KHR_NODE_VISIBILITY;

--- a/packages/extensions/src/khr-node-visibility/visibility.ts
+++ b/packages/extensions/src/khr-node-visibility/visibility.ts
@@ -7,8 +7,6 @@ interface IVisibility extends IProperty {
 
 /**
  * Defines visibility of a {@link Node} and its descendants. See {@link KHRNodeVisibility}.
- *
- * @experimental KHR_node_visibility is not yet ratified by the Khronos Group.
  */
 export class Visibility extends ExtensionProperty<IVisibility> {
 	public static EXTENSION_NAME: typeof KHR_NODE_VISIBILITY = KHR_NODE_VISIBILITY;


### PR DESCRIPTION
KHR_node_visibility has been ratified by Khronos, and can be considered stable in glTF Transform.


#### PR Dependency Tree


* **PR #1818** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)