### PR TITLE
feat(cli): expose --resize for etc1s and uastc

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1335,6 +1335,9 @@ normal maps and ETC1S for other textures, for example.`.trim(),
 		validator: Validator.STRING,
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING })
+	.option('--resize <size>', 'Maximum texture dimensions, in pixels.', {
+		validator: Validator.NUMBER,
+	})
 	.option('--mipmaps <bool>', 'Generate mipmaps.', {
 		validator: Validator.BOOLEAN,
 		default: ETC1S_DEFAULTS.mipmaps,
@@ -1393,8 +1396,11 @@ normal maps and ETC1S for other textures, for example.`.trim(),
 		const mode = Mode.ETC1S;
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
 		const slots = options.slots ? micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS) : null;
+		const resize: vec2 | undefined = options.resize
+			? [Number(options.resize), Number(options.resize)]
+			: undefined;
 		return Session.create(io, logger, args.input, args.output).transform(
-			toktx({ ...options, encoder, mode, pattern, slots }),
+			toktx({ ...options, encoder, mode, pattern, slots, resize }),
 		);
 	});
 
@@ -1417,6 +1423,9 @@ for textures where the quality is sufficient.`.trim(),
 		validator: Validator.STRING,
 	})
 	.option('--slots <slots>', 'Texture slots to include (glob)', { validator: Validator.STRING })
+	.option('--resize <size>', 'Maximum texture dimensions, in pixels.', {
+		validator: Validator.NUMBER,
+	})
 	.option('--mipmaps <bool>', 'Generate mipmaps.', {
 		validator: Validator.BOOLEAN,
 		default: UASTC_DEFAULTS.mipmaps,
@@ -1510,8 +1519,11 @@ for textures where the quality is sufficient.`.trim(),
 		const mode = Mode.UASTC;
 		const pattern = options.pattern ? micromatch.makeRe(String(options.pattern), MICROMATCH_OPTIONS) : null;
 		const slots = options.slots ? micromatch.makeRe(String(options.slots), MICROMATCH_OPTIONS) : null;
+		const resize: vec2 | undefined = options.resize
+			? [Number(options.resize), Number(options.resize)]
+			: undefined;
 		Session.create(io, logger, args.input, args.output).transform(
-			toktx({ ...options, encoder, mode, pattern, slots }),
+			toktx({ ...options, encoder, mode, pattern, slots, resize }),
 		);
 	});
 


### PR DESCRIPTION
Fixes #1776.

## Summary

Exposes the existing texture resize capability on the standalone `etc1s` and `uastc` CLI commands.

Both commands now accept `--resize <size>` and pass the requested maximum dimensions through to `toktx()`, matching the resize behavior already available through `optimize`.

## Testing

- `corepack yarn test packages/cli/test/toktx.test.ts`
  - 1 test passed
- `corepack yarn build --ignore "@gltf-transform/view"`
  - build succeeded for 6 projects
- verified `etc1s --help` includes `--resize`
- verified `uastc --help` includes `--resize`
- `git diff --check`