### PR TITLE
chore(cli): Update KTX Software dependency to v4.4

### DIFF
--- a/packages/cli/src/transforms/toktx.ts
+++ b/packages/cli/src/transforms/toktx.ts
@@ -34,7 +34,10 @@ import { pLimit } from '../utils/p-limit.js';
 import { commandExists, spawn, TrustedCommand, waitExit } from '../utils/process.js';
 
 const NUM_CPUS = os.cpus().length || 1; // microsoft/vscode#112122
-const KTX_SOFTWARE_VERSION_MIN = '4.3.0';
+
+// Options for specifying transfer functions refactored in v4.4.
+// https://github.com/KhronosGroup/KTX-Software/releases#release-v4.4.0
+const KTX_SOFTWARE_VERSION_MIN = '4.4.0';
 
 const { R, G, A } = TextureChannel;
 const { NEAREST, NEAREST_MIPMAP_LINEAR, NEAREST_MIPMAP_NEAREST, LINEAR, LINEAR_MIPMAP_NEAREST } = TextureInfo.MinFilter;
@@ -402,11 +405,11 @@ function createParams(
 
 	// See: https://github.com/donmccurdy/glTF-Transform/issues/215
 	if (colorSpace === 'srgb') {
-		params.push('--assign-oetf', 'srgb', '--assign-primaries', 'bt709');
+		params.push('--assign-tf', 'srgb', '--assign-primaries', 'bt709');
 	} else if (colorSpace === 'srgb-linear') {
-		params.push('--assign-oetf', 'linear', '--assign-primaries', 'bt709');
+		params.push('--assign-tf', 'linear', '--assign-primaries', 'bt709');
 	} else if (slots.length && !colorSpace) {
-		params.push('--assign-oetf', 'linear', '--assign-primaries', 'none');
+		params.push('--assign-tf', 'linear', '--assign-primaries', 'none');
 	}
 
 	if (channels === R) {

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -42,13 +42,13 @@ test('compress and resize', async (t) => {
 
 	t.is(
 		await getParams({ mode: Mode.ETC1S }, await createImage([508, 508]), R),
-		'create --generate-mipmap --encode basis-lz --assign-oetf linear --assign-primaries none --format R8_UNORM',
+		'create --generate-mipmap --encode basis-lz --assign-tf linear --assign-primaries none --format R8_UNORM',
 		'channels → R',
 	);
 
 	t.is(
 		await getParams({ mode: Mode.ETC1S }, await createImage([508, 508]), G),
-		'create --generate-mipmap --encode basis-lz --assign-oetf linear --assign-primaries none --format R8G8_UNORM',
+		'create --generate-mipmap --encode basis-lz --assign-tf linear --assign-primaries none --format R8G8_UNORM',
 		'channels → RG',
 	);
 });


### PR DESCRIPTION
Require KTX Software v4.4+ for KTX compression in `@gltf-transform/cli`. Necessary for forward-compatibility with KTX Software v5.

- See: https://github.com/KhronosGroup/KTX-Software/releases#release-v4.4.0
- Fixes #1823


#### PR Dependency Tree


* **PR #1840** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)