### PR TITLE
feat(cli): add --resize to etc1s and uastc

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1341,6 +1341,9 @@ normal maps and ETC1S for other textures, for example.`.trim(),
 		validator: Validator.STRING,
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING })
+	.option('--resize <size>', 'Maximum texture dimensions, in pixels.', {
+		validator: Validator.NUMBER,
+	})
 	.option('--mipmaps <bool>', 'Generate mipmaps.', {
 		validator: Validator.BOOLEAN,
 		default: ETC1S_DEFAULTS.mipmaps,
@@ -1399,8 +1402,11 @@ normal maps and ETC1S for other textures, for example.`.trim(),
 		const mode = Mode.ETC1S;
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
 		const slots = options.slots ? micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS) : null;
+		const resize = Number.isInteger(options.resize)
+			? ([Number(options.resize), Number(options.resize)] as vec2)
+			: undefined;
 		return Session.create(io, logger, args.input, args.output).transform(
-			toktx({ ...options, encoder, mode, pattern, slots }),
+			toktx({ ...options, encoder, mode, pattern, slots, resize }),
 		);
 	});
 
@@ -1423,6 +1429,9 @@ for textures where the quality is sufficient.`.trim(),
 		validator: Validator.STRING,
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING })
+	.option('--resize <size>', 'Maximum texture dimensions, in pixels.', {
+		validator: Validator.NUMBER,
+	})
 	.option('--mipmaps <bool>', 'Generate mipmaps.', {
 		validator: Validator.BOOLEAN,
 		default: UASTC_DEFAULTS.mipmaps,
@@ -1516,8 +1525,11 @@ for textures where the quality is sufficient.`.trim(),
 		const mode = Mode.UASTC;
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
 		const slots = options.slots ? micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS) : null;
+		const resize = Number.isInteger(options.resize)
+			? ([Number(options.resize), Number(options.resize)] as vec2)
+			: undefined;
 		Session.create(io, logger, args.input, args.output).transform(
-			toktx({ ...options, encoder, mode, pattern, slots }),
+			toktx({ ...options, encoder, mode, pattern, slots, resize }),
 		);
 	});
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -2,16 +2,32 @@ import { mockConsoleLog, program, programReady } from '@gltf-transform/cli';
 import { Document, FileUtils, NodeIO } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
 import test from 'ava';
+import { execFile } from 'child_process';
 import draco3d from 'draco3dgltf';
 import fs from 'fs';
 import { MeshoptDecoder } from 'meshoptimizer';
 import path, { dirname } from 'path';
 import tmp from 'tmp';
 import { fileURLToPath } from 'url';
+import { promisify } from 'util';
 
 tmp.setGracefulCleanup();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const execFileAsync = promisify(execFile);
+
+test('KTX resize option', async (t) => {
+	const cliPath = path.join(__dirname, '..', 'bin', 'cli.js');
+
+	for (const command of ['etc1s', 'uastc']) {
+		const { stdout } = await execFileAsync(process.execPath, [
+			cliPath,
+			'help',
+			command,
+		]);
+		t.regex(stdout, /--resize <size>/, command);
+	}
+});
 
 test('copy', async (t) => {
 	await programReady;


### PR DESCRIPTION
Adds `--resize <size>` to the standalone `etc1s` and `uastc` commands and passes square dimensions through to `toktx()`.

Includes CLI coverage for both commands. Tests: CLI tests and build.

Closes #1776.
