### PR TITLE
chore(test): Migrate tests to `node:test`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ API functions by the user, rather than being created by the API directly.
 
 ### Testing
 
-Unit tests use [Ava](https://github.com/avajs/ava).
+Unit tests use [`node:test`](https://nodejs.org/api/test.html).
 
 ```bash
 # run all tests
@@ -67,10 +67,10 @@ yarn test
 yarn test --watch
 
 # run one test
-yarn test packages/functions/test/palette.test.ts
+node --test packages/functions/test/palette.test.ts
 
 # run one test, watching for source file changes to re-run
-yarn test packages/functions/test/palette.test.ts --watch
+node --test --watch packages/functions/test/palette.test.ts
 ```
 
 ### Debugging
@@ -78,7 +78,7 @@ yarn test packages/functions/test/palette.test.ts --watch
 To use a debugger and step through tests using Chrome Developer Tools, see [_Debugging tests with Chrome DevTools_](https://github.com/avajs/ava/blob/main/docs/recipes/debugging-with-chrome-devtools.md). Add a `debugger;` statement to the body of the test, then run:
 
 ```bash
-yarn test:debug packages/functions/test/palette.test.ts --break
+node --test --inspect-brk packages/functions/test/palette.test.ts
 ```
 
 To use the CLI with a debugger, run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ node --test --watch packages/functions/test/palette.test.ts
 
 ### Debugging
 
-To use a debugger and step through tests using Chrome Developer Tools, see [_Debugging tests with Chrome DevTools_](https://github.com/avajs/ava/blob/main/docs/recipes/debugging-with-chrome-devtools.md). Add a `debugger;` statement to the body of the test, then run:
+To use a debugger and step through tests using Chrome Developer Tools, add a `debugger;` statement to the body of the test, then run:
 
 ```bash
 node --test --inspect-brk packages/functions/test/palette.test.ts

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "clean:dist": "rm -rf packages/*/dist/** | true",
     "clean:deps": "rm -rf packages/*/node_modules/** | true",
     "clean:test": "rm -rf packages/*/test/out/** | true",
-    "test": "ava --no-worker-threads",
-    "test:debug": "ava debug --no-worker-threads",
+    "test": "node --test packages/*/test/**/*.test.ts",
     "coverage": "c8 --config .github/.c8rc --reporter=lcov --reporter=text yarn test --tap",
     "coverage:report": "c8 report --config .github/.c8rc --reporter=text-lcov > coverage/coverage.lcov",
     "lint": "biome check packages/*/{src,test}",
@@ -40,7 +39,6 @@
     "@types/node": "26.2.0",
     "@types/semver": "^7.8.0",
     "@types/three": "^0.177.0",
-    "ava": "^7.0.0",
     "c8": "^11.0.0",
     "d3-dsv": "^3.0.1",
     "draco3dgltf": "1.5.7",
@@ -64,11 +62,6 @@
   },
   "resolutions": {
     "sharp": "~0.35.0"
-  },
-  "ava": {
-    "extensions": {
-      "ts": "module"
-    }
   },
   "packageManager": "yarn@4.17.0"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean:deps": "rm -rf packages/*/node_modules/** | true",
     "clean:test": "rm -rf packages/*/test/out/** | true",
     "test": "node --test packages/*/test/**/*.test.ts",
-    "coverage": "c8 --config .github/.c8rc --reporter=lcov --reporter=text yarn test --tap",
+    "coverage": "c8 --config .github/.c8rc --reporter=lcov --reporter=text yarn test",
     "coverage:report": "c8 report --config .github/.c8rc --reporter=text-lcov > coverage/coverage.lcov",
     "lint": "biome check packages/*/{src,test}",
     "lint:ci": "biome ci packages/*/{src,test}",

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -14,7 +14,7 @@ tmp.setGracefulCleanup();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('cli', () => {
+describe('cli::cli', () => {
 	test('copy', async () => {
 		await programReady;
 		const io = new NodeIO();

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,7 +1,8 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { mockConsoleLog, program, programReady } from '@gltf-transform/cli';
 import { Document, FileUtils, NodeIO } from '@gltf-transform/core';
 import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
-import test from 'ava';
 import draco3d from 'draco3dgltf';
 import fs from 'fs';
 import { MeshoptDecoder } from 'meshoptimizer';
@@ -13,144 +14,144 @@ tmp.setGracefulCleanup();
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('copy', async (t) => {
-	await programReady;
-	const io = new NodeIO();
-	const input = tmp.tmpNameSync({ postfix: '.glb' });
-	const output = tmp.tmpNameSync({ postfix: '.glb' });
+describe('cli', () => {
+	test('copy', async () => {
+		await programReady;
+		const io = new NodeIO();
+		const input = tmp.tmpNameSync({ postfix: '.glb' });
+		const output = tmp.tmpNameSync({ postfix: '.glb' });
 
-	const document = new Document();
-	document.createBuffer();
-	document.createAccessor().setArray(new Uint8Array([1, 2, 3]));
-	document.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
-	await io.write(input, document);
+		const document = new Document();
+		document.createBuffer();
+		document.createAccessor().setArray(new Uint8Array([1, 2, 3]));
+		document.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
+		await io.write(input, document);
 
-	return program.exec(['copy', input, output]).then(async () => {
-		const doc2 = await io.read(output);
-		t.truthy(doc2, 'roundtrip document');
-		t.is(doc2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'roundtrip material');
+		return program.exec(['copy', input, output]).then(async () => {
+			const doc2 = await io.read(output);
+			ok(doc2, 'roundtrip document');
+			strictEqual(doc2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'roundtrip material');
+		});
 	});
-});
 
-test('meshopt', async (t) => {
-	await programReady;
-	await MeshoptDecoder.ready;
-	const io = new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
-		'meshopt.decoder': MeshoptDecoder,
+	test('meshopt', async () => {
+		await programReady;
+		await MeshoptDecoder.ready;
+		const io = new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
+			'meshopt.decoder': MeshoptDecoder,
+		});
+		const input = path.join(__dirname, 'in', 'chr_knight.glb');
+		const output = tmp.tmpNameSync({ postfix: '.glb' });
+
+		return program.exec(['meshopt', input, output], { silent: true }).then(async () => {
+			const doc2 = await io.read(output);
+			ok(doc2, 'meshopt succeeds');
+		});
 	});
-	const input = path.join(__dirname, 'in', 'chr_knight.glb');
-	const output = tmp.tmpNameSync({ postfix: '.glb' });
 
-	return program.exec(['meshopt', input, output], { silent: true }).then(async () => {
-		const doc2 = await io.read(output);
-		t.truthy(doc2, 'meshopt succeeds');
+	test('draco', async () => {
+		await programReady;
+		const io = new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
+			'draco3d.decoder': await draco3d.createDecoderModule(),
+			'draco3d.encoder': await draco3d.createEncoderModule(),
+		});
+		const input = path.join(__dirname, 'in', 'chr_knight.glb');
+		const output = tmp.tmpNameSync({ postfix: '.glb' });
+
+		return program.exec(['draco', input, output], { silent: true }).then(async () => {
+			const doc2 = await io.read(output);
+			ok(doc2, 'draco succeeds');
+		});
 	});
-});
 
-test('draco', async (t) => {
-	await programReady;
-	const io = new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
-		'draco3d.decoder': await draco3d.createDecoderModule(),
-		'draco3d.encoder': await draco3d.createEncoderModule(),
+	test('optimize', async () => {
+		await programReady;
+		await MeshoptDecoder.ready;
+		const io = new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
+			'meshopt.decoder': MeshoptDecoder,
+		});
+		const input = path.join(__dirname, 'in', 'chr_knight.glb');
+		const output = tmp.tmpNameSync({ postfix: '.glb' });
+
+		return program.exec(['optimize', input, output], { silent: true }).then(async () => {
+			const doc2 = await io.read(output);
+			ok(doc2, 'optimize succeeds');
+		});
 	});
-	const input = path.join(__dirname, 'in', 'chr_knight.glb');
-	const output = tmp.tmpNameSync({ postfix: '.glb' });
 
-	return program.exec(['draco', input, output], { silent: true }).then(async () => {
-		const doc2 = await io.read(output);
-		t.truthy(doc2, 'draco succeeds');
+	test('validate', async () => {
+		mockConsoleLog(() => {});
+
+		await programReady;
+		const io = new NodeIO();
+		const input = tmp.tmpNameSync({ postfix: '.glb' });
+
+		const document = new Document();
+		document.createBuffer();
+		document.createAccessor().setArray(new Uint8Array([1, 2, 3]));
+		document.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
+		await io.write(input, document);
+
+		await program.exec(['validate', input], { silent: true });
 	});
-});
 
-test('optimize', async (t) => {
-	await programReady;
-	await MeshoptDecoder.ready;
-	const io = new NodeIO().registerExtensions(ALL_EXTENSIONS).registerDependencies({
-		'meshopt.decoder': MeshoptDecoder,
+	test('inspect', async () => {
+		mockConsoleLog(() => {});
+
+		await programReady;
+		const io = new NodeIO();
+		const input = tmp.tmpNameSync({ postfix: '.glb' });
+
+		const document = new Document();
+		document.createBuffer();
+		document.createAccessor().setArray(new Uint8Array([1, 2, 3]));
+		document.createMesh('MyMesh');
+		document.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
+		document.createScene('MyScene').addChild(document.createNode('MyNode'));
+		document.createAnimation();
+		await io.write(input, document);
+		await runSilent(async () => program.exec(['inspect', input], { silent: true }));
 	});
-	const input = path.join(__dirname, 'in', 'chr_knight.glb');
-	const output = tmp.tmpNameSync({ postfix: '.glb' });
 
-	return program.exec(['optimize', input, output], { silent: true }).then(async () => {
-		const doc2 = await io.read(output);
-		t.truthy(doc2, 'optimize succeeds');
+	test('merge', async () => {
+		await programReady;
+		const io = new NodeIO();
+		const inputA = tmp.tmpNameSync({ postfix: '.glb' });
+		const inputB = tmp.tmpNameSync({ postfix: '.glb' });
+		const inputC = tmp.tmpNameSync({ postfix: '.png' });
+		const output = tmp.tmpNameSync({ postfix: '.glb' });
+
+		const documentA = new Document();
+		documentA.createScene('SceneA');
+		const bufA = documentA.createBuffer('BufferA');
+		documentA
+			.createAccessor()
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setBuffer(bufA);
+		await io.write(inputA, documentA);
+
+		const documentB = new Document();
+		documentB.createScene('');
+		const bufB = documentB.createBuffer('BufferB');
+		documentB
+			.createAccessor()
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setBuffer(bufB);
+		await io.write(inputB, documentB);
+
+		fs.writeFileSync(inputC, new Uint8Array([1, 2, 3, 4, 5]));
+
+		await program
+			// https://github.com/mattallty/Caporal.js/issues/195
+			.exec(['merge', [inputA, inputB, inputC, output].join(',')], { silent: true });
+
+		const document = await io.read(output);
+		const root = document.getRoot();
+		const sceneNames = root.listScenes().map((s) => s.getName());
+		const texName = root.listTextures()[0].getName();
+		deepEqual(sceneNames, ['SceneA', FileUtils.basename(inputB)], 'merge scenes');
+		strictEqual(texName, FileUtils.basename(inputC), 'merge textures');
 	});
-});
-
-test('validate', async (t) => {
-	mockConsoleLog(() => {});
-
-	await programReady;
-	const io = new NodeIO();
-	const input = tmp.tmpNameSync({ postfix: '.glb' });
-
-	const document = new Document();
-	document.createBuffer();
-	document.createAccessor().setArray(new Uint8Array([1, 2, 3]));
-	document.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
-	await io.write(input, document);
-
-	await program.exec(['validate', input], { silent: true });
-	t.pass();
-});
-
-test('inspect', async (t) => {
-	mockConsoleLog(() => {});
-
-	await programReady;
-	const io = new NodeIO();
-	const input = tmp.tmpNameSync({ postfix: '.glb' });
-
-	const document = new Document();
-	document.createBuffer();
-	document.createAccessor().setArray(new Uint8Array([1, 2, 3]));
-	document.createMesh('MyMesh');
-	document.createMaterial('MyMaterial').setBaseColorFactor([1, 0, 0, 1]);
-	document.createScene('MyScene').addChild(document.createNode('MyNode'));
-	document.createAnimation();
-	await io.write(input, document);
-	await runSilent(async () => program.exec(['inspect', input], { silent: true }));
-	t.pass();
-});
-
-test('merge', async (t) => {
-	await programReady;
-	const io = new NodeIO();
-	const inputA = tmp.tmpNameSync({ postfix: '.glb' });
-	const inputB = tmp.tmpNameSync({ postfix: '.glb' });
-	const inputC = tmp.tmpNameSync({ postfix: '.png' });
-	const output = tmp.tmpNameSync({ postfix: '.glb' });
-
-	const documentA = new Document();
-	documentA.createScene('SceneA');
-	const bufA = documentA.createBuffer('BufferA');
-	documentA
-		.createAccessor()
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setBuffer(bufA);
-	await io.write(inputA, documentA);
-
-	const documentB = new Document();
-	documentB.createScene('');
-	const bufB = documentB.createBuffer('BufferB');
-	documentB
-		.createAccessor()
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setBuffer(bufB);
-	await io.write(inputB, documentB);
-
-	fs.writeFileSync(inputC, new Uint8Array([1, 2, 3, 4, 5]));
-
-	await program
-		// https://github.com/mattallty/Caporal.js/issues/195
-		.exec(['merge', [inputA, inputB, inputC, output].join(',')], { silent: true });
-
-	const document = await io.read(output);
-	const root = document.getRoot();
-	const sceneNames = root.listScenes().map((s) => s.getName());
-	const texName = root.listTextures()[0].getName();
-	t.deepEqual(sceneNames, ['SceneA', FileUtils.basename(inputB)], 'merge scenes');
-	t.is(texName, FileUtils.basename(inputC), 'merge textures');
 });
 
 async function runSilent(fn: () => Promise<unknown>): Promise<void> {

--- a/packages/cli/test/ktxdecompress.test.ts
+++ b/packages/cli/test/ktxdecompress.test.ts
@@ -11,7 +11,7 @@ import { logger } from '@gltf-transform/test-utils';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('ktxdecompress', () => {
+describe('cli::ktxdecompress', () => {
 	test('decompress', async () => {
 		KHRTextureBasisu.register();
 

--- a/packages/cli/test/ktxdecompress.test.ts
+++ b/packages/cli/test/ktxdecompress.test.ts
@@ -1,55 +1,58 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
 import type { ChildProcess } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { ktxdecompress, mockCommandExists, mockSpawn, mockWaitExit } from '@gltf-transform/cli';
 import { BufferUtils, Document } from '@gltf-transform/core';
 import { KHRTextureBasisu } from '@gltf-transform/extensions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('decompress', async (t) => {
-	KHRTextureBasisu.register();
+describe('ktxdecompress', () => {
+	test('decompress', async () => {
+		KHRTextureBasisu.register();
 
-	const imageKTX2 = BufferUtils.toView(await readFile(join(__dirname, 'in', 'test.ktx2')));
-	const imagePNG = new Uint8Array(32);
+		const imageKTX2 = BufferUtils.toView(await readFile(join(__dirname, 'in', 'test.ktx2')));
+		const imagePNG = new Uint8Array(32);
 
-	const calls = [] as string[][];
+		const calls = [] as string[][];
 
-	mockSpawn(async (_, params: string[]): Promise<ChildProcess> => {
-		calls.push(params);
+		mockSpawn(async (_, params: string[]): Promise<ChildProcess> => {
+			calls.push(params);
 
-		// Mock `ktx` version check.
-		if (params.join() === '--version') {
-			return { status: 0, stdout: 'v4.0.0', stderr: '' } as unknown as ChildProcess;
-		}
+			// Mock `ktx` version check.
+			if (params.join() === '--version') {
+				return { status: 0, stdout: 'v4.0.0', stderr: '' } as unknown as ChildProcess;
+			}
 
-		// Mock `ktx` decompression.
-		await writeFile(params[params.length - 1], imagePNG);
-		return { status: 0, stdout: '', stderr: '' } as unknown as ChildProcess;
+			// Mock `ktx` decompression.
+			await writeFile(params[params.length - 1], imagePNG);
+			return { status: 0, stdout: '', stderr: '' } as unknown as ChildProcess;
+		});
+
+		// biome-ignore lint/suspicious/noExplicitAny: TODO
+		mockWaitExit(async (process: any) => {
+			const { status, stdout, stderr } = await process;
+			return [status as number, stdout, stderr];
+		});
+
+		mockCommandExists(() => Promise.resolve(true));
+
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRTextureBasisu);
+		const texture = document.createTexture().setImage(imageKTX2).setMimeType('image/ktx2');
+		await document.transform(ktxdecompress());
+
+		strictEqual(calls.length, 2, 'calls ktx twice');
+		deepEqual(calls[0], ['--version'], 'calls ktx with --version');
+		deepEqual(calls[1][0], 'extract', 'calls ktx extract command');
+
+		strictEqual(texture.getMimeType(), 'image/png', 'replaces MIME type');
+		ok(BufferUtils.equals(texture.getImage()!, imagePNG), 'replaces image');
+
+		deepEqual(document.getRoot().listExtensionsUsed(), [], 'removes KHR_texture_basisu extension');
 	});
-
-	// biome-ignore lint/suspicious/noExplicitAny: TODO
-	mockWaitExit(async (process: any) => {
-		const { status, stdout, stderr } = await process;
-		return [status as number, stdout, stderr];
-	});
-
-	mockCommandExists(() => Promise.resolve(true));
-
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRTextureBasisu);
-	const texture = document.createTexture().setImage(imageKTX2).setMimeType('image/ktx2');
-	await document.transform(ktxdecompress());
-
-	t.is(calls.length, 2, 'calls ktx twice');
-	t.deepEqual(calls[0], ['--version'], 'calls ktx with --version');
-	t.deepEqual(calls[1][0], 'extract', 'calls ktx extract command');
-
-	t.is(texture.getMimeType(), 'image/png', 'replaces MIME type');
-	t.true(BufferUtils.equals(texture.getImage()!, imagePNG), 'replaces image');
-
-	t.deepEqual(document.getRoot().listExtensionsUsed(), [], 'removes KHR_texture_basisu extension');
 });

--- a/packages/cli/test/ktxfix.test.ts
+++ b/packages/cli/test/ktxfix.test.ts
@@ -1,7 +1,8 @@
+import { strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { ktxfix } from '@gltf-transform/cli';
 import { Document, type Texture } from '@gltf-transform/core';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import fs from 'fs';
 import { KHR_DF_PRIMARIES_BT709, KHR_DF_PRIMARIES_UNSPECIFIED, read } from 'ktx-parse';
 import path, { dirname } from 'path';
@@ -9,34 +10,36 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('repair', async (t) => {
-	const document = new Document().setLogger(logger);
-	const material = document.createMaterial();
-	const texture = document
-		.createTexture()
-		.setMimeType('image/ktx2')
-		.setImage(fs.readFileSync(path.join(__dirname, 'in', 'test.ktx2')));
+describe('ktxfix', () => {
+	test('repair', async () => {
+		const document = new Document().setLogger(logger);
+		const material = document.createMaterial();
+		const texture = document
+			.createTexture()
+			.setMimeType('image/ktx2')
+			.setImage(fs.readFileSync(path.join(__dirname, 'in', 'test.ktx2')));
 
-	t.is(getColorPrimaries(texture), KHR_DF_PRIMARIES_BT709, 'initial - sRGB');
+		strictEqual(getColorPrimaries(texture), KHR_DF_PRIMARIES_BT709, 'initial - sRGB');
 
-	await document.transform(ktxfix());
+		await document.transform(ktxfix());
 
-	t.is(getColorPrimaries(texture), KHR_DF_PRIMARIES_BT709, 'unused - no change');
+		strictEqual(getColorPrimaries(texture), KHR_DF_PRIMARIES_BT709, 'unused - no change');
 
-	material.setOcclusionTexture(texture);
-	await document.transform(ktxfix());
+		material.setOcclusionTexture(texture);
+		await document.transform(ktxfix());
 
-	t.is(getColorPrimaries(texture), KHR_DF_PRIMARIES_UNSPECIFIED, 'occlusion - unspecified');
+		strictEqual(getColorPrimaries(texture), KHR_DF_PRIMARIES_UNSPECIFIED, 'occlusion - unspecified');
 
-	texture.detach();
-	await document.transform(ktxfix());
+		texture.detach();
+		await document.transform(ktxfix());
 
-	t.is(getColorPrimaries(texture), KHR_DF_PRIMARIES_UNSPECIFIED, 'unused - no change');
+		strictEqual(getColorPrimaries(texture), KHR_DF_PRIMARIES_UNSPECIFIED, 'unused - no change');
 
-	material.setBaseColorTexture(texture);
-	await document.transform(ktxfix());
+		material.setBaseColorTexture(texture);
+		await document.transform(ktxfix());
 
-	t.is(getColorPrimaries(texture), KHR_DF_PRIMARIES_BT709, 'base color - sRGB');
+		strictEqual(getColorPrimaries(texture), KHR_DF_PRIMARIES_BT709, 'base color - sRGB');
+	});
 });
 
 function getColorPrimaries(texture: Texture): number {

--- a/packages/cli/test/ktxfix.test.ts
+++ b/packages/cli/test/ktxfix.test.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('ktxfix', () => {
+describe('cli::ktxfix', () => {
 	test('repair', async () => {
 		const document = new Document().setLogger(logger);
 		const material = document.createMaterial();

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -16,7 +16,7 @@ const createImage = (size: vec2): Promise<Uint8Array> => {
 	return savePixels(pixels, 'image/png');
 };
 
-describe('toktx', () => {
+describe('cli::toktx', () => {
 	test('compress and resize', async () => {
 		strictEqual(
 			await getParams({ mode: Mode.ETC1S }, await createImage([508, 508])),

--- a/packages/cli/test/toktx.test.ts
+++ b/packages/cli/test/toktx.test.ts
@@ -1,8 +1,9 @@
+import { strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Mode, mockCommandExists, mockSpawn, mockWaitExit, toktx } from '@gltf-transform/cli';
 import { Document, TextureChannel, type vec2 } from '@gltf-transform/core';
 import { KHRMaterialsClearcoat } from '@gltf-transform/extensions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import type { ChildProcess } from 'child_process';
 import fs from 'fs/promises';
 import ndarray from 'ndarray';
@@ -15,42 +16,44 @@ const createImage = (size: vec2): Promise<Uint8Array> => {
 	return savePixels(pixels, 'image/png');
 };
 
-test('compress and resize', async (t) => {
-	t.is(
-		await getParams({ mode: Mode.ETC1S }, await createImage([508, 508])),
-		'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM',
-		'508x508 → no change',
-	);
+describe('toktx', () => {
+	test('compress and resize', async () => {
+		strictEqual(
+			await getParams({ mode: Mode.ETC1S }, await createImage([508, 508])),
+			'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM',
+			'508x508 → no change',
+		);
 
-	t.is(
-		await getParams({ mode: Mode.ETC1S }, await createImage([507, 509])),
-		'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM --width 508 --height 512',
-		'507x509 → 508x512',
-	);
+		strictEqual(
+			await getParams({ mode: Mode.ETC1S }, await createImage([507, 509])),
+			'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM --width 508 --height 512',
+			'507x509 → 508x512',
+		);
 
-	t.is(
-		await getParams({ mode: Mode.ETC1S, resize: [504, 504] }, await createImage([508, 508])),
-		'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM --width 504 --height 504',
-		'508x508 → 504x504',
-	);
+		strictEqual(
+			await getParams({ mode: Mode.ETC1S, resize: [504, 504] }, await createImage([508, 508])),
+			'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM --width 504 --height 504',
+			'508x508 → 504x504',
+		);
 
-	t.is(
-		await getParams({ mode: Mode.ETC1S, resize: [4, 4] }, await createImage([5, 3])),
-		'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM --width 4 --height 4',
-		'5x3 → 4x4',
-	);
+		strictEqual(
+			await getParams({ mode: Mode.ETC1S, resize: [4, 4] }, await createImage([5, 3])),
+			'create --generate-mipmap --encode basis-lz --format R8G8B8_UNORM --width 4 --height 4',
+			'5x3 → 4x4',
+		);
 
-	t.is(
-		await getParams({ mode: Mode.ETC1S }, await createImage([508, 508]), R),
-		'create --generate-mipmap --encode basis-lz --assign-tf linear --assign-primaries none --format R8_UNORM',
-		'channels → R',
-	);
+		strictEqual(
+			await getParams({ mode: Mode.ETC1S }, await createImage([508, 508]), R),
+			'create --generate-mipmap --encode basis-lz --assign-tf linear --assign-primaries none --format R8_UNORM',
+			'channels → R',
+		);
 
-	t.is(
-		await getParams({ mode: Mode.ETC1S }, await createImage([508, 508]), G),
-		'create --generate-mipmap --encode basis-lz --assign-tf linear --assign-primaries none --format R8G8_UNORM',
-		'channels → RG',
-	);
+		strictEqual(
+			await getParams({ mode: Mode.ETC1S }, await createImage([508, 508]), G),
+			'create --generate-mipmap --encode basis-lz --assign-tf linear --assign-primaries none --format R8G8_UNORM',
+			'channels → RG',
+		);
+	});
 });
 
 async function getParams(options: Record<string, unknown>, image: Uint8Array, channels = 0): Promise<string> {

--- a/packages/cli/test/util.test.ts
+++ b/packages/cli/test/util.test.ts
@@ -1,5 +1,6 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { formatBytes, formatHeader, formatParagraph, pLimit } from '@gltf-transform/cli';
-import test from 'ava';
 
 const HEADER = `
  HELLO
@@ -14,24 +15,26 @@ Sesame snaps sweet roll icing macaroon croissant jujubes pastry apple pie
 chocolate cake. Liquorice jelly-o pie jujubes fruitcake chocolate bar jelly-o
 tart. Marshmallow icing tart tootsie roll brownie dragée.`.trim();
 
-test('formatBytes', (t) => {
-	t.is(formatBytes(1000), '1 KB', 'formatBytes');
-});
+describe('ktxdecompress', () => {
+	test('formatBytes', () => {
+		strictEqual(formatBytes(1000), '1 KB', 'formatBytes');
+	});
 
-test('formatHeader', (t) => {
-	t.is(formatHeader('Hello'), HEADER, 'formatHeader');
-});
+	test('formatHeader', () => {
+		strictEqual(formatHeader('Hello'), HEADER, 'formatHeader');
+	});
 
-test('formatParagraph', (t) => {
-	t.is(formatParagraph(TEXT), PARAGRAPH, 'formatParagraph');
-});
+	test('formatParagraph', () => {
+		strictEqual(formatParagraph(TEXT), PARAGRAPH, 'formatParagraph');
+	});
 
-test('pLimit', async (t) => {
-	const expected = ['a', 'b', 'c', 'd', 'e'];
+	test('pLimit', async () => {
+		const expected = ['a', 'b', 'c', 'd', 'e'];
 
-	for (const limit of [1, 2, 3, 4, 5]) {
-		const actual = [];
-		await pLimit(expected, limit, (item, index) => (actual[index] = item));
-		t.deepEqual(actual, expected, `limit=${limit}`);
-	}
+		for (const limit of [1, 2, 3, 4, 5]) {
+			const actual = [];
+			await pLimit(expected, limit, (item, index) => (actual[index] = item));
+			deepEqual(actual, expected, `limit=${limit}`);
+		}
+	});
 });

--- a/packages/cli/test/util.test.ts
+++ b/packages/cli/test/util.test.ts
@@ -15,7 +15,7 @@ Sesame snaps sweet roll icing macaroon croissant jujubes pastry apple pie
 chocolate cake. Liquorice jelly-o pie jujubes fruitcake chocolate bar jelly-o
 tart. Marshmallow icing tart tootsie roll brownie dragée.`.trim();
 
-describe('ktxdecompress', () => {
+describe('util', () => {
 	test('formatBytes', () => {
 		strictEqual(formatBytes(1000), '1 KB', 'formatBytes');
 	});

--- a/packages/cli/test/util.test.ts
+++ b/packages/cli/test/util.test.ts
@@ -15,7 +15,7 @@ Sesame snaps sweet roll icing macaroon croissant jujubes pastry apple pie
 chocolate cake. Liquorice jelly-o pie jujubes fruitcake chocolate bar jelly-o
 tart. Marshmallow icing tart tootsie roll brownie dragée.`.trim();
 
-describe('util', () => {
+describe('cli::util', () => {
 	test('formatBytes', () => {
 		strictEqual(formatBytes(1000), '1 KB', 'formatBytes');
 	});

--- a/packages/core/test/document.test.ts
+++ b/packages/core/test/document.test.ts
@@ -2,7 +2,7 @@ import { ok, strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 
-describe('Document', () => {
+describe('core::Document', () => {
 	test('transform', async () => {
 		const document = new Document();
 

--- a/packages/core/test/document.test.ts
+++ b/packages/core/test/document.test.ts
@@ -1,7 +1,8 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document } from '@gltf-transform/core';
-import test from 'ava';
 
-test('transform', async (t) => {
+test('transform', async () => {
 	const document = new Document();
 
 	await document.transform(
@@ -9,11 +10,11 @@ test('transform', async (t) => {
 		(c) => c.createBuffer(''),
 	);
 
-	t.is(document.getRoot().listTextures().length, 1, 'transform 1');
-	t.is(document.getRoot().listBuffers().length, 1, 'transform 2');
+	strictEqual(document.getRoot().listTextures().length, 1, 'transform 1');
+	strictEqual(document.getRoot().listBuffers().length, 1, 'transform 2');
 });
 
-test('defaults', (t) => {
+test('defaults', () => {
 	// offering to the code coverage gods.
 	const document = new Document();
 
@@ -30,5 +31,5 @@ test('defaults', (t) => {
 	document.createScene('test');
 	document.createSkin('test');
 
-	t.truthy(true);
+	ok(true);
 });

--- a/packages/core/test/document.test.ts
+++ b/packages/core/test/document.test.ts
@@ -1,35 +1,37 @@
 import { ok, strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 
-test('transform', async () => {
-	const document = new Document();
+describe('Document', () => {
+	test('transform', async () => {
+		const document = new Document();
 
-	await document.transform(
-		(c) => c.createTexture(''),
-		(c) => c.createBuffer(''),
-	);
+		await document.transform(
+			(c) => c.createTexture(''),
+			(c) => c.createBuffer(''),
+		);
 
-	strictEqual(document.getRoot().listTextures().length, 1, 'transform 1');
-	strictEqual(document.getRoot().listBuffers().length, 1, 'transform 2');
-});
+		strictEqual(document.getRoot().listTextures().length, 1, 'transform 1');
+		strictEqual(document.getRoot().listBuffers().length, 1, 'transform 2');
+	});
 
-test('defaults', () => {
-	// offering to the code coverage gods.
-	const document = new Document();
+	test('defaults', () => {
+		// offering to the code coverage gods.
+		const document = new Document();
 
-	document.createAccessor('test');
-	document.createAnimation('test');
-	document.createAnimationChannel('test');
-	document.createAnimationSampler('test');
-	document.createBuffer('test');
-	document.createCamera('test');
-	document.createMesh('test');
-	document.createNode('test');
-	document.createPrimitive();
-	document.createPrimitiveTarget('test');
-	document.createScene('test');
-	document.createSkin('test');
+		document.createAccessor('test');
+		document.createAnimation('test');
+		document.createAnimationChannel('test');
+		document.createAnimationSampler('test');
+		document.createBuffer('test');
+		document.createCamera('test');
+		document.createMesh('test');
+		document.createNode('test');
+		document.createPrimitive();
+		document.createPrimitiveTarget('test');
+		document.createScene('test');
+		document.createSkin('test');
 
-	ok(true);
+		ok(true);
+	});
 });

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -46,7 +46,7 @@ class Gizmo extends ExtensionProperty {
 GizmoExtension.EXTENSION_NAME = EXTENSION_NAME;
 Gizmo.EXTENSION_NAME = EXTENSION_NAME;
 
-describe('Extension', () => {
+describe('core::Extension', () => {
 	test('list', () => {
 		const document = new Document();
 		const extension = document.createExtension(GizmoExtension);

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -1,7 +1,8 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document, Extension, ExtensionProperty, PropertyType, type WriterContext } from '@gltf-transform/core';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const EXTENSION_NAME = 'TEST_node_gizmo';
 
@@ -45,54 +46,54 @@ class Gizmo extends ExtensionProperty {
 GizmoExtension.EXTENSION_NAME = EXTENSION_NAME;
 Gizmo.EXTENSION_NAME = EXTENSION_NAME;
 
-test('list', (t) => {
+test('list', () => {
 	const document = new Document();
 	const extension = document.createExtension(GizmoExtension);
 
-	t.deepEqual(document.getRoot().listExtensionsUsed(), [extension], 'listExtensionsUsed()');
-	t.deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
+	deepEqual(document.getRoot().listExtensionsUsed(), [extension], 'listExtensionsUsed()');
+	deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
 
 	extension.setRequired(true);
-	t.deepEqual(document.getRoot().listExtensionsRequired(), [extension], 'listExtensionsRequired()');
+	deepEqual(document.getRoot().listExtensionsRequired(), [extension], 'listExtensionsRequired()');
 
 	extension.dispose();
-	t.deepEqual(document.getRoot().listExtensionsUsed(), [], 'listExtensionsUsed()');
-	t.deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
+	deepEqual(document.getRoot().listExtensionsUsed(), [], 'listExtensionsUsed()');
+	deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
 });
 
-test('property', (t) => {
+test('property', () => {
 	const document = new Document();
 	const extension = document.createExtension(GizmoExtension) as GizmoExtension;
 	const gizmo = extension.createGizmo();
 	const node = document.createNode('MyNode');
 
-	t.is(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (1)');
+	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (1)');
 
 	// Add ExtensionProperty.
 
 	node.setExtension(EXTENSION_NAME, gizmo);
-	t.is(node.getExtension(EXTENSION_NAME), gizmo, 'getExtension() → gizmo');
-	t.deepEqual(node.listExtensions(), [gizmo], 'listExtensions() → [gizmo x1]');
+	strictEqual(node.getExtension(EXTENSION_NAME), gizmo, 'getExtension() → gizmo');
+	deepEqual(node.listExtensions(), [gizmo], 'listExtensions() → [gizmo x1]');
 
 	// Remove ExtensionProperty.
 
 	node.setExtension(EXTENSION_NAME, null);
-	t.is(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (2)');
+	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (2)');
 
 	// Dispose ExtensionProperty.
 
 	node.setExtension(EXTENSION_NAME, gizmo);
 	gizmo.dispose();
-	t.is(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (3)');
+	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (3)');
 
 	// Dispose Extension.
 
 	node.setExtension(EXTENSION_NAME, extension.createGizmo());
 	extension.dispose();
-	t.is(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (4)');
+	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (4)');
 });
 
-test('i/o', async (t) => {
+test('i/o', async () => {
 	const io = (await createPlatformIO()).registerExtensions([GizmoExtension]);
 	const document = new Document();
 	const extension = document.createExtension(GizmoExtension) as GizmoExtension;
@@ -106,19 +107,19 @@ test('i/o', async (t) => {
 	// Write (unregistered).
 
 	jsonDoc = await (await createPlatformIO()).writeJSON(document, options);
-	t.deepEqual(jsonDoc.json.extensionsUsed, undefined, 'write extensionsUsed (unregistered)');
+	deepEqual(jsonDoc.json.extensionsUsed, undefined, 'write extensionsUsed (unregistered)');
 
 	// Write (registered).
 
 	jsonDoc = await io.writeJSON(document, options);
-	t.deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)');
-	t.is(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
-	t.is(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
+	deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)');
+	strictEqual(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
+	strictEqual(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
 
 	// Read.
 
 	resultDoc = await io.readJSON(jsonDoc);
-	t.deepEqual(
+	deepEqual(
 		resultDoc
 			.getRoot()
 			.listExtensionsUsed()
@@ -126,8 +127,8 @@ test('i/o', async (t) => {
 		['TEST_node_gizmo'],
 		'roundtrip extensionsUsed',
 	);
-	t.deepEqual(resultDoc.getRoot().listExtensionsRequired(), [], 'roundtrip omit extensionsRequired');
-	t.is(
+	deepEqual(resultDoc.getRoot().listExtensionsRequired(), [], 'roundtrip omit extensionsRequired');
+	strictEqual(
 		resultDoc.getRoot().listNodes()[0].getExtension(EXTENSION_NAME).extensionName,
 		'TEST_node_gizmo',
 		'roundtrip extend node',
@@ -137,9 +138,9 @@ test('i/o', async (t) => {
 
 	extension.setRequired(true);
 	jsonDoc = await io.writeJSON(document, options);
-	t.deepEqual(jsonDoc.json.extensionsRequired, ['TEST_node_gizmo'], 'write extensionsRequired');
+	deepEqual(jsonDoc.json.extensionsRequired, ['TEST_node_gizmo'], 'write extensionsRequired');
 	resultDoc = await io.readJSON(jsonDoc);
-	t.deepEqual(
+	deepEqual(
 		resultDoc
 			.getRoot()
 			.listExtensionsRequired()
@@ -149,19 +150,19 @@ test('i/o', async (t) => {
 	);
 });
 
-test('clone', (t) => {
+test('clone', () => {
 	const document = new Document();
 	const extension = document.createExtension(GizmoExtension) as GizmoExtension;
 	const gizmo = extension.createGizmo();
 	document.createNode().setExtension(EXTENSION_NAME, gizmo);
 
 	let docClone: Document;
-	t.truthy(gizmo.clone(), 'clones gizmo');
-	t.truthy((docClone = cloneDocument(document)), 'clones document');
-	t.truthy(docClone.getRoot().listNodes()[0].getExtension(EXTENSION_NAME), 'preserves gizmo');
+	ok(gizmo.clone(), 'clones gizmo');
+	ok((docClone = cloneDocument(document)), 'clones document');
+	ok(docClone.getRoot().listNodes()[0].getExtension(EXTENSION_NAME), 'preserves gizmo');
 });
 
-test('stable execution order', async (t) => {
+test('stable execution order', async () => {
 	const readOrder: string[] = [];
 	const writeOrder: string[] = [];
 
@@ -220,9 +221,9 @@ test('stable execution order', async (t) => {
 		.listExtensionsUsed()
 		.map((ext) => ext.extensionName);
 
-	t.deepEqual(writeOrder, expectedOrder, 'write order');
-	t.deepEqual(readOrder, expectedOrder, 'read order');
-	t.deepEqual(extensionNames, ['A', 'B', 'C'], 'extension order');
+	deepEqual(writeOrder, expectedOrder, 'write order');
+	deepEqual(readOrder, expectedOrder, 'read order');
+	deepEqual(extensionNames, ['A', 'B', 'C'], 'extension order');
 
 	// Reset.
 
@@ -242,7 +243,7 @@ test('stable execution order', async (t) => {
 		.listExtensionsUsed()
 		.map((ext) => ext.extensionName);
 
-	t.deepEqual(writeOrder, expectedOrder, 'write order (reversed)');
-	t.deepEqual(readOrder, expectedOrder, 'read order (reversed)');
-	t.deepEqual(extensionNamesReversed, ['A', 'B', 'C'], 'extension order (reversed)');
+	deepEqual(writeOrder, expectedOrder, 'write order (reversed)');
+	deepEqual(readOrder, expectedOrder, 'read order (reversed)');
+	deepEqual(extensionNamesReversed, ['A', 'B', 'C'], 'extension order (reversed)');
 });

--- a/packages/core/test/extension.test.ts
+++ b/packages/core/test/extension.test.ts
@@ -1,5 +1,5 @@
 import { deepEqual, ok, strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { Document, Extension, ExtensionProperty, PropertyType, type WriterContext } from '@gltf-transform/core';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
@@ -46,204 +46,206 @@ class Gizmo extends ExtensionProperty {
 GizmoExtension.EXTENSION_NAME = EXTENSION_NAME;
 Gizmo.EXTENSION_NAME = EXTENSION_NAME;
 
-test('list', () => {
-	const document = new Document();
-	const extension = document.createExtension(GizmoExtension);
+describe('Extension', () => {
+	test('list', () => {
+		const document = new Document();
+		const extension = document.createExtension(GizmoExtension);
 
-	deepEqual(document.getRoot().listExtensionsUsed(), [extension], 'listExtensionsUsed()');
-	deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
+		deepEqual(document.getRoot().listExtensionsUsed(), [extension], 'listExtensionsUsed()');
+		deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
 
-	extension.setRequired(true);
-	deepEqual(document.getRoot().listExtensionsRequired(), [extension], 'listExtensionsRequired()');
+		extension.setRequired(true);
+		deepEqual(document.getRoot().listExtensionsRequired(), [extension], 'listExtensionsRequired()');
 
-	extension.dispose();
-	deepEqual(document.getRoot().listExtensionsUsed(), [], 'listExtensionsUsed()');
-	deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
-});
+		extension.dispose();
+		deepEqual(document.getRoot().listExtensionsUsed(), [], 'listExtensionsUsed()');
+		deepEqual(document.getRoot().listExtensionsRequired(), [], 'listExtensionsRequired()');
+	});
 
-test('property', () => {
-	const document = new Document();
-	const extension = document.createExtension(GizmoExtension) as GizmoExtension;
-	const gizmo = extension.createGizmo();
-	const node = document.createNode('MyNode');
+	test('property', () => {
+		const document = new Document();
+		const extension = document.createExtension(GizmoExtension) as GizmoExtension;
+		const gizmo = extension.createGizmo();
+		const node = document.createNode('MyNode');
 
-	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (1)');
+		strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (1)');
 
-	// Add ExtensionProperty.
+		// Add ExtensionProperty.
 
-	node.setExtension(EXTENSION_NAME, gizmo);
-	strictEqual(node.getExtension(EXTENSION_NAME), gizmo, 'getExtension() → gizmo');
-	deepEqual(node.listExtensions(), [gizmo], 'listExtensions() → [gizmo x1]');
+		node.setExtension(EXTENSION_NAME, gizmo);
+		strictEqual(node.getExtension(EXTENSION_NAME), gizmo, 'getExtension() → gizmo');
+		deepEqual(node.listExtensions(), [gizmo], 'listExtensions() → [gizmo x1]');
 
-	// Remove ExtensionProperty.
+		// Remove ExtensionProperty.
 
-	node.setExtension(EXTENSION_NAME, null);
-	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (2)');
+		node.setExtension(EXTENSION_NAME, null);
+		strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (2)');
 
-	// Dispose ExtensionProperty.
+		// Dispose ExtensionProperty.
 
-	node.setExtension(EXTENSION_NAME, gizmo);
-	gizmo.dispose();
-	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (3)');
+		node.setExtension(EXTENSION_NAME, gizmo);
+		gizmo.dispose();
+		strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (3)');
 
-	// Dispose Extension.
+		// Dispose Extension.
 
-	node.setExtension(EXTENSION_NAME, extension.createGizmo());
-	extension.dispose();
-	strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (4)');
-});
+		node.setExtension(EXTENSION_NAME, extension.createGizmo());
+		extension.dispose();
+		strictEqual(node.getExtension(EXTENSION_NAME), null, 'getExtension() → null (4)');
+	});
 
-test('i/o', async () => {
-	const io = (await createPlatformIO()).registerExtensions([GizmoExtension]);
-	const document = new Document();
-	const extension = document.createExtension(GizmoExtension) as GizmoExtension;
-	document.createNode().setExtension(EXTENSION_NAME, extension.createGizmo());
+	test('i/o', async () => {
+		const io = (await createPlatformIO()).registerExtensions([GizmoExtension]);
+		const document = new Document();
+		const extension = document.createExtension(GizmoExtension) as GizmoExtension;
+		document.createNode().setExtension(EXTENSION_NAME, extension.createGizmo());
 
-	const options = { basename: 'extensionTest' };
+		const options = { basename: 'extensionTest' };
 
-	let jsonDoc;
-	let resultDoc;
+		let jsonDoc;
+		let resultDoc;
 
-	// Write (unregistered).
+		// Write (unregistered).
 
-	jsonDoc = await (await createPlatformIO()).writeJSON(document, options);
-	deepEqual(jsonDoc.json.extensionsUsed, undefined, 'write extensionsUsed (unregistered)');
+		jsonDoc = await (await createPlatformIO()).writeJSON(document, options);
+		deepEqual(jsonDoc.json.extensionsUsed, undefined, 'write extensionsUsed (unregistered)');
 
-	// Write (registered).
+		// Write (registered).
 
-	jsonDoc = await io.writeJSON(document, options);
-	deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)');
-	strictEqual(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
-	strictEqual(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
+		jsonDoc = await io.writeJSON(document, options);
+		deepEqual(jsonDoc.json.extensionsUsed, ['TEST_node_gizmo'], 'write extensionsUsed (registered)');
+		strictEqual(jsonDoc.json.extensionsRequired, undefined, 'omit extensionsRequired');
+		strictEqual(jsonDoc.json.nodes[0].extensions.TEST_node_gizmo.isGizmo, true, 'extend node');
 
-	// Read.
+		// Read.
 
-	resultDoc = await io.readJSON(jsonDoc);
-	deepEqual(
-		resultDoc
+		resultDoc = await io.readJSON(jsonDoc);
+		deepEqual(
+			resultDoc
+				.getRoot()
+				.listExtensionsUsed()
+				.map((ext) => ext.extensionName),
+			['TEST_node_gizmo'],
+			'roundtrip extensionsUsed',
+		);
+		deepEqual(resultDoc.getRoot().listExtensionsRequired(), [], 'roundtrip omit extensionsRequired');
+		strictEqual(
+			resultDoc.getRoot().listNodes()[0].getExtension(EXTENSION_NAME).extensionName,
+			'TEST_node_gizmo',
+			'roundtrip extend node',
+		);
+
+		// Write + read with extensionsRequired.
+
+		extension.setRequired(true);
+		jsonDoc = await io.writeJSON(document, options);
+		deepEqual(jsonDoc.json.extensionsRequired, ['TEST_node_gizmo'], 'write extensionsRequired');
+		resultDoc = await io.readJSON(jsonDoc);
+		deepEqual(
+			resultDoc
+				.getRoot()
+				.listExtensionsRequired()
+				.map((ext) => ext.extensionName),
+			['TEST_node_gizmo'],
+			'roundtrip extensionsRequired',
+		);
+	});
+
+	test('clone', () => {
+		const document = new Document();
+		const extension = document.createExtension(GizmoExtension) as GizmoExtension;
+		const gizmo = extension.createGizmo();
+		document.createNode().setExtension(EXTENSION_NAME, gizmo);
+
+		let docClone: Document;
+		ok(gizmo.clone(), 'clones gizmo');
+		ok((docClone = cloneDocument(document)), 'clones document');
+		ok(docClone.getRoot().listNodes()[0].getExtension(EXTENSION_NAME), 'preserves gizmo');
+	});
+
+	test('stable execution order', async () => {
+		const readOrder: string[] = [];
+		const writeOrder: string[] = [];
+
+		abstract class MockExtension extends Extension {
+			prewrite(): this {
+				writeOrder.push(this.extensionName);
+				return this;
+			}
+			write(): this {
+				writeOrder.push(this.extensionName);
+				return this;
+			}
+			preread() {
+				readOrder.push(this.extensionName);
+				return this;
+			}
+			read() {
+				readOrder.push(this.extensionName);
+				return this;
+			}
+		}
+
+		class ExtensionA extends MockExtension {
+			static EXTENSION_NAME = 'A';
+			extensionName = 'A';
+		}
+
+		class ExtensionB extends MockExtension {
+			static EXTENSION_NAME = 'B';
+			extensionName = 'B';
+			prereadTypes = [PropertyType.MATERIAL];
+			prewriteTypes = [PropertyType.MATERIAL];
+		}
+
+		class ExtensionC extends MockExtension {
+			static EXTENSION_NAME = 'C';
+			extensionName = 'C';
+			prereadTypes = [PropertyType.MESH];
+			prewriteTypes = [PropertyType.MESH];
+		}
+
+		// Execution order must be stable regardless of the order in which
+		// extensions are registered.
+		const expectedOrder = ['B', 'C', 'A', 'B', 'C'];
+
+		// Alphabetical.
+
+		const extensions = [ExtensionA, ExtensionB, ExtensionC];
+		const io = (await createPlatformIO()).registerExtensions(extensions);
+		const document = new Document();
+		extensions.forEach((Ext) => document.createExtension(Ext));
+		const glb = await io.writeBinary(document);
+		const rtDocument = await io.readBinary(glb);
+		const extensionNames = rtDocument
 			.getRoot()
 			.listExtensionsUsed()
-			.map((ext) => ext.extensionName),
-		['TEST_node_gizmo'],
-		'roundtrip extensionsUsed',
-	);
-	deepEqual(resultDoc.getRoot().listExtensionsRequired(), [], 'roundtrip omit extensionsRequired');
-	strictEqual(
-		resultDoc.getRoot().listNodes()[0].getExtension(EXTENSION_NAME).extensionName,
-		'TEST_node_gizmo',
-		'roundtrip extend node',
-	);
+			.map((ext) => ext.extensionName);
 
-	// Write + read with extensionsRequired.
+		deepEqual(writeOrder, expectedOrder, 'write order');
+		deepEqual(readOrder, expectedOrder, 'read order');
+		deepEqual(extensionNames, ['A', 'B', 'C'], 'extension order');
 
-	extension.setRequired(true);
-	jsonDoc = await io.writeJSON(document, options);
-	deepEqual(jsonDoc.json.extensionsRequired, ['TEST_node_gizmo'], 'write extensionsRequired');
-	resultDoc = await io.readJSON(jsonDoc);
-	deepEqual(
-		resultDoc
+		// Reset.
+
+		writeOrder.length = 0;
+		readOrder.length = 0;
+
+		// Reverse alphabetical.
+
+		const extensionsReversed = extensions.slice().reverse();
+		const ioReversed = (await createPlatformIO()).registerExtensions(extensionsReversed);
+		const documentReversed = new Document();
+		extensionsReversed.forEach((Ext) => documentReversed.createExtension(Ext));
+		const glbReversed = await ioReversed.writeBinary(documentReversed);
+		const rtDocumentReversed = await ioReversed.readBinary(glbReversed);
+		const extensionNamesReversed = rtDocumentReversed
 			.getRoot()
-			.listExtensionsRequired()
-			.map((ext) => ext.extensionName),
-		['TEST_node_gizmo'],
-		'roundtrip extensionsRequired',
-	);
-});
+			.listExtensionsUsed()
+			.map((ext) => ext.extensionName);
 
-test('clone', () => {
-	const document = new Document();
-	const extension = document.createExtension(GizmoExtension) as GizmoExtension;
-	const gizmo = extension.createGizmo();
-	document.createNode().setExtension(EXTENSION_NAME, gizmo);
-
-	let docClone: Document;
-	ok(gizmo.clone(), 'clones gizmo');
-	ok((docClone = cloneDocument(document)), 'clones document');
-	ok(docClone.getRoot().listNodes()[0].getExtension(EXTENSION_NAME), 'preserves gizmo');
-});
-
-test('stable execution order', async () => {
-	const readOrder: string[] = [];
-	const writeOrder: string[] = [];
-
-	abstract class MockExtension extends Extension {
-		prewrite(): this {
-			writeOrder.push(this.extensionName);
-			return this;
-		}
-		write(): this {
-			writeOrder.push(this.extensionName);
-			return this;
-		}
-		preread() {
-			readOrder.push(this.extensionName);
-			return this;
-		}
-		read() {
-			readOrder.push(this.extensionName);
-			return this;
-		}
-	}
-
-	class ExtensionA extends MockExtension {
-		static EXTENSION_NAME = 'A';
-		extensionName = 'A';
-	}
-
-	class ExtensionB extends MockExtension {
-		static EXTENSION_NAME = 'B';
-		extensionName = 'B';
-		prereadTypes = [PropertyType.MATERIAL];
-		prewriteTypes = [PropertyType.MATERIAL];
-	}
-
-	class ExtensionC extends MockExtension {
-		static EXTENSION_NAME = 'C';
-		extensionName = 'C';
-		prereadTypes = [PropertyType.MESH];
-		prewriteTypes = [PropertyType.MESH];
-	}
-
-	// Execution order must be stable regardless of the order in which
-	// extensions are registered.
-	const expectedOrder = ['B', 'C', 'A', 'B', 'C'];
-
-	// Alphabetical.
-
-	const extensions = [ExtensionA, ExtensionB, ExtensionC];
-	const io = (await createPlatformIO()).registerExtensions(extensions);
-	const document = new Document();
-	extensions.forEach((Ext) => document.createExtension(Ext));
-	const glb = await io.writeBinary(document);
-	const rtDocument = await io.readBinary(glb);
-	const extensionNames = rtDocument
-		.getRoot()
-		.listExtensionsUsed()
-		.map((ext) => ext.extensionName);
-
-	deepEqual(writeOrder, expectedOrder, 'write order');
-	deepEqual(readOrder, expectedOrder, 'read order');
-	deepEqual(extensionNames, ['A', 'B', 'C'], 'extension order');
-
-	// Reset.
-
-	writeOrder.length = 0;
-	readOrder.length = 0;
-
-	// Reverse alphabetical.
-
-	const extensionsReversed = extensions.slice().reverse();
-	const ioReversed = (await createPlatformIO()).registerExtensions(extensionsReversed);
-	const documentReversed = new Document();
-	extensionsReversed.forEach((Ext) => documentReversed.createExtension(Ext));
-	const glbReversed = await ioReversed.writeBinary(documentReversed);
-	const rtDocumentReversed = await ioReversed.readBinary(glbReversed);
-	const extensionNamesReversed = rtDocumentReversed
-		.getRoot()
-		.listExtensionsUsed()
-		.map((ext) => ext.extensionName);
-
-	deepEqual(writeOrder, expectedOrder, 'write order (reversed)');
-	deepEqual(readOrder, expectedOrder, 'read order (reversed)');
-	deepEqual(extensionNamesReversed, ['A', 'B', 'C'], 'extension order (reversed)');
+		deepEqual(writeOrder, expectedOrder, 'write order (reversed)');
+		deepEqual(readOrder, expectedOrder, 'read order (reversed)');
+		deepEqual(extensionNamesReversed, ['A', 'B', 'C'], 'extension order (reversed)');
+	});
 });

--- a/packages/core/test/io/node-io.test.ts
+++ b/packages/core/test/io/node-io.test.ts
@@ -24,7 +24,7 @@ const fetch = async (input: RequestInfo, _init?: RequestInit) => {
 	};
 };
 
-describe('NodeIO', () => {
+describe('core::NodeIO', () => {
 	test('read glb', async () => {
 		if (environment !== Environment.NODE) return;
 		const io = (await createPlatformIO()) as NodeIO;

--- a/packages/core/test/io/node-io.test.ts
+++ b/packages/core/test/io/node-io.test.ts
@@ -1,9 +1,10 @@
+import { deepEqual, ok, rejects, strictEqual } from 'node:assert/strict';
 import { glob, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
+import { describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { createPlatformIO, Environment, environment, logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -23,183 +24,185 @@ const fetch = async (input: RequestInfo, _init?: RequestInit) => {
 	};
 };
 
-test('read glb', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = (await createPlatformIO()) as NodeIO;
-	let count = 0;
-	for await (const inputURI of glob(resolve(__dirname, '../in/**/*.glb'))) {
-		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
-		const document = io.read(inputURI);
+describe('NodeIO', () => {
+	test('read glb', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = (await createPlatformIO()) as NodeIO;
+		let count = 0;
+		for await (const inputURI of glob(resolve(__dirname, '../in/**/*.glb'))) {
+			const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
+			const document = io.read(inputURI);
 
-		t.truthy(document, `Read "${basepath}".`);
-		count++;
-	}
-	t.truthy(count > 0, 'tests completed');
-});
+			ok(document, `Read "${basepath}".`);
+			count++;
+		}
+		ok(count > 0, 'tests completed');
+	});
 
-test('read gltf', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = (await createPlatformIO()) as NodeIO;
-	let count = 0;
-	for await (const inputURI of glob(resolve(__dirname, '../in/**/*.gltf'))) {
-		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
-		const document = await io.read(inputURI);
+	test('read gltf', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = (await createPlatformIO()) as NodeIO;
+		let count = 0;
+		for await (const inputURI of glob(resolve(__dirname, '../in/**/*.gltf'))) {
+			const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
+			const document = await io.read(inputURI);
 
-		t.truthy(document, `Read "${basepath}".`);
-		count++;
-	}
-	t.truthy(count > 0, 'tests completed');
-});
+			ok(document, `Read "${basepath}".`);
+			count++;
+		}
+		ok(count > 0, 'tests completed');
+	});
 
-test('read glb http', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
-	let count = 0;
-	for await (const inputURI of glob(resolve(__dirname, '../in/**/*.glb'))) {
-		const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
-		const document = await io.read(basepath);
+	test('read glb http', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
+		let count = 0;
+		for await (const inputURI of glob(resolve(__dirname, '../in/**/*.glb'))) {
+			const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
+			const document = await io.read(basepath);
 
-		t.truthy(document, `Read "${basepath}".`);
-		count++;
-	}
-	t.truthy(count > 0, 'tests completed');
-});
+			ok(document, `Read "${basepath}".`);
+			count++;
+		}
+		ok(count > 0, 'tests completed');
+	});
 
-test('read gltf http', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
-	let count = 0;
-	for await (const inputURI of glob(resolve(__dirname, '../in/**/*.gltf'))) {
-		const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
-		const document = await io.read(basepath);
+	test('read gltf http', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
+		let count = 0;
+		for await (const inputURI of glob(resolve(__dirname, '../in/**/*.gltf'))) {
+			const basepath = inputURI.replace(resolve(__dirname, '../in'), MOCK_DOMAIN);
+			const document = await io.read(basepath);
 
-		t.truthy(document, `Read "${basepath}".`);
-		count++;
-	}
-	t.truthy(count > 0, 'tests completed');
-});
+			ok(document, `Read "${basepath}".`);
+			count++;
+		}
+		ok(count > 0, 'tests completed');
+	});
 
-test('write glb', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = (await createPlatformIO()) as NodeIO;
-	let count = 0;
-	for await (const inputURI of glob(resolve(__dirname, '../in/**/*.gltf'))) {
-		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
-		const outputURI = resolve(__dirname, `../out/${basepath}`);
-		const document = await io.read(inputURI);
+	test('write glb', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = (await createPlatformIO()) as NodeIO;
+		let count = 0;
+		for await (const inputURI of glob(resolve(__dirname, '../in/**/*.gltf'))) {
+			const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
+			const outputURI = resolve(__dirname, `../out/${basepath}`);
+			const document = await io.read(inputURI);
 
-		await mkdir(dirname(outputURI), { recursive: true });
-		await io.write(outputURI.replace('.gltf', '.glb'), document);
-		t.truthy(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
-		count++;
-	}
-	t.truthy(count > 0, 'tests completed');
-});
+			await mkdir(dirname(outputURI), { recursive: true });
+			await io.write(outputURI.replace('.gltf', '.glb'), document);
+			ok(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
+			count++;
+		}
+		ok(count > 0, 'tests completed');
+	});
 
-test('write gltf', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = (await createPlatformIO()) as NodeIO;
-	let count = 0;
-	for await (const inputURI of glob(resolve(__dirname, '../in/**/*.glb'))) {
-		const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
-		const outputURI = resolve(__dirname, `../out/${basepath}`);
-		const document = await io.read(inputURI);
+	test('write gltf', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = (await createPlatformIO()) as NodeIO;
+		let count = 0;
+		for await (const inputURI of glob(resolve(__dirname, '../in/**/*.glb'))) {
+			const basepath = inputURI.replace(resolve(__dirname, '../in'), '.');
+			const outputURI = resolve(__dirname, `../out/${basepath}`);
+			const document = await io.read(inputURI);
 
-		await mkdir(dirname(outputURI), { recursive: true });
-		await io.write(outputURI.replace('.glb', '.gltf'), document);
-		t.truthy(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
-		count++;
-	}
-	t.truthy(count > 0, 'tests completed');
-});
+			await mkdir(dirname(outputURI), { recursive: true });
+			await io.write(outputURI.replace('.glb', '.gltf'), document);
+			ok(true, `Wrote "${basepath}".`); // TODO(cleanup): Test the output somehow.
+			count++;
+		}
+		ok(count > 0, 'tests completed');
+	});
 
-test('write gltf with HTTP', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const document = new Document();
-	document.createBuffer();
-	document
-		.createTexture('Internal Texture')
-		.setURI('internal.png')
-		.setMimeType('image/png')
-		.setImage(new Uint8Array(1024));
-	document
-		.createTexture('External Texture')
-		.setURI('https://test.example/external.png')
-		.setMimeType('image/png')
-		.setImage(new Uint8Array(1024));
-	const io = (await createPlatformIO()) as NodeIO;
-	const outputURI = resolve(__dirname, '../out/node-io-external-test');
-	await mkdir(outputURI, { recursive: true });
-	await io.write(join(outputURI, 'scene.gltf'), document);
-	t.truthy((await stat(join(outputURI, 'internal.png'))).isFile(), 'writes internal image');
-	t.falsy(await stat(join(outputURI, 'external.png')).catch(() => false), 'skips external image');
-	t.truthy(io.lastWriteBytes < 2048, 'writes < 2048 bytes');
-});
+	test('write gltf with HTTP', async () => {
+		if (environment !== Environment.NODE) return;
+		const document = new Document();
+		document.createBuffer();
+		document
+			.createTexture('Internal Texture')
+			.setURI('internal.png')
+			.setMimeType('image/png')
+			.setImage(new Uint8Array(1024));
+		document
+			.createTexture('External Texture')
+			.setURI('https://test.example/external.png')
+			.setMimeType('image/png')
+			.setImage(new Uint8Array(1024));
+		const io = (await createPlatformIO()) as NodeIO;
+		const outputURI = resolve(__dirname, '../out/node-io-external-test');
+		await mkdir(outputURI, { recursive: true });
+		await io.write(join(outputURI, 'scene.gltf'), document);
+		ok((await stat(join(outputURI, 'internal.png'))).isFile(), 'writes internal image');
+		strictEqual(await stat(join(outputURI, 'external.png')).catch(() => false), false, 'skips external image');
+		ok(io.lastWriteBytes < 2048, 'writes < 2048 bytes');
+	});
 
-test('resource URI encoding', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = (await createPlatformIO()) as NodeIO;
+	test('resource URI encoding', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = (await createPlatformIO()) as NodeIO;
 
-	const srcDir = resolve(__dirname, '..', 'in', 'EncodingTest');
-	const dstDir = resolve(__dirname, '..', 'out', 'EncodingTest');
-	await mkdir(dstDir, { recursive: true });
+		const srcDir = resolve(__dirname, '..', 'in', 'EncodingTest');
+		const dstDir = resolve(__dirname, '..', 'out', 'EncodingTest');
+		await mkdir(dstDir, { recursive: true });
 
-	const srcJSONDocument = await io.readAsJSON(resolve(srcDir, 'Unicode ❤♻ Test.gltf'));
+		const srcJSONDocument = await io.readAsJSON(resolve(srcDir, 'Unicode ❤♻ Test.gltf'));
 
-	t.deepEqual(
-		Object.keys(srcJSONDocument.resources).sort(),
-		['Unicode%20❤♻ Binary.bin', 'Unicode%20❤♻ Texture.png'],
-		'URIs in source JSON document',
-	);
+		deepEqual(
+			Object.keys(srcJSONDocument.resources).sort(),
+			['Unicode%20❤♻ Binary.bin', 'Unicode%20❤♻ Texture.png'],
+			'URIs in source JSON document',
+		);
 
-	const document = await io.readJSON(srcJSONDocument);
-	const buffer = document.getRoot().listBuffers()[0];
-	const texture = document.getRoot().listTextures()[0];
+		const document = await io.readJSON(srcJSONDocument);
+		const buffer = document.getRoot().listBuffers()[0];
+		const texture = document.getRoot().listTextures()[0];
 
-	// TODO(v4): For backward-compatibility, URIs remain encoded in memory.
-	t.deepEqual(
-		[buffer.getURI(), texture.getURI()],
-		['Unicode%20❤♻ Binary.bin', 'Unicode%20❤♻ Texture.png'],
-		'URIs in document',
-	);
+		// TODO(v4): For backward-compatibility, URIs remain encoded in memory.
+		deepEqual(
+			[buffer.getURI(), texture.getURI()],
+			['Unicode%20❤♻ Binary.bin', 'Unicode%20❤♻ Texture.png'],
+			'URIs in document',
+		);
 
-	const dstJSONDocument = await io.writeJSON(document);
+		const dstJSONDocument = await io.writeJSON(document);
 
-	t.deepEqual(
-		Object.keys(dstJSONDocument.resources).sort(),
-		['Unicode%20❤♻ Binary.bin', 'Unicode%20❤♻ Texture.png'],
-		'URIs in source JSON document',
-	);
+		deepEqual(
+			Object.keys(dstJSONDocument.resources).sort(),
+			['Unicode%20❤♻ Binary.bin', 'Unicode%20❤♻ Texture.png'],
+			'URIs in source JSON document',
+		);
 
-	await io.write(resolve(dstDir, 'Unicode ❤♻ Test.gltf'), document);
+		await io.write(resolve(dstDir, 'Unicode ❤♻ Test.gltf'), document);
 
-	// Decoded URIs match source resources, not the (encoded) URI in the source glTF JSON.
-	t.true((await stat(resolve(dstDir, 'Unicode ❤♻ Binary.bin'))).isFile(), 'file path to buffer');
-	t.true((await stat(resolve(dstDir, 'Unicode ❤♻ Texture.png'))).isFile(), 'file path to texture');
-});
+		// Decoded URIs match source resources, not the (encoded) URI in the source glTF JSON.
+		ok((await stat(resolve(dstDir, 'Unicode ❤♻ Binary.bin'))).isFile(), 'file path to buffer');
+		ok((await stat(resolve(dstDir, 'Unicode ❤♻ Texture.png'))).isFile(), 'file path to texture');
+	});
 
-test('strict / non-strict resource modes', async (t) => {
-	if (environment !== Environment.NODE) return t.pass();
-	const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
+	test('strict / non-strict resource modes', async () => {
+		if (environment !== Environment.NODE) return;
+		const io = new NodeIO(fetch).setLogger(logger).setAllowNetwork(true);
 
-	const dstDir = resolve(__dirname, '..', 'out', 'MissingImageTest');
-	const dstPath = resolve(dstDir, 'MissingImage.gltf');
-	await mkdir(dstDir, { recursive: true });
+		const dstDir = resolve(__dirname, '..', 'out', 'MissingImageTest');
+		const dstPath = resolve(dstDir, 'MissingImage.gltf');
+		await mkdir(dstDir, { recursive: true });
 
-	writeFile(
-		dstPath,
-		JSON.stringify({
-			asset: { version: '2.0' },
-			images: [{ uri: '__missing.png', mimeType: 'image/png' }],
-		}),
-	);
+		writeFile(
+			dstPath,
+			JSON.stringify({
+				asset: { version: '2.0' },
+				images: [{ uri: '__missing.png', mimeType: 'image/png' }],
+			}),
+		);
 
-	await t.throwsAsync(() => io.read(dstPath), { message: /no such file/i }, 'throws on missing image');
+		await rejects(() => io.read(dstPath), { message: /no such file/i }, 'throws on missing image');
 
-	io.setStrictResources(false);
+		io.setStrictResources(false);
 
-	const document = await io.read(dstPath);
-	const textures = document.getRoot().listTextures();
-	t.is(textures.length, 1, 'texture != null');
-	t.is(textures[0].getImage(), null, 'texture.image == null');
+		const document = await io.read(dstPath);
+		const textures = document.getRoot().listTextures();
+		strictEqual(textures.length, 1, 'texture != null');
+		strictEqual(textures[0].getImage(), null, 'texture.image == null');
+	});
 });

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -1,268 +1,271 @@
+import { deepEqual, ok, rejects, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { BufferUtils, Document, Format, GLB_BUFFER, type GLTF, type JSONDocument } from '@gltf-transform/core';
 import { createPlatformIO, logger, resolve } from '@gltf-transform/test-utils';
-import test from 'ava';
 import fs from 'fs';
 
-test('common', async (t) => {
-	const io = await createPlatformIO();
-	await t.throwsAsync(
-		() =>
-			io.readJSON({
-				json: { asset: { version: '1.0' } },
-				resources: {},
-			}),
-		{ message: /Unsupported/i },
-		'1.0',
-	);
-});
+describe('PlatformIO', () => {
+	test('common', async () => {
+		const io = await createPlatformIO();
+		await rejects(
+			() =>
+				io.readJSON({
+					json: { asset: { version: '1.0' } },
+					resources: {},
+				}),
+			{ message: /Unsupported/i },
+			'1.0',
+		);
+	});
 
-test('glb without optional buffer', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createScene().addChild(document.createNode('MyNode'));
+	test('glb without optional buffer', async () => {
+		const document = new Document().setLogger(logger);
+		document.createScene().addChild(document.createNode('MyNode'));
 
-	const io = await createPlatformIO();
-	const json = await io.writeJSON(document, { format: Format.GLB });
-	const binary = await io.writeBinary(document);
+		const io = await createPlatformIO();
+		const json = await io.writeJSON(document, { format: Format.GLB });
+		const binary = await io.writeBinary(document);
 
-	t.truthy(json, 'writes json');
-	t.truthy(binary, 'writes binary');
-	t.is(Object.values(json.resources).length, 0, 'no buffers');
-	t.truthy(await io.readJSON(json), 'reads json');
-	t.truthy(await io.readBinary(binary), 'reads binary');
-	t.deepEqual(
-		(await io.readBinary(binary))
+		ok(json, 'writes json');
+		ok(binary, 'writes binary');
+		strictEqual(Object.values(json.resources).length, 0, 'no buffers');
+		ok(await io.readJSON(json), 'reads json');
+		ok(await io.readBinary(binary), 'reads binary');
+		deepEqual(
+			(await io.readBinary(binary))
+				.getRoot()
+				.listNodes()
+				.map((n) => n.getName()),
+			['MyNode'],
+			'same nodes',
+		);
+	});
+
+	test('glb without required buffer', async () => {
+		const io = await createPlatformIO();
+
+		let document = new Document().setLogger(logger);
+		document.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
+		document.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
+
+		await rejects(
+			() => io.writeJSON(document, { format: Format.GLB }),
+			{ message: /buffer required/i },
+			'writeJSON throws',
+		);
+		await rejects(() => io.writeBinary(document), { message: /buffer required/i }, 'writeBinary throws');
+
+		document.createBuffer();
+
+		ok(io.writeJSON(document, { format: Format.GLB }), 'writeJSON succeeds');
+		ok(io.writeBinary(document), 'writeBinary succeeds');
+
+		document = new Document().setLogger(logger);
+		document.createAccessor().setArray(new Float32Array(10));
+		document.createAccessor().setArray(new Float32Array(20));
+
+		await rejects(
+			() => io.writeJSON(document, { format: Format.GLB }),
+			{ message: /buffer required/i },
+			'writeJSON throws',
+		);
+		await rejects(() => io.writeBinary(document), { message: /buffer required/i }, 'writeBinary throws');
+
+		document.createBuffer();
+
+		ok(await io.writeJSON(document, { format: Format.GLB }), 'writeJSON succeeds');
+		ok(await io.writeBinary(document), 'writeBinary succeeds');
+	});
+
+	test('glb with texture-only buffer', async () => {
+		const document = new Document().setLogger(logger);
+		document.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
+		document.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
+		document.createBuffer();
+
+		const io = await createPlatformIO();
+		const json = await io.writeJSON(document, { format: Format.GLB });
+		const binary = await io.writeBinary(document);
+
+		ok(json, 'writes json');
+		ok(binary, 'writes binary');
+		strictEqual(Object.values(json.resources).length, 1, 'writes 1 buffer');
+
+		const rtTextures = (await io.readBinary(binary)).getRoot().listTextures();
+
+		strictEqual(rtTextures[0].getName(), 'TexA', 'reads texture 1');
+		strictEqual(rtTextures[1].getName(), 'TexB', 'reads texture 1');
+		deepEqual(rtTextures[0].getImage(), new Uint8Array(1), 'reads texture 1 data');
+		deepEqual(rtTextures[1].getImage(), new Uint8Array(2), 'reads texture 2 data');
+	});
+
+	test('glb with data uri', async () => {
+		const document = new Document().setLogger(logger);
+		document.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
+		document.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
+		document.createBuffer();
+
+		// (1) Write JSONDocument and replace resources with Data URIs.
+
+		const io = await createPlatformIO();
+		const { json, resources } = await io.writeJSON(document, { format: Format.GLB });
+		for (const buffer of json.buffers!) {
+			const uri = buffer.uri || GLB_BUFFER;
+			const resource = resources[uri]!;
+			buffer.uri = `data:text/plain;base64,` + Buffer.from(resource).toString('base64');
+			delete resources[uri];
+		}
+
+		ok(json, 'writes json');
+		ok(json.buffers[0].uri.startsWith('data:'), 'buffer contains data uri');
+		strictEqual(Object.values(resources).length, 0, 'no external resources');
+
+		// (2) Convert the JSONDocument to a GLB without a BIN chunk.
+
+		const header = new Uint32Array([0x46546c67, 2, 12]);
+
+		const jsonText = JSON.stringify(json);
+		const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
+		const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
+		const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
+		header[header.length - 1] += jsonChunk.byteLength;
+
+		const binary = BufferUtils.concat([BufferUtils.toView(header), jsonChunk]);
+
+		ok(binary, 'writes binary');
+
+		// (3) Test that we can read GLBs with Data URIs.
+
+		const rtTextures = (await io.readBinary(binary)).getRoot().listTextures();
+
+		strictEqual(rtTextures[0].getName(), 'TexA', 'reads texture 1');
+		strictEqual(rtTextures[1].getName(), 'TexB', 'reads texture 1');
+		deepEqual(Array.from(rtTextures[0].getImage()), Array.from(new Uint8Array(1)), 'reads texture 1 data');
+		deepEqual(Array.from(rtTextures[1].getImage()), Array.from(new Uint8Array(2)), 'reads texture 2 data');
+	});
+
+	test('gltf embedded', async () => {
+		const io = await createPlatformIO();
+		const jsonPath = resolve('../in/Box_glTF-Embedded/Box.gltf', import.meta.url);
+		const jsonContent = fs.readFileSync(jsonPath, 'utf-8');
+		const json = JSON.parse(jsonContent);
+		const jsonDoc = { json, resources: {} } as JSONDocument;
+		const jsonDocCopy = JSON.parse(JSON.stringify(jsonDoc));
+
+		ok(await io.readJSON(jsonDoc), 'reads document');
+		deepEqual(jsonDoc, jsonDocCopy, 'original unchanged');
+	});
+
+	test('glb with unknown chunk', async () => {
+		const io = await createPlatformIO();
+
+		const jsonChunkText = JSON.stringify({
+			asset: { version: '2.0' },
+			scenes: [{ nodes: [0] }],
+			nodes: [{ name: 'RootNode' }],
+		} as GLTF.IGLTF);
+		const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonChunkText), 0x20);
+		const totalByteLength = 12 + 8 + jsonChunkData.byteLength + 8 + 80;
+
+		const glb = BufferUtils.concat([
+			BufferUtils.toView(new Uint32Array([0x46546c67, 2, totalByteLength])),
+			BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a])),
+			jsonChunkData,
+			BufferUtils.toView(new Uint32Array([80, 0x12345678])),
+			new Uint8Array(80).fill(0),
+		]);
+
+		const document = await io.readBinary(glb);
+		ok(document, 'parses GLB with unknown chunk');
+
+		const node = document.getRoot().listNodes()[0];
+		strictEqual(node.getName(), 'RootNode', 'parses nodes');
+	});
+
+	test('read duplicate buffer URIs', async () => {
+		const io = await createPlatformIO();
+
+		// https://github.com/KhronosGroup/glTF/issues/2446
+		// https://github.com/donmccurdy/glTF-Transform/issues/1513
+		const jsonDocument: JSONDocument = {
+			json: {
+				asset: { version: '2.0' },
+				buffers: [
+					{ uri: 'scene.bin', byteLength: 20 },
+					{ uri: 'scene.bin', byteLength: 20 },
+				],
+			},
+			resources: { 'scene.bin': new Uint8Array(20) },
+		};
+
+		const document = await io.readJSON(jsonDocument);
+
+		const bufferURIs = document
 			.getRoot()
-			.listNodes()
-			.map((n) => n.getName()),
-		['MyNode'],
-		'same nodes',
-	);
-});
+			.listBuffers()
+			.map((buffer) => buffer.getURI());
 
-test('glb without required buffer', async (t) => {
-	const io = await createPlatformIO();
+		deepEqual(bufferURIs, ['scene.bin', 'scene.bin'], 'removes duplicate buffer URIs');
+	});
 
-	let document = new Document().setLogger(logger);
-	document.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
-	document.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
+	test('read duplicate image URIs', async () => {
+		const io = await createPlatformIO();
 
-	await t.throwsAsync(
-		() => io.writeJSON(document, { format: Format.GLB }),
-		{ message: /buffer required/i },
-		'writeJSON throws',
-	);
-	await t.throwsAsync(() => io.writeBinary(document), { message: /buffer required/i }, 'writeBinary throws');
+		// https://github.com/KhronosGroup/glTF/issues/2446
+		// https://github.com/donmccurdy/glTF-Transform/issues/1513
+		const image = new Uint8Array(20);
+		const jsonDocument: JSONDocument = {
+			json: {
+				asset: { version: '2.0' },
+				images: [{ uri: 'color.png' }, { uri: 'color.png' }],
+			},
+			resources: { 'color.png': image },
+		};
 
-	document.createBuffer();
+		const document = await io.readJSON(jsonDocument);
 
-	t.truthy(io.writeJSON(document, { format: Format.GLB }), 'writeJSON succeeds');
-	t.truthy(io.writeBinary(document), 'writeBinary succeeds');
+		const imageURIs = document
+			.getRoot()
+			.listTextures()
+			.map((texture) => texture.getURI());
+		const images = document
+			.getRoot()
+			.listTextures()
+			.map((texture) => texture.getImage());
 
-	document = new Document().setLogger(logger);
-	document.createAccessor().setArray(new Float32Array(10));
-	document.createAccessor().setArray(new Float32Array(20));
+		deepEqual(imageURIs, ['color.png', 'color.png'], 'loads duplicate image URIs');
+		deepEqual(images, [image, image], 'loads duplicate image data');
+	});
 
-	await t.throwsAsync(
-		() => io.writeJSON(document, { format: Format.GLB }),
-		{ message: /buffer required/i },
-		'writeJSON throws',
-	);
-	await t.throwsAsync(() => io.writeBinary(document), { message: /buffer required/i }, 'writeBinary throws');
+	test('write duplicate buffer URIs', async () => {
+		const io = await createPlatformIO();
 
-	document.createBuffer();
+		// https://github.com/KhronosGroup/glTF/issues/2446
+		const document = new Document().setLogger(logger);
+		const buffer1 = document.createBuffer().setURI('a.bin');
+		const buffer2 = document.createBuffer().setURI('a.bin');
+		document.createAccessor().setBuffer(buffer1).setArray(new Float32Array(10).fill(1));
+		document.createAccessor().setBuffer(buffer2).setArray(new Float32Array(10).fill(2));
 
-	t.truthy(await io.writeJSON(document, { format: Format.GLB }), 'writeJSON succeeds');
-	t.truthy(await io.writeBinary(document), 'writeBinary succeeds');
-});
+		// Buffers with the same name and different content must throw.
+		await rejects(() => io.writeJSON(document), { message: /Resource URI/i }, 'duplicate buffer URIs');
 
-test('glb with texture-only buffer', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
-	document.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
-	document.createBuffer();
+		buffer2.setURI('b.bin');
 
-	const io = await createPlatformIO();
-	const json = await io.writeJSON(document, { format: Format.GLB });
-	const binary = await io.writeBinary(document);
+		ok(await io.writeJSON(document), 'unique buffer URIs');
+	});
 
-	t.truthy(json, 'writes json');
-	t.truthy(binary, 'writes binary');
-	t.is(Object.values(json.resources).length, 1, 'writes 1 buffer');
+	test('write duplicate image URIs', async () => {
+		const io = await createPlatformIO();
 
-	const rtTextures = (await io.readBinary(binary)).getRoot().listTextures();
+		// https://github.com/KhronosGroup/glTF/issues/2446
+		const document = new Document().setLogger(logger);
+		document.createTexture().setImage(new Uint8Array(2)).setURI('color.png');
+		document.createTexture().setImage(new Uint8Array(1)).setURI('color.png');
 
-	t.is(rtTextures[0].getName(), 'TexA', 'reads texture 1');
-	t.is(rtTextures[1].getName(), 'TexB', 'reads texture 1');
-	t.deepEqual(rtTextures[0].getImage(), new Uint8Array(1), 'reads texture 1 data');
-	t.deepEqual(rtTextures[1].getImage(), new Uint8Array(2), 'reads texture 2 data');
-});
-
-test('glb with data uri', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createTexture('TexA').setImage(new Uint8Array(1)).setMimeType('image/png');
-	document.createTexture('TexB').setImage(new Uint8Array(2)).setMimeType('image/png');
-	document.createBuffer();
-
-	// (1) Write JSONDocument and replace resources with Data URIs.
-
-	const io = await createPlatformIO();
-	const { json, resources } = await io.writeJSON(document, { format: Format.GLB });
-	for (const buffer of json.buffers!) {
-		const uri = buffer.uri || GLB_BUFFER;
-		const resource = resources[uri]!;
-		buffer.uri = `data:text/plain;base64,` + Buffer.from(resource).toString('base64');
-		delete resources[uri];
-	}
-
-	t.truthy(json, 'writes json');
-	t.truthy(json.buffers[0].uri.startsWith('data:'), 'buffer contains data uri');
-	t.is(Object.values(resources).length, 0, 'no external resources');
-
-	// (2) Convert the JSONDocument to a GLB without a BIN chunk.
-
-	const header = new Uint32Array([0x46546c67, 2, 12]);
-
-	const jsonText = JSON.stringify(json);
-	const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-	const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
-	const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
-	header[header.length - 1] += jsonChunk.byteLength;
-
-	const binary = BufferUtils.concat([BufferUtils.toView(header), jsonChunk]);
-
-	t.truthy(binary, 'writes binary');
-
-	// (3) Test that we can read GLBs with Data URIs.
-
-	const rtTextures = (await io.readBinary(binary)).getRoot().listTextures();
-
-	t.is(rtTextures[0].getName(), 'TexA', 'reads texture 1');
-	t.is(rtTextures[1].getName(), 'TexB', 'reads texture 1');
-	t.deepEqual(Array.from(rtTextures[0].getImage()), Array.from(new Uint8Array(1)), 'reads texture 1 data');
-	t.deepEqual(Array.from(rtTextures[1].getImage()), Array.from(new Uint8Array(2)), 'reads texture 2 data');
-});
-
-test('gltf embedded', async (t) => {
-	const io = await createPlatformIO();
-	const jsonPath = resolve('../in/Box_glTF-Embedded/Box.gltf', import.meta.url);
-	const jsonContent = fs.readFileSync(jsonPath, 'utf-8');
-	const json = JSON.parse(jsonContent);
-	const jsonDoc = { json, resources: {} } as JSONDocument;
-	const jsonDocCopy = JSON.parse(JSON.stringify(jsonDoc));
-
-	t.truthy(await io.readJSON(jsonDoc), 'reads document');
-	t.deepEqual(jsonDoc, jsonDocCopy, 'original unchanged');
-});
-
-test('glb with unknown chunk', async (t) => {
-	const io = await createPlatformIO();
-
-	const jsonChunkText = JSON.stringify({
-		asset: { version: '2.0' },
-		scenes: [{ nodes: [0] }],
-		nodes: [{ name: 'RootNode' }],
-	} as GLTF.IGLTF);
-	const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonChunkText), 0x20);
-	const totalByteLength = 12 + 8 + jsonChunkData.byteLength + 8 + 80;
-
-	const glb = BufferUtils.concat([
-		BufferUtils.toView(new Uint32Array([0x46546c67, 2, totalByteLength])),
-		BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a])),
-		jsonChunkData,
-		BufferUtils.toView(new Uint32Array([80, 0x12345678])),
-		new Uint8Array(80).fill(0),
-	]);
-
-	const document = await io.readBinary(glb);
-	t.truthy(document, 'parses GLB with unknown chunk');
-
-	const node = document.getRoot().listNodes()[0];
-	t.is(node.getName(), 'RootNode', 'parses nodes');
-});
-
-test('read duplicate buffer URIs', async (t) => {
-	const io = await createPlatformIO();
-
-	// https://github.com/KhronosGroup/glTF/issues/2446
-	// https://github.com/donmccurdy/glTF-Transform/issues/1513
-	const jsonDocument: JSONDocument = {
-		json: {
-			asset: { version: '2.0' },
-			buffers: [
-				{ uri: 'scene.bin', byteLength: 20 },
-				{ uri: 'scene.bin', byteLength: 20 },
-			],
-		},
-		resources: { 'scene.bin': new Uint8Array(20) },
-	};
-
-	const document = await io.readJSON(jsonDocument);
-
-	const bufferURIs = document
-		.getRoot()
-		.listBuffers()
-		.map((buffer) => buffer.getURI());
-
-	t.deepEqual(bufferURIs, ['scene.bin', 'scene.bin'], 'removes duplicate buffer URIs');
-});
-
-test('read duplicate image URIs', async (t) => {
-	const io = await createPlatformIO();
-
-	// https://github.com/KhronosGroup/glTF/issues/2446
-	// https://github.com/donmccurdy/glTF-Transform/issues/1513
-	const image = new Uint8Array(20);
-	const jsonDocument: JSONDocument = {
-		json: {
-			asset: { version: '2.0' },
-			images: [{ uri: 'color.png' }, { uri: 'color.png' }],
-		},
-		resources: { 'color.png': image },
-	};
-
-	const document = await io.readJSON(jsonDocument);
-
-	const imageURIs = document
-		.getRoot()
-		.listTextures()
-		.map((texture) => texture.getURI());
-	const images = document
-		.getRoot()
-		.listTextures()
-		.map((texture) => texture.getImage());
-
-	t.deepEqual(imageURIs, ['color.png', 'color.png'], 'loads duplicate image URIs');
-	t.deepEqual(images, [image, image], 'loads duplicate image data');
-});
-
-test('write duplicate buffer URIs', async (t) => {
-	const io = await createPlatformIO();
-
-	// https://github.com/KhronosGroup/glTF/issues/2446
-	const document = new Document().setLogger(logger);
-	const buffer1 = document.createBuffer().setURI('a.bin');
-	const buffer2 = document.createBuffer().setURI('a.bin');
-	document.createAccessor().setBuffer(buffer1).setArray(new Float32Array(10).fill(1));
-	document.createAccessor().setBuffer(buffer2).setArray(new Float32Array(10).fill(2));
-
-	// Buffers with the same name and different content must throw.
-	await t.throwsAsync(() => io.writeJSON(document), { message: /Resource URI/i }, 'duplicate buffer URIs');
-
-	buffer2.setURI('b.bin');
-
-	t.truthy(await io.writeJSON(document), 'unique buffer URIs');
-});
-
-test('write duplicate image URIs', async (t) => {
-	const io = await createPlatformIO();
-
-	// https://github.com/KhronosGroup/glTF/issues/2446
-	const document = new Document().setLogger(logger);
-	document.createTexture().setImage(new Uint8Array(2)).setURI('color.png');
-	document.createTexture().setImage(new Uint8Array(1)).setURI('color.png');
-
-	// Textures with the same name and different content are, for now, allowed.
-	// TODO(v5): Consider whether duplicates should be handled more strictly.
-	// See https://github.com/donmccurdy/glTF-Transform/issues/1513.
-	t.truthy(await io.writeJSON(document), 'duplicate image URIs');
+		// Textures with the same name and different content are, for now, allowed.
+		// TODO(v5): Consider whether duplicates should be handled more strictly.
+		// See https://github.com/donmccurdy/glTF-Transform/issues/1513.
+		ok(await io.writeJSON(document), 'duplicate image URIs');
+	});
 });

--- a/packages/core/test/io/platform-io.test.ts
+++ b/packages/core/test/io/platform-io.test.ts
@@ -4,7 +4,7 @@ import { BufferUtils, Document, Format, GLB_BUFFER, type GLTF, type JSONDocument
 import { createPlatformIO, logger, resolve } from '@gltf-transform/test-utils';
 import fs from 'fs';
 
-describe('PlatformIO', () => {
+describe('core::PlatformIO', () => {
 	test('common', async () => {
 		const io = await createPlatformIO();
 		await rejects(

--- a/packages/core/test/io/web-io.test.ts
+++ b/packages/core/test/io/web-io.test.ts
@@ -18,7 +18,7 @@ function mockFetch(response: unknown): string[] {
 	return paths;
 }
 
-describe('WebIO', () => {
+describe('core::WebIO', () => {
 	test('read glb', async () => {
 		mockWindow('https://www.example.com/test');
 		mockFetch({

--- a/packages/core/test/io/web-io.test.ts
+++ b/packages/core/test/io/web-io.test.ts
@@ -1,5 +1,6 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { BufferUtils, WebIO } from '@gltf-transform/core';
-import test from 'ava';
 
 const SAMPLE_GLB =
 	'data:application/octet-stream;base64,Z2xURgIAAACABgAA3AMAAEpTT057ImFzc2V0Ijp7ImdlbmVyYXRvciI6IkNPTExBREEyR0xURiIsInZlcnNpb24iOiIyLjAifSwic2NlbmUiOjAsInNjZW5lcyI6W3sibm9kZXMiOlswXX1dLCJub2RlcyI6W3siY2hpbGRyZW4iOlsxXSwibWF0cml4IjpbMS4wLDAuMCwwLjAsMC4wLDAuMCwwLjAsLTEuMCwwLjAsMC4wLDEuMCwwLjAsMC4wLDAuMCwwLjAsMC4wLDEuMF19LHsibWVzaCI6MH1dLCJtZXNoZXMiOlt7InByaW1pdGl2ZXMiOlt7ImF0dHJpYnV0ZXMiOnsiTk9STUFMIjoxLCJQT1NJVElPTiI6Mn0sImluZGljZXMiOjAsIm1vZGUiOjQsIm1hdGVyaWFsIjowfV0sIm5hbWUiOiJNZXNoIn1dLCJhY2Nlc3NvcnMiOlt7ImJ1ZmZlclZpZXciOjAsImJ5dGVPZmZzZXQiOjAsImNvbXBvbmVudFR5cGUiOjUxMjMsImNvdW50IjozNiwibWF4IjpbMjNdLCJtaW4iOlswXSwidHlwZSI6IlNDQUxBUiJ9LHsiYnVmZmVyVmlldyI6MSwiYnl0ZU9mZnNldCI6MCwiY29tcG9uZW50VHlwZSI6NTEyNiwiY291bnQiOjI0LCJtYXgiOlsxLjAsMS4wLDEuMF0sIm1pbiI6Wy0xLjAsLTEuMCwtMS4wXSwidHlwZSI6IlZFQzMifSx7ImJ1ZmZlclZpZXciOjEsImJ5dGVPZmZzZXQiOjI4OCwiY29tcG9uZW50VHlwZSI6NTEyNiwiY291bnQiOjI0LCJtYXgiOlswLjUsMC41LDAuNV0sIm1pbiI6Wy0wLjUsLTAuNSwtMC41XSwidHlwZSI6IlZFQzMifV0sIm1hdGVyaWFscyI6W3sicGJyTWV0YWxsaWNSb3VnaG5lc3MiOnsiYmFzZUNvbG9yRmFjdG9yIjpbMC44MDAwMDAwMTE5MjA5MjksMC4wLDAuMCwxLjBdLCJtZXRhbGxpY0ZhY3RvciI6MC4wfSwibmFtZSI6IlJlZCJ9XSwiYnVmZmVyVmlld3MiOlt7ImJ1ZmZlciI6MCwiYnl0ZU9mZnNldCI6NTc2LCJieXRlTGVuZ3RoIjo3MiwidGFyZ2V0IjozNDk2M30seyJidWZmZXIiOjAsImJ5dGVPZmZzZXQiOjAsImJ5dGVMZW5ndGgiOjU3NiwiYnl0ZVN0cmlkZSI6MTIsInRhcmdldCI6MzQ5NjJ9XSwiYnVmZmVycyI6W3siYnl0ZUxlbmd0aCI6NjQ4fV19iAIAAEJJTgAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAgD8AAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAAAAAACAvwAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAAAAAACAPwAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAIC/AAAAAAAAAAAAAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAAAAAAAAAAAgL8AAAC/AAAAvwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAL8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAA/AAAAPwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAEAAgADAAIAAQAEAAUABgAHAAYABQAIAAkACgALAAoACQAMAA0ADgAPAA4ADQAQABEAEgATABIAEQAUABUAFgAXABYAFQA=';
@@ -17,217 +18,219 @@ function mockFetch(response: unknown): string[] {
 	return paths;
 }
 
-test.serial('read glb', async (t) => {
-	mockWindow('https://www.example.com/test');
-	mockFetch({
-		arrayBuffer: () => BufferUtils.createBufferFromDataURI(SAMPLE_GLB),
-		text: () => {
-			throw new Error('Do not call.');
-		},
-		json: () => {
-			throw new Error('Do not call.');
-		},
+describe('WebIO', () => {
+	test('read glb', async () => {
+		mockWindow('https://www.example.com/test');
+		mockFetch({
+			arrayBuffer: () => BufferUtils.createBufferFromDataURI(SAMPLE_GLB),
+			text: () => {
+				throw new Error('Do not call.');
+			},
+			json: () => {
+				throw new Error('Do not call.');
+			},
+		});
+
+		const io = new WebIO();
+		ok(io, 'creates WebIO');
+
+		const document = await io.read('mock.glb');
+		strictEqual(document.getRoot().listBuffers().length, 1, 'reads a GLB with Fetch API');
 	});
 
-	const io = new WebIO();
-	t.truthy(io, 'creates WebIO');
-
-	const document = await io.read('mock.glb');
-	t.is(document.getRoot().listBuffers().length, 1, 'reads a GLB with Fetch API');
-});
-
-test.serial('read glb + resources', async (t) => {
-	const json = {
-		asset: { version: '2.0' },
-		scenes: [{ name: 'Default Scene' }],
-		images: [
-			{ uri: 'image1.png' },
-			{ uri: '/abs/path/image2.png' },
-			{ uri: './rel/path/image3.png' },
-			{ uri: 'rel/path/image3.png' },
-		],
-	};
-
-	const jsonText = JSON.stringify(json);
-	const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
-	const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
-	const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
-
-	const binaryChunkData = BufferUtils.pad(new Uint8Array(0), 0x00);
-	const binaryChunkHeader = BufferUtils.toView(new Uint32Array([binaryChunkData.byteLength, 0x004e4942]));
-	const binaryChunk = BufferUtils.concat([binaryChunkHeader, binaryChunkData]);
-
-	const header = BufferUtils.toView(
-		new Uint32Array([0x46546c67, 2, 12 + jsonChunk.byteLength + binaryChunk.byteLength]),
-	);
-
-	const responses = [
-		new Uint8Array(4),
-		new Uint8Array(3),
-		new Uint8Array(2),
-		new Uint8Array(1),
-		BufferUtils.concat([header, jsonChunk, binaryChunk]),
-	].map(toArrayBuffer);
-
-	mockWindow('https://www.example.com/test');
-	const fetchedPaths = mockFetch({
-		arrayBuffer: () => responses.pop(),
-		text: () => {
-			throw new Error('Do not call.');
-		},
-		json: () => {
-			throw new Error('Do not call.');
-		},
-	});
-
-	const io = new WebIO();
-	t.truthy(io, 'creates WebIO');
-
-	const document = await io.read('model/dir/mock.glb');
-	t.deepEqual(
-		fetchedPaths,
-		[
-			'model/dir/mock.glb',
-			'model/dir/image1.png',
-			'/abs/path/image2.png',
-			'model/dir/rel/path/image3.png',
-			'model/dir/rel/path/image3.png',
-		],
-		'reads all linked resources',
-	);
-	t.is(document.getRoot().listScenes().length, 1, 'reads GLB + resources with Fetch API');
-});
-
-test.serial('read gltf', async (t) => {
-	const json = JSON.stringify({
-		asset: { version: '2.0' },
-		scenes: [{ name: 'Default Scene' }],
-		images: [
-			{ uri: 'image1.png' },
-			{ uri: '/abs/path/image2.png' },
-			{ uri: './rel/path/image3.png' },
-			{ uri: 'rel/path/image3.png' },
-		],
-	});
-	const gltf = toArrayBuffer(BufferUtils.encodeText(json));
-	const images = [new Uint8Array(4), new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)].map(toArrayBuffer);
-	const responses = [...images, gltf];
-
-	mockWindow('https://www.example.com/test');
-	const fetchedPaths = mockFetch({
-		arrayBuffer: () => responses.pop(),
-		text: () => {
-			throw new Error('Do not call.');
-		},
-	});
-
-	const io = new WebIO();
-	t.truthy(io, 'creates WebIO');
-
-	const document = await io.read('model/dir/mock.gltf');
-	t.deepEqual(
-		fetchedPaths,
-		[
-			'model/dir/mock.gltf',
-			'model/dir/image1.png',
-			'/abs/path/image2.png',
-			'model/dir/rel/path/image3.png',
-			'model/dir/rel/path/image3.png',
-		],
-		'reads all linked resources',
-	);
-	t.is(document.getRoot().listScenes().length, 1, 'reads a glTF with Fetch API');
-});
-
-test.serial('read + data URIs', async (t) => {
-	const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
-	const uris = images.map((image) => {
-		return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
-	});
-
-	mockWindow('https://www.example.com/test');
-	const fetchedPaths = mockFetch({
-		arrayBuffer: () => {
-			return toArrayBuffer(
-				BufferUtils.encodeText(
-					JSON.stringify({
-						asset: { version: '2.0' },
-						images: uris.map((uri) => ({ uri })),
-					}),
-				),
-			);
-		},
-		text: () => {
-			throw new Error('Do not call.');
-		},
-	});
-
-	const io = new WebIO();
-
-	const document = await io.read('test.gltf');
-	const textures = document.getRoot().listTextures();
-
-	t.deepEqual(fetchedPaths, ['test.gltf'], 'one network request');
-	t.is(textures.length, 3, 'reads a textures from Data URIs');
-	t.deepEqual(Array.from(textures[0].getImage()), Array.from(images[0]), 'reads texture 0');
-	t.deepEqual(Array.from(textures[1].getImage()), Array.from(images[1]), 'reads texture 1');
-	t.deepEqual(Array.from(textures[2].getImage()), Array.from(images[2]), 'reads texture 2');
-});
-
-test.serial('readJSON + data URIs', async (t) => {
-	const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
-	const uris = images.map((image) => {
-		return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
-	});
-
-	mockWindow('https://www.example.com/test');
-	const fetchedPaths = mockFetch({
-		arrayBuffer: () => {
-			throw new Error('Do not call.');
-		},
-		text: () => {
-			throw new Error('Do not call.');
-		},
-		json: () => () => {
-			throw new Error('Do not call.');
-		},
-	});
-
-	const io = new WebIO();
-
-	const document = await io.readJSON({
-		json: {
+	test('read glb + resources', async () => {
+		const json = {
 			asset: { version: '2.0' },
-			images: uris.map((uri) => ({ uri })),
-		},
-		resources: {},
-	});
-	const textures = document.getRoot().listTextures();
+			scenes: [{ name: 'Default Scene' }],
+			images: [
+				{ uri: 'image1.png' },
+				{ uri: '/abs/path/image2.png' },
+				{ uri: './rel/path/image3.png' },
+				{ uri: 'rel/path/image3.png' },
+			],
+		};
 
-	t.deepEqual(fetchedPaths, [], 'no network requests');
-	t.is(textures.length, 3, 'reads a textures from Data URIs');
-	t.deepEqual(Array.from(textures[0].getImage()), Array.from(images[0]), 'reads texture 0');
-	t.deepEqual(Array.from(textures[1].getImage()), Array.from(images[1]), 'reads texture 1');
-	t.deepEqual(Array.from(textures[2].getImage()), Array.from(images[2]), 'reads texture 2');
+		const jsonText = JSON.stringify(json);
+		const jsonChunkData = BufferUtils.pad(BufferUtils.encodeText(jsonText), 0x20);
+		const jsonChunkHeader = BufferUtils.toView(new Uint32Array([jsonChunkData.byteLength, 0x4e4f534a]));
+		const jsonChunk = BufferUtils.concat([jsonChunkHeader, jsonChunkData]);
+
+		const binaryChunkData = BufferUtils.pad(new Uint8Array(0), 0x00);
+		const binaryChunkHeader = BufferUtils.toView(new Uint32Array([binaryChunkData.byteLength, 0x004e4942]));
+		const binaryChunk = BufferUtils.concat([binaryChunkHeader, binaryChunkData]);
+
+		const header = BufferUtils.toView(
+			new Uint32Array([0x46546c67, 2, 12 + jsonChunk.byteLength + binaryChunk.byteLength]),
+		);
+
+		const responses = [
+			new Uint8Array(4),
+			new Uint8Array(3),
+			new Uint8Array(2),
+			new Uint8Array(1),
+			BufferUtils.concat([header, jsonChunk, binaryChunk]),
+		].map(toArrayBuffer);
+
+		mockWindow('https://www.example.com/test');
+		const fetchedPaths = mockFetch({
+			arrayBuffer: () => responses.pop(),
+			text: () => {
+				throw new Error('Do not call.');
+			},
+			json: () => {
+				throw new Error('Do not call.');
+			},
+		});
+
+		const io = new WebIO();
+		ok(io, 'creates WebIO');
+
+		const document = await io.read('model/dir/mock.glb');
+		deepEqual(
+			fetchedPaths,
+			[
+				'model/dir/mock.glb',
+				'model/dir/image1.png',
+				'/abs/path/image2.png',
+				'model/dir/rel/path/image3.png',
+				'model/dir/rel/path/image3.png',
+			],
+			'reads all linked resources',
+		);
+		strictEqual(document.getRoot().listScenes().length, 1, 'reads GLB + resources with Fetch API');
+	});
+
+	test('read gltf', async () => {
+		const json = JSON.stringify({
+			asset: { version: '2.0' },
+			scenes: [{ name: 'Default Scene' }],
+			images: [
+				{ uri: 'image1.png' },
+				{ uri: '/abs/path/image2.png' },
+				{ uri: './rel/path/image3.png' },
+				{ uri: 'rel/path/image3.png' },
+			],
+		});
+		const gltf = toArrayBuffer(BufferUtils.encodeText(json));
+		const images = [new Uint8Array(4), new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)].map(toArrayBuffer);
+		const responses = [...images, gltf];
+
+		mockWindow('https://www.example.com/test');
+		const fetchedPaths = mockFetch({
+			arrayBuffer: () => responses.pop(),
+			text: () => {
+				throw new Error('Do not call.');
+			},
+		});
+
+		const io = new WebIO();
+		ok(io, 'creates WebIO');
+
+		const document = await io.read('model/dir/mock.gltf');
+		deepEqual(
+			fetchedPaths,
+			[
+				'model/dir/mock.gltf',
+				'model/dir/image1.png',
+				'/abs/path/image2.png',
+				'model/dir/rel/path/image3.png',
+				'model/dir/rel/path/image3.png',
+			],
+			'reads all linked resources',
+		);
+		strictEqual(document.getRoot().listScenes().length, 1, 'reads a glTF with Fetch API');
+	});
+
+	test('read + data URIs', async () => {
+		const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
+		const uris = images.map((image) => {
+			return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
+		});
+
+		mockWindow('https://www.example.com/test');
+		const fetchedPaths = mockFetch({
+			arrayBuffer: () => {
+				return toArrayBuffer(
+					BufferUtils.encodeText(
+						JSON.stringify({
+							asset: { version: '2.0' },
+							images: uris.map((uri) => ({ uri })),
+						}),
+					),
+				);
+			},
+			text: () => {
+				throw new Error('Do not call.');
+			},
+		});
+
+		const io = new WebIO();
+
+		const document = await io.read('test.gltf');
+		const textures = document.getRoot().listTextures();
+
+		deepEqual(fetchedPaths, ['test.gltf'], 'one network request');
+		strictEqual(textures.length, 3, 'reads a textures from Data URIs');
+		deepEqual(Array.from(textures[0].getImage()), Array.from(images[0]), 'reads texture 0');
+		deepEqual(Array.from(textures[1].getImage()), Array.from(images[1]), 'reads texture 1');
+		deepEqual(Array.from(textures[2].getImage()), Array.from(images[2]), 'reads texture 2');
+	});
+
+	test('readJSON + data URIs', async () => {
+		const images = [new Uint8Array(3), new Uint8Array(2), new Uint8Array(1)];
+		const uris = images.map((image) => {
+			return 'data:image/png;base64,' + Buffer.from(image).toString('base64');
+		});
+
+		mockWindow('https://www.example.com/test');
+		const fetchedPaths = mockFetch({
+			arrayBuffer: () => {
+				throw new Error('Do not call.');
+			},
+			text: () => {
+				throw new Error('Do not call.');
+			},
+			json: () => () => {
+				throw new Error('Do not call.');
+			},
+		});
+
+		const io = new WebIO();
+
+		const document = await io.readJSON({
+			json: {
+				asset: { version: '2.0' },
+				images: uris.map((uri) => ({ uri })),
+			},
+			resources: {},
+		});
+		const textures = document.getRoot().listTextures();
+
+		deepEqual(fetchedPaths, [], 'no network requests');
+		strictEqual(textures.length, 3, 'reads a textures from Data URIs');
+		deepEqual(Array.from(textures[0].getImage()), Array.from(images[0]), 'reads texture 0');
+		deepEqual(Array.from(textures[1].getImage()), Array.from(images[1]), 'reads texture 1');
+		deepEqual(Array.from(textures[2].getImage()), Array.from(images[2]), 'reads texture 2');
+	});
+
+	test('read + blob URIs', async () => {
+		mockWindow('https://www.example.com/test');
+		mockFetch({
+			arrayBuffer: () => BufferUtils.createBufferFromDataURI(SAMPLE_GLB),
+			text: () => {
+				throw new Error('Do not call.');
+			},
+			json: () => {
+				throw new Error('Do not call.');
+			},
+		});
+
+		const io = new WebIO();
+		const document = await io.read('blob:nonsense');
+		strictEqual(document.getRoot().listBuffers().length, 1, 'reads a GLB from Blob URI');
+	});
 });
 
-test.serial('read + blob URIs', async (t) => {
-	mockWindow('https://www.example.com/test');
-	mockFetch({
-		arrayBuffer: () => BufferUtils.createBufferFromDataURI(SAMPLE_GLB),
-		text: () => {
-			throw new Error('Do not call.');
-		},
-		json: () => {
-			throw new Error('Do not call.');
-		},
-	});
-
-	const io = new WebIO();
-	const document = await io.read('blob:nonsense');
-	t.is(document.getRoot().listBuffers().length, 1, 'reads a GLB from Blob URI');
-});
-
-function toArrayBuffer(view: Uint8Array): ArrayBuffer {
+function toArrayBuffer(view: Uint8Array): Uint8Array {
 	return view.slice(view.byteOffset, view.byteLength);
 }

--- a/packages/core/test/properties/accessor.test.ts
+++ b/packages/core/test/properties/accessor.test.ts
@@ -1,313 +1,316 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, type GLTF, type TypedArray } from '@gltf-transform/core';
 import { createPlatformIO, round } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const { FLOAT, UNSIGNED_BYTE, UNSIGNED_SHORT, UNSIGNED_INT, BYTE, SHORT } = Accessor.ComponentType;
 
-test('getScalar/setScalar', (t) => {
-	const accessor = new Document()
-		.createAccessor()
-		.setArray(new Float32Array([1, 2, 3, 4, 6]))
-		.setType(Accessor.Type.SCALAR);
+describe('Accessor', () => {
+	test('getScalar/setScalar', () => {
+		const accessor = new Document()
+			.createAccessor()
+			.setArray(new Float32Array([1, 2, 3, 4, 6]))
+			.setType(Accessor.Type.SCALAR);
 
-	accessor.setScalar(2, 500);
-	t.is(accessor.getScalar(1), 2, 'getScalar');
-	t.is(accessor.getScalar(2), 500, 'getScalar');
-});
+		accessor.setScalar(2, 500);
+		strictEqual(accessor.getScalar(1), 2, 'getScalar');
+		strictEqual(accessor.getScalar(2), 500, 'getScalar');
+	});
 
-test('getElement/setElement', (t) => {
-	const accessor = new Document()
-		.createAccessor()
-		.setArray(new Float32Array([1, 2, 3, 4, 6, 7]))
-		.setType(Accessor.Type.VEC2);
+	test('getElement/setElement', () => {
+		const accessor = new Document()
+			.createAccessor()
+			.setArray(new Float32Array([1, 2, 3, 4, 6, 7]))
+			.setType(Accessor.Type.VEC2);
 
-	accessor.setElement(2, [300, 400]);
-	t.deepEqual(accessor.getElement(1, []), [3, 4], 'getElement');
-	t.deepEqual(accessor.getElement(2, []), [300, 400], 'getElement');
-});
+		accessor.setElement(2, [300, 400]);
+		deepEqual(accessor.getElement(1, []), [3, 4], 'getElement');
+		deepEqual(accessor.getElement(2, []), [300, 400], 'getElement');
+	});
 
-test('normalized', (t) => {
-	const accessor = new Document()
-		.createAccessor()
-		.setArray(new Uint8Array([128, 255]))
-		.setNormalized(true)
-		.setType(Accessor.Type.SCALAR);
+	test('normalized', () => {
+		const accessor = new Document()
+			.createAccessor()
+			.setArray(new Uint8Array([128, 255]))
+			.setNormalized(true)
+			.setType(Accessor.Type.SCALAR);
 
-	t.deepEqual(accessor.getMin([])[0].toFixed(2), '128.00', 'getMin');
-	t.deepEqual(accessor.getMinNormalized([])[0].toFixed(2), '0.50', 'getMinNormalized'); // TODO: loose?
-	t.deepEqual(accessor.getMax([])[0].toFixed(2), '255.00', 'getMax');
-	t.deepEqual(accessor.getMaxNormalized([])[0].toFixed(2), '1.00', 'getMaxNormalized'); // TODO: loose?
-});
+		deepEqual(accessor.getMin([])[0].toFixed(2), '128.00', 'getMin');
+		deepEqual(accessor.getMinNormalized([])[0].toFixed(2), '0.50', 'getMinNormalized'); // TODO: loose?
+		deepEqual(accessor.getMax([])[0].toFixed(2), '255.00', 'getMax');
+		deepEqual(accessor.getMaxNormalized([])[0].toFixed(2), '1.00', 'getMaxNormalized'); // TODO: loose?
+	});
 
-test('getComponentType', (t) => {
-	const accessor = new Document().createAccessor();
+	test('getComponentType', () => {
+		const accessor = new Document().createAccessor();
 
-	t.is(accessor.setArray(new Float32Array()).getComponentType(), FLOAT, 'float');
-	t.is(accessor.setArray(new Uint32Array()).getComponentType(), UNSIGNED_INT, 'uint32');
-	t.is(accessor.setArray(new Uint16Array()).getComponentType(), UNSIGNED_SHORT, 'uint16');
-	t.is(accessor.setArray(new Uint8Array()).getComponentType(), UNSIGNED_BYTE, 'uint8');
-	t.is(accessor.setArray(new Int16Array()).getComponentType(), SHORT, 'int16');
-	t.is(accessor.setArray(new Int8Array()).getComponentType(), BYTE, 'int8');
-	t.throws(
-		() => accessor.setArray(new Int32Array() as unknown as TypedArray).getComponentType(),
-		undefined,
-		'int32 (throws)',
-	);
-});
+		strictEqual(accessor.setArray(new Float32Array()).getComponentType(), FLOAT, 'float');
+		strictEqual(accessor.setArray(new Uint32Array()).getComponentType(), UNSIGNED_INT, 'uint32');
+		strictEqual(accessor.setArray(new Uint16Array()).getComponentType(), UNSIGNED_SHORT, 'uint16');
+		strictEqual(accessor.setArray(new Uint8Array()).getComponentType(), UNSIGNED_BYTE, 'uint8');
+		strictEqual(accessor.setArray(new Int16Array()).getComponentType(), SHORT, 'int16');
+		strictEqual(accessor.setArray(new Int8Array()).getComponentType(), BYTE, 'int8');
+		throws(
+			() => accessor.setArray(new Int32Array() as unknown as TypedArray).getComponentType(),
+			undefined,
+			'int32 (throws)',
+		);
+	});
 
-test('getComponentSize', (t) => {
-	const accessor = new Document().createAccessor();
+	test('getComponentSize', () => {
+		const accessor = new Document().createAccessor();
 
-	t.is(accessor.setArray(new Float32Array()).getComponentSize(), Float32Array.BYTES_PER_ELEMENT, 'float');
-	t.is(accessor.setArray(new Uint32Array()).getComponentSize(), Uint32Array.BYTES_PER_ELEMENT, 'uint32');
-	t.is(accessor.setArray(new Uint16Array()).getComponentSize(), Uint16Array.BYTES_PER_ELEMENT, 'uint16');
-	t.is(accessor.setArray(new Uint8Array()).getComponentSize(), Uint8Array.BYTES_PER_ELEMENT, 'uint8');
-	t.is(accessor.setArray(new Int16Array()).getComponentSize(), Int16Array.BYTES_PER_ELEMENT, 'int16');
-	t.is(accessor.setArray(new Int8Array()).getComponentSize(), Int8Array.BYTES_PER_ELEMENT, 'int8');
-	t.throws(
-		() => accessor.setArray(new Int32Array() as unknown as TypedArray).getComponentSize(),
-		undefined,
-		'int32 (throws)',
-	);
-});
+		strictEqual(accessor.setArray(new Float32Array()).getComponentSize(), Float32Array.BYTES_PER_ELEMENT, 'float');
+		strictEqual(accessor.setArray(new Uint32Array()).getComponentSize(), Uint32Array.BYTES_PER_ELEMENT, 'uint32');
+		strictEqual(accessor.setArray(new Uint16Array()).getComponentSize(), Uint16Array.BYTES_PER_ELEMENT, 'uint16');
+		strictEqual(accessor.setArray(new Uint8Array()).getComponentSize(), Uint8Array.BYTES_PER_ELEMENT, 'uint8');
+		strictEqual(accessor.setArray(new Int16Array()).getComponentSize(), Int16Array.BYTES_PER_ELEMENT, 'int16');
+		strictEqual(accessor.setArray(new Int8Array()).getComponentSize(), Int8Array.BYTES_PER_ELEMENT, 'int8');
+		throws(
+			() => accessor.setArray(new Int32Array() as unknown as TypedArray).getComponentSize(),
+			undefined,
+			'int32 (throws)',
+		);
+	});
 
-test('getElementSize', (t) => {
-	const accessor = new Document().createAccessor();
+	test('getElementSize', () => {
+		const accessor = new Document().createAccessor();
 
-	t.is(accessor.setType('SCALAR').getElementSize(), 1, 'scalar');
-	t.is(accessor.setType('VEC2').getElementSize(), 2, 'vec2');
-	t.is(accessor.setType('VEC3').getElementSize(), 3, 'vec3');
-	t.is(accessor.setType('VEC4').getElementSize(), 4, 'vec4');
-	t.is(accessor.setType('MAT3').getElementSize(), 9, 'mat3');
-	t.is(accessor.setType('MAT4').getElementSize(), 16, 'mat4');
-	t.throws(() => accessor.setType('VEC5' as GLTF.AccessorType).getElementSize(), undefined, 'vec5 (throws)');
-});
+		strictEqual(accessor.setType('SCALAR').getElementSize(), 1, 'scalar');
+		strictEqual(accessor.setType('VEC2').getElementSize(), 2, 'vec2');
+		strictEqual(accessor.setType('VEC3').getElementSize(), 3, 'vec3');
+		strictEqual(accessor.setType('VEC4').getElementSize(), 4, 'vec4');
+		strictEqual(accessor.setType('MAT3').getElementSize(), 9, 'mat3');
+		strictEqual(accessor.setType('MAT4').getElementSize(), 16, 'mat4');
+		throws(() => accessor.setType('VEC5' as GLTF.AccessorType).getElementSize(), undefined, 'vec5 (throws)');
+	});
 
-test('interleaved', async (t) => {
-	const resources = {
-		'test.bin': new Uint8Array(
-			new Uint16Array([
-				// vertex 1
-				0,
-				1,
-				2,
-				10,
-				20,
-				100,
-				200,
+	test('interleaved', async () => {
+		const resources = {
+			'test.bin': new Uint8Array(
+				new Uint16Array([
+					// vertex 1
+					0,
+					1,
+					2,
+					10,
+					20,
+					100,
+					200,
 
-				0, // pad
+					0, // pad
 
-				// vertex 2
-				3,
-				4,
-				5,
-				40,
-				50,
-				400,
-				500,
+					// vertex 2
+					3,
+					4,
+					5,
+					40,
+					50,
+					400,
+					500,
 
-				0, // pad
-			]).buffer,
-		),
-	};
+					0, // pad
+				]).buffer,
+			),
+		};
 
-	const json = {
-		asset: { version: '2.0' },
-		accessors: [
-			{
-				count: 2,
-				bufferView: 0,
-				byteOffset: 0,
-				type: Accessor.Type.VEC3,
-				componentType: UNSIGNED_SHORT,
-			},
-			{
-				count: 2,
-				bufferView: 0,
-				byteOffset: 6,
-				type: Accessor.Type.VEC2,
-				componentType: UNSIGNED_SHORT,
-			},
-			{
-				count: 2,
-				bufferView: 0,
-				byteOffset: 10,
-				type: Accessor.Type.VEC2,
-				componentType: UNSIGNED_SHORT,
-			},
-		],
-		bufferViews: [
-			{
-				buffer: 0,
-				byteOffset: 0,
-				byteStride: 16,
-				byteLength: resources['test.bin'].byteLength,
-			},
-		],
-		buffers: [
-			{
-				uri: 'test.bin',
-				byteLength: resources['test.bin'].byteLength,
-			},
-		],
-	};
+		const json = {
+			asset: { version: '2.0' },
+			accessors: [
+				{
+					count: 2,
+					bufferView: 0,
+					byteOffset: 0,
+					type: Accessor.Type.VEC3,
+					componentType: UNSIGNED_SHORT,
+				},
+				{
+					count: 2,
+					bufferView: 0,
+					byteOffset: 6,
+					type: Accessor.Type.VEC2,
+					componentType: UNSIGNED_SHORT,
+				},
+				{
+					count: 2,
+					bufferView: 0,
+					byteOffset: 10,
+					type: Accessor.Type.VEC2,
+					componentType: UNSIGNED_SHORT,
+				},
+			],
+			bufferViews: [
+				{
+					buffer: 0,
+					byteOffset: 0,
+					byteStride: 16,
+					byteLength: resources['test.bin'].byteLength,
+				},
+			],
+			buffers: [
+				{
+					uri: 'test.bin',
+					byteLength: resources['test.bin'].byteLength,
+				},
+			],
+		};
 
-	const io = await createPlatformIO();
-	const document = await io.readJSON({ json, resources });
-	const arrays = document
-		.getRoot()
-		.listAccessors()
-		.map((accessor) => accessor.getArray());
+		const io = await createPlatformIO();
+		const document = await io.readJSON({ json, resources });
+		const arrays = document
+			.getRoot()
+			.listAccessors()
+			.map((accessor) => accessor.getArray());
 
-	t.deepEqual(arrays[0], new Uint16Array([0, 1, 2, 3, 4, 5]), 'accessor 1, vec3');
-	t.deepEqual(arrays[1], new Uint16Array([10, 20, 40, 50]), 'accessor 2, vec2');
-	t.deepEqual(arrays[2], new Uint16Array([100, 200, 400, 500]), 'accessor 3, vec2');
-});
+		deepEqual(arrays[0], new Uint16Array([0, 1, 2, 3, 4, 5]), 'accessor 1, vec3');
+		deepEqual(arrays[1], new Uint16Array([10, 20, 40, 50]), 'accessor 2, vec2');
+		deepEqual(arrays[2], new Uint16Array([100, 200, 400, 500]), 'accessor 3, vec2');
+	});
 
-test('read sparse', async (t) => {
-	const resources = {
-		'indices.bin': new Uint8Array(new Uint16Array([10, 50, 51]).buffer),
-		'values.bin': new Uint8Array(new Float32Array([1, 2, 3, 10, 12, 14, 25, 50, 75]).buffer),
-	};
+	test('read sparse', async () => {
+		const resources = {
+			'indices.bin': new Uint8Array(new Uint16Array([10, 50, 51]).buffer),
+			'values.bin': new Uint8Array(new Float32Array([1, 2, 3, 10, 12, 14, 25, 50, 75]).buffer),
+		};
 
-	const json = {
-		asset: { version: '2.0' },
-		accessors: [
-			{
-				count: 100,
-				type: Accessor.Type.VEC3,
-				componentType: FLOAT,
-				sparse: {
-					count: 3,
-					indices: {
-						bufferView: 0,
-						componentType: UNSIGNED_SHORT,
-					},
-					values: {
-						bufferView: 1,
+		const json = {
+			asset: { version: '2.0' },
+			accessors: [
+				{
+					count: 100,
+					type: Accessor.Type.VEC3,
+					componentType: FLOAT,
+					sparse: {
+						count: 3,
+						indices: {
+							bufferView: 0,
+							componentType: UNSIGNED_SHORT,
+						},
+						values: {
+							bufferView: 1,
+						},
 					},
 				},
-			},
-		],
-		bufferViews: [
+			],
+			bufferViews: [
+				{
+					buffer: 0,
+					byteLength: resources['indices.bin'].byteLength,
+				},
+				{
+					buffer: 1,
+					byteLength: resources['values.bin'].byteLength,
+				},
+			],
+			buffers: [
+				{
+					uri: 'indices.bin',
+					byteLength: resources['indices.bin'].byteLength,
+				},
+				{
+					uri: 'values.bin',
+					byteLength: resources['values.bin'].byteLength,
+				},
+			],
+		};
+
+		const io = await createPlatformIO();
+		const document = await io.readJSON({ json, resources });
+		const accessors = document.getRoot().listAccessors();
+
+		const actual = [];
+		strictEqual(accessors.length, 1, 'found one sparse accessor');
+		deepEqual(accessors[0].getElement(0, actual) && actual, [0, 0, 0], 'empty index 1');
+		deepEqual(accessors[0].getElement(10, actual) && actual, [1, 2, 3], 'sparse index 1');
+		deepEqual(accessors[0].getElement(50, actual) && actual, [10, 12, 14], 'sparse index 2');
+		deepEqual(accessors[0].getElement(51, actual) && actual, [25, 50, 75], 'sparse index 3');
+		deepEqual(accessors[0].getElement(52, actual) && actual, [0, 0, 0], 'empty index 2');
+	});
+
+	test('write sparse', async () => {
+		const document = new Document();
+		const buffer = document.createBuffer();
+		const emptyArray = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		const sparseArray = [0, 0, 0, 0, 0, 25, 0, 0, 15, 0, 0, 0, 0, 0];
+		document.createAccessor('Empty').setArray(new Uint8Array(emptyArray)).setSparse(true).setBuffer(buffer);
+		document.createAccessor('Sparse').setArray(new Uint8Array(sparseArray)).setSparse(true).setBuffer(buffer);
+
+		const io = await createPlatformIO();
+		const { json, resources } = await io.writeJSON(document);
+
+		const emptyDef = json.accessors[0]!;
+		const sparseDef = json.accessors[1]!;
+
+		strictEqual(emptyDef.count, 14, 'emptyAccessor.count');
+		strictEqual(sparseDef.count, 14, 'sparseAccessor.count');
+		strictEqual(emptyDef.sparse, undefined, 'emptyAccessor json');
+		deepEqual(
+			sparseDef.sparse,
 			{
-				buffer: 0,
-				byteLength: resources['indices.bin'].byteLength,
+				count: 2,
+				indices: {
+					bufferView: 0,
+					byteOffset: 0,
+					componentType: UNSIGNED_BYTE,
+				},
+				values: {
+					bufferView: 1,
+					byteOffset: 0,
+				},
 			},
-			{
-				buffer: 1,
-				byteLength: resources['values.bin'].byteLength,
-			},
-		],
-		buffers: [
-			{
-				uri: 'indices.bin',
-				byteLength: resources['indices.bin'].byteLength,
-			},
-			{
-				uri: 'values.bin',
-				byteLength: resources['values.bin'].byteLength,
-			},
-		],
-	};
+			'sparseAccessor json',
+		);
 
-	const io = await createPlatformIO();
-	const document = await io.readJSON({ json, resources });
-	const accessors = document.getRoot().listAccessors();
+		const rtDocument = await io.readJSON({ json, resources });
+		const rtEmptyAccessor = rtDocument.getRoot().listAccessors()[0];
+		const rtSparseAccessor = rtDocument.getRoot().listAccessors()[1];
 
-	const actual = [];
-	t.is(accessors.length, 1, 'found one sparse accessor');
-	t.deepEqual(accessors[0].getElement(0, actual) && actual, [0, 0, 0], 'empty index 1');
-	t.deepEqual(accessors[0].getElement(10, actual) && actual, [1, 2, 3], 'sparse index 1');
-	t.deepEqual(accessors[0].getElement(50, actual) && actual, [10, 12, 14], 'sparse index 2');
-	t.deepEqual(accessors[0].getElement(51, actual) && actual, [25, 50, 75], 'sparse index 3');
-	t.deepEqual(accessors[0].getElement(52, actual) && actual, [0, 0, 0], 'empty index 2');
-});
+		strictEqual(rtEmptyAccessor.getSparse(), true, 'emptyAccessor.sparse (round trip)');
+		strictEqual(rtSparseAccessor.getSparse(), true, 'sparseAccessor.sparse (round trip)');
 
-test('write sparse', async (t) => {
-	const document = new Document();
-	const buffer = document.createBuffer();
-	const emptyArray = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
-	const sparseArray = [0, 0, 0, 0, 0, 25, 0, 0, 15, 0, 0, 0, 0, 0];
-	document.createAccessor('Empty').setArray(new Uint8Array(emptyArray)).setSparse(true).setBuffer(buffer);
-	document.createAccessor('Sparse').setArray(new Uint8Array(sparseArray)).setSparse(true).setBuffer(buffer);
+		deepEqual(Array.from(rtEmptyAccessor.getArray()), emptyArray, 'emptyAccessor.array (round trip)');
+		deepEqual(Array.from(rtSparseAccessor.getArray()), sparseArray, 'sparseAccessor.array (round trip)');
+	});
 
-	const io = await createPlatformIO();
-	const { json, resources } = await io.writeJSON(document);
+	test('minmax', () => {
+		const document = new Document();
+		const accessor = document
+			.createAccessor()
+			.setArray(new Float32Array([0, 0, 0, Infinity, NaN, -Infinity, 1, 0, -1, 0, 0, -3]))
+			.setType(Accessor.Type.VEC3);
 
-	const emptyDef = json.accessors[0]!;
-	const sparseDef = json.accessors[1]!;
+		deepEqual(accessor.getMin([]), [0, 0, -3], 'computes min, ignoring infinite and NaN');
+		deepEqual(accessor.getMax([]), [1, 0, 0], 'computes max, ignoring infinite and NaN');
+	});
 
-	t.is(emptyDef.count, 14, 'emptyAccessor.count');
-	t.is(sparseDef.count, 14, 'sparseAccessor.count');
-	t.falsy(emptyDef.sparse, 'emptyAccessor json');
-	t.deepEqual(
-		sparseDef.sparse,
-		{
-			count: 2,
-			indices: {
-				bufferView: 0,
-				byteOffset: 0,
-				componentType: UNSIGNED_BYTE,
-			},
-			values: {
-				bufferView: 1,
-				byteOffset: 0,
-			},
-		},
-		'sparseAccessor json',
-	);
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document
+			.createAccessor('A')
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setExtras({ foo: 1, bar: 2 })
+			.setBuffer(document.createBuffer());
 
-	const rtDocument = await io.readJSON({ json, resources });
-	const rtEmptyAccessor = rtDocument.getRoot().listAccessors()[0];
-	const rtSparseAccessor = rtDocument.getRoot().listAccessors()[1];
+		const doc2 = await io.readBinary(await io.writeBinary(document));
 
-	t.is(rtEmptyAccessor.getSparse(), true, 'emptyAccessor.sparse (round trip)');
-	t.is(rtSparseAccessor.getSparse(), true, 'sparseAccessor.sparse (round trip)');
+		deepEqual(document.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
+		deepEqual(doc2.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');
+	});
 
-	t.deepEqual(Array.from(rtEmptyAccessor.getArray()), emptyArray, 'emptyAccessor.array (round trip)');
-	t.deepEqual(Array.from(rtSparseAccessor.getArray()), sparseArray, 'sparseAccessor.array (round trip)');
-});
+	// See: https://github.com/donmccurdy/glTF-Transform/issues/1271
+	test('clone', async () => {
+		const srcDocument = new Document();
+		const srcAccessor = srcDocument
+			.createAccessor()
+			.setType('VEC3')
+			.setNormalized(true)
+			.setArray(new Uint8Array([0, 64, 255]));
+		deepEqual(srcAccessor.getElement(0, []).map(round(2)), [0, 0.25, 1]);
 
-test('minmax', (t) => {
-	const document = new Document();
-	const accessor = document
-		.createAccessor()
-		.setArray(new Float32Array([0, 0, 0, Infinity, NaN, -Infinity, 1, 0, -1, 0, 0, -3]))
-		.setType(Accessor.Type.VEC3);
+		const dstAccessor = srcAccessor.clone();
+		srcAccessor.setArray(new Float32Array([0, 0, 0]));
 
-	t.deepEqual(accessor.getMin([]), [0, 0, -3], 'computes min, ignoring infinite and NaN');
-	t.deepEqual(accessor.getMax([]), [1, 0, 0], 'computes max, ignoring infinite and NaN');
-});
-
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document
-		.createAccessor('A')
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setExtras({ foo: 1, bar: 2 })
-		.setBuffer(document.createBuffer());
-
-	const doc2 = await io.readBinary(await io.writeBinary(document));
-
-	t.deepEqual(document.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
-	t.deepEqual(doc2.getRoot().listAccessors()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');
-});
-
-// See: https://github.com/donmccurdy/glTF-Transform/issues/1271
-test('clone', async (t) => {
-	const srcDocument = new Document();
-	const srcAccessor = srcDocument
-		.createAccessor()
-		.setType('VEC3')
-		.setNormalized(true)
-		.setArray(new Uint8Array([0, 64, 255]));
-	t.deepEqual(srcAccessor.getElement(0, []).map(round(2)), [0, 0.25, 1]);
-
-	const dstAccessor = srcAccessor.clone();
-	srcAccessor.setArray(new Float32Array([0, 0, 0]));
-
-	t.deepEqual(dstAccessor.getElement(0, []).map(round(2)), [0, 0.25, 1]);
+		deepEqual(dstAccessor.getElement(0, []).map(round(2)), [0, 0.25, 1]);
+	});
 });

--- a/packages/core/test/properties/accessor.test.ts
+++ b/packages/core/test/properties/accessor.test.ts
@@ -5,7 +5,7 @@ import { createPlatformIO, round } from '@gltf-transform/test-utils';
 
 const { FLOAT, UNSIGNED_BYTE, UNSIGNED_SHORT, UNSIGNED_INT, BYTE, SHORT } = Accessor.ComponentType;
 
-describe('Accessor', () => {
+describe('core::Accessor', () => {
 	test('getScalar/setScalar', () => {
 		const accessor = new Document()
 			.createAccessor()

--- a/packages/core/test/properties/animation.test.ts
+++ b/packages/core/test/properties/animation.test.ts
@@ -1,130 +1,133 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document();
+describe('Animation', () => {
+	test('basic', async () => {
+		const document = new Document();
 
-	const buffer = document.createBuffer('default');
+		const buffer = document.createBuffer('default');
 
-	const ball = document.createNode('Ball');
+		const ball = document.createNode('Ball');
 
-	const input = document
-		.createAccessor('times')
-		.setArray(new Float32Array([0, 1, 2]))
-		.setType(Accessor.Type.SCALAR)
-		.setBuffer(buffer);
+		const input = document
+			.createAccessor('times')
+			.setArray(new Float32Array([0, 1, 2]))
+			.setType(Accessor.Type.SCALAR)
+			.setBuffer(buffer);
 
-	const output = document
-		.createAccessor('values')
-		.setArray(new Float32Array([0, 0, 0, 0, 1, 0, 0, 0, 0]))
-		.setType(Accessor.Type.VEC3)
-		.setBuffer(buffer);
+		const output = document
+			.createAccessor('values')
+			.setArray(new Float32Array([0, 0, 0, 0, 1, 0, 0, 0, 0]))
+			.setType(Accessor.Type.VEC3)
+			.setBuffer(buffer);
 
-	const sampler = document.createAnimationSampler().setInput(input).setOutput(output).setInterpolation('LINEAR');
+		const sampler = document.createAnimationSampler().setInput(input).setOutput(output).setInterpolation('LINEAR');
 
-	const channel = document
-		.createAnimationChannel()
-		.setTargetNode(ball)
-		.setTargetPath('translation')
-		.setSampler(sampler);
+		const channel = document
+			.createAnimationChannel()
+			.setTargetNode(ball)
+			.setTargetPath('translation')
+			.setSampler(sampler);
 
-	document.createAnimation('BallBounce').addChannel(channel).addSampler(sampler);
+		document.createAnimation('BallBounce').addChannel(channel).addSampler(sampler);
 
-	const io = await createPlatformIO();
+		const io = await createPlatformIO();
 
-	const options = { basename: 'animationTest' };
-	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, options)), options);
+		const options = { basename: 'animationTest' };
+		const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, options)), options);
 
-	t.deepEqual(
-		jsonDoc.json.animations[0],
-		{
-			name: 'BallBounce',
-			channels: [
-				{
-					sampler: 0,
-					target: {
-						node: 0,
-						path: 'translation',
+		deepEqual(
+			jsonDoc.json.animations[0],
+			{
+				name: 'BallBounce',
+				channels: [
+					{
+						sampler: 0,
+						target: {
+							node: 0,
+							path: 'translation',
+						},
 					},
-				},
-			],
-			samplers: [
-				{
-					interpolation: 'LINEAR',
-					input: 0,
-					output: 1,
-				},
-			],
-		},
-		'animation samplers and channels',
-	);
+				],
+				samplers: [
+					{
+						interpolation: 'LINEAR',
+						input: 0,
+						output: 1,
+					},
+				],
+			},
+			'animation samplers and channels',
+		);
 
-	const finalDoc = await io.readJSON(jsonDoc);
+		const finalDoc = await io.readJSON(jsonDoc);
 
-	t.deepEqual(finalDoc.getRoot().listAccessors()[0].getArray(), input.getArray(), 'sampler times');
-	t.deepEqual(finalDoc.getRoot().listAccessors()[1].getArray(), output.getArray(), 'sampler values');
-});
+		deepEqual(finalDoc.getRoot().listAccessors()[0].getArray(), input.getArray(), 'sampler times');
+		deepEqual(finalDoc.getRoot().listAccessors()[1].getArray(), output.getArray(), 'sampler values');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const a = document
-		.createAnimation('MyAnim')
-		.addChannel(document.createAnimationChannel())
-		.addSampler(document.createAnimationSampler());
-	const b = document.createAnimation().copy(a);
+	test('copy', () => {
+		const document = new Document();
+		const a = document
+			.createAnimation('MyAnim')
+			.addChannel(document.createAnimationChannel())
+			.addSampler(document.createAnimationSampler());
+		const b = document.createAnimation().copy(a);
 
-	t.is(b.getName(), a.getName(), 'copy name');
-	t.deepEqual(b.listChannels(), a.listChannels(), 'copy channels');
-	t.deepEqual(b.listSamplers(), a.listSamplers(), 'copy samplers');
-});
+		strictEqual(b.getName(), a.getName(), 'copy name');
+		deepEqual(b.listChannels(), a.listChannels(), 'copy channels');
+		deepEqual(b.listSamplers(), a.listSamplers(), 'copy samplers');
+	});
 
-test('copy channel', (t) => {
-	const document = new Document();
-	const a = document
-		.createAnimationChannel('MyChannel')
-		.setTargetNode(document.createNode())
-		.setSampler(document.createAnimationSampler());
-	const b = document.createAnimationChannel().copy(a);
+	test('copy channel', () => {
+		const document = new Document();
+		const a = document
+			.createAnimationChannel('MyChannel')
+			.setTargetNode(document.createNode())
+			.setSampler(document.createAnimationSampler());
+		const b = document.createAnimationChannel().copy(a);
 
-	t.is(b.getName(), a.getName(), 'copy name');
-	t.is(b.getTargetNode(), a.getTargetNode(), 'copy targetNode');
-	t.is(b.getSampler(), a.getSampler(), 'copy sampler');
-});
+		strictEqual(b.getName(), a.getName(), 'copy name');
+		strictEqual(b.getTargetNode(), a.getTargetNode(), 'copy targetNode');
+		strictEqual(b.getSampler(), a.getSampler(), 'copy sampler');
+	});
 
-test('copy sampler', (t) => {
-	const document = new Document();
-	const a = document
-		.createAnimationSampler('MySampler')
-		.setInterpolation('STEP')
-		.setInput(document.createAccessor())
-		.setOutput(document.createAccessor());
-	const b = document.createAnimationSampler().copy(a);
+	test('copy sampler', () => {
+		const document = new Document();
+		const a = document
+			.createAnimationSampler('MySampler')
+			.setInterpolation('STEP')
+			.setInput(document.createAccessor())
+			.setOutput(document.createAccessor());
+		const b = document.createAnimationSampler().copy(a);
 
-	t.is(b.getName(), a.getName(), 'copy name');
-	t.is(b.getInterpolation(), a.getInterpolation(), 'copy interpolation');
-	t.is(b.getInput(), a.getInput(), 'copy input');
-	t.is(b.getOutput(), a.getOutput(), 'copy output');
-});
+		strictEqual(b.getName(), a.getName(), 'copy name');
+		strictEqual(b.getInterpolation(), a.getInterpolation(), 'copy interpolation');
+		strictEqual(b.getInput(), a.getInput(), 'copy input');
+		strictEqual(b.getOutput(), a.getOutput(), 'copy output');
+	});
 
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document
-		.createAnimation('A')
-		.setExtras({ foo: 1, bar: 2 })
-		.addChannel(document.createAnimationChannel().setExtras({ channel: true }))
-		.addSampler(document.createAnimationSampler().setExtras({ sampler: true }));
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document
+			.createAnimation('A')
+			.setExtras({ foo: 1, bar: 2 })
+			.addChannel(document.createAnimationChannel().setExtras({ channel: true }))
+			.addSampler(document.createAnimationSampler().setExtras({ sampler: true }));
 
-	const document2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
+		const document2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
 
-	const anim = document.getRoot().listAnimations()[0];
-	const anim2 = document2.getRoot().listAnimations()[0];
+		const anim = document.getRoot().listAnimations()[0];
+		const anim2 = document2.getRoot().listAnimations()[0];
 
-	t.deepEqual(anim.getExtras(), { foo: 1, bar: 2 }, 'stores extras');
-	t.deepEqual(anim2.getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
-	t.deepEqual(anim.listChannels()[0].getExtras(), { channel: true }, 'stores channel extras');
-	t.deepEqual(anim2.listChannels()[0].getExtras(), { channel: true }, 'roundtrips channel extras');
-	t.deepEqual(anim.listSamplers()[0].getExtras(), { sampler: true }, 'stores channel extras');
-	t.deepEqual(anim2.listSamplers()[0].getExtras(), { sampler: true }, 'roundtrips channel extras');
+		deepEqual(anim.getExtras(), { foo: 1, bar: 2 }, 'stores extras');
+		deepEqual(anim2.getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+		deepEqual(anim.listChannels()[0].getExtras(), { channel: true }, 'stores channel extras');
+		deepEqual(anim2.listChannels()[0].getExtras(), { channel: true }, 'roundtrips channel extras');
+		deepEqual(anim.listSamplers()[0].getExtras(), { sampler: true }, 'stores channel extras');
+		deepEqual(anim2.listSamplers()[0].getExtras(), { sampler: true }, 'roundtrips channel extras');
+	});
 });

--- a/packages/core/test/properties/animation.test.ts
+++ b/packages/core/test/properties/animation.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Animation', () => {
+describe('core::Animation', () => {
 	test('basic', async () => {
 		const document = new Document();
 

--- a/packages/core/test/properties/buffer.test.ts
+++ b/packages/core/test/properties/buffer.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Buffer', () => {
+describe('core::Buffer', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const buffer1 = doc.createBuffer().setURI('mybuffer.bin');

--- a/packages/core/test/properties/buffer.test.ts
+++ b/packages/core/test/properties/buffer.test.ts
@@ -1,54 +1,57 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const buffer1 = doc.createBuffer().setURI('mybuffer.bin');
-	const buffer2 = doc.createBuffer().setURI('');
-	const buffer3 = doc.createBuffer();
-	doc.createBuffer().setURI('empty.bin');
+describe('Buffer', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const buffer1 = doc.createBuffer().setURI('mybuffer.bin');
+		const buffer2 = doc.createBuffer().setURI('');
+		const buffer3 = doc.createBuffer();
+		doc.createBuffer().setURI('empty.bin');
 
-	// Empty buffers aren't written.
-	doc.createAccessor()
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setBuffer(buffer1);
-	doc.createAccessor()
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setBuffer(buffer2);
-	doc.createAccessor()
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setBuffer(buffer3);
+		// Empty buffers aren't written.
+		doc.createAccessor()
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setBuffer(buffer1);
+		doc.createAccessor()
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setBuffer(buffer2);
+		doc.createAccessor()
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setBuffer(buffer3);
 
-	const io = await createPlatformIO();
-	const jsonDoc = await io.writeJSON(doc, { basename: 'basename' });
+		const io = await createPlatformIO();
+		const jsonDoc = await io.writeJSON(doc, { basename: 'basename' });
 
-	t.true('mybuffer.bin' in jsonDoc.resources, 'explicitly named buffer');
-	t.true('basename_1.bin' in jsonDoc.resources, 'implicitly named buffer #1');
-	t.true('basename_2.bin' in jsonDoc.resources, 'implicitly named buffer #2');
-	t.false('empty.bin' in jsonDoc.resources, 'empty buffer skipped');
-});
+		ok('mybuffer.bin' in jsonDoc.resources, 'explicitly named buffer');
+		ok('basename_1.bin' in jsonDoc.resources, 'implicitly named buffer #1');
+		ok('basename_2.bin' in jsonDoc.resources, 'implicitly named buffer #2');
+		strictEqual('empty.bin' in jsonDoc.resources, false, 'empty buffer skipped');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const buffer1 = document.createBuffer('MyBuffer').setURI('mybuffer.bin');
-	const buffer2 = document.createBuffer().copy(buffer1);
+	test('copy', () => {
+		const document = new Document();
+		const buffer1 = document.createBuffer('MyBuffer').setURI('mybuffer.bin');
+		const buffer2 = document.createBuffer().copy(buffer1);
 
-	t.is(buffer1.getName(), buffer2.getName(), 'copy name');
-	t.is(buffer1.getURI(), buffer2.getURI(), 'copy URI');
-});
+		strictEqual(buffer1.getName(), buffer2.getName(), 'copy name');
+		strictEqual(buffer1.getURI(), buffer2.getURI(), 'copy URI');
+	});
 
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	const buffer = document.createBuffer('A').setExtras({ foo: 1, bar: 2 });
-	document
-		.createAccessor()
-		.setArray(new Uint8Array([1, 2, 3]))
-		.setBuffer(buffer);
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		const buffer = document.createBuffer('A').setExtras({ foo: 1, bar: 2 });
+		document
+			.createAccessor()
+			.setArray(new Uint8Array([1, 2, 3]))
+			.setBuffer(buffer);
 
-	const document2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
+		const document2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
 
-	t.deepEqual(document.getRoot().listBuffers()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
-	t.deepEqual(document2.getRoot().listBuffers()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+		deepEqual(document.getRoot().listBuffers()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
+		deepEqual(document2.getRoot().listBuffers()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+	});
 });

--- a/packages/core/test/properties/camera.test.ts
+++ b/packages/core/test/properties/camera.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Camera', () => {
+describe('core::Camera', () => {
 	test('basic', async () => {
 		const document = new Document();
 

--- a/packages/core/test/properties/camera.test.ts
+++ b/packages/core/test/properties/camera.test.ts
@@ -1,88 +1,91 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document();
+describe('Camera', () => {
+	test('basic', async () => {
+		const document = new Document();
 
-	document
-		.createCamera('p')
-		.setType('perspective')
-		.setZNear(0.1)
-		.setZFar(10)
-		.setYFov(Math.PI / 5)
-		.setAspectRatio(0.5);
+		document
+			.createCamera('p')
+			.setType('perspective')
+			.setZNear(0.1)
+			.setZFar(10)
+			.setYFov(Math.PI / 5)
+			.setAspectRatio(0.5);
 
-	document.createCamera('o').setType('orthographic').setZNear(10).setZFar(100).setXMag(50).setYMag(25);
+		document.createCamera('o').setType('orthographic').setZNear(10).setZFar(100).setXMag(50).setYMag(25);
 
-	const io = await createPlatformIO();
+		const io = await createPlatformIO();
 
-	const options = { basename: 'cameraTest' };
-	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, options)), options);
+		const options = { basename: 'cameraTest' };
+		const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, options)), options);
 
-	t.deepEqual(
-		jsonDoc.json.cameras[0],
-		{
-			name: 'p',
-			type: 'perspective',
-			perspective: {
-				znear: 0.1,
-				zfar: 10,
-				yfov: Math.PI / 5,
-				aspectRatio: 0.5,
+		deepEqual(
+			jsonDoc.json.cameras[0],
+			{
+				name: 'p',
+				type: 'perspective',
+				perspective: {
+					znear: 0.1,
+					zfar: 10,
+					yfov: Math.PI / 5,
+					aspectRatio: 0.5,
+				},
 			},
-		},
-		'perspective camera',
-	);
+			'perspective camera',
+		);
 
-	t.deepEqual(
-		jsonDoc.json.cameras[1],
-		{
-			name: 'o',
-			type: 'orthographic',
-			orthographic: {
-				znear: 10,
-				zfar: 100,
-				xmag: 50,
-				ymag: 25,
+		deepEqual(
+			jsonDoc.json.cameras[1],
+			{
+				name: 'o',
+				type: 'orthographic',
+				orthographic: {
+					znear: 10,
+					zfar: 100,
+					xmag: 50,
+					ymag: 25,
+				},
 			},
-		},
-		'orthographic camera',
-	);
-});
+			'orthographic camera',
+		);
+	});
 
-test('copy', (t) => {
-	const document = new Document();
+	test('copy', () => {
+		const document = new Document();
 
-	const a = document
-		.createCamera('MyPerspectiveCamera')
-		.setType('perspective')
-		.setZNear(0.1)
-		.setZFar(10)
-		.setYFov(Math.PI / 5)
-		.setAspectRatio(0.5);
-	const b = document
-		.createCamera('MyOrthoCamera')
-		.setType('orthographic')
-		.setZNear(10)
-		.setZFar(100)
-		.setXMag(50)
-		.setYMag(25);
-	const c = document.createCamera().copy(a);
+		const a = document
+			.createCamera('MyPerspectiveCamera')
+			.setType('perspective')
+			.setZNear(0.1)
+			.setZFar(10)
+			.setYFov(Math.PI / 5)
+			.setAspectRatio(0.5);
+		const b = document
+			.createCamera('MyOrthoCamera')
+			.setType('orthographic')
+			.setZNear(10)
+			.setZFar(100)
+			.setXMag(50)
+			.setYMag(25);
+		const c = document.createCamera().copy(a);
 
-	t.is(c.getName(), a.getName(), 'copy name');
-	t.is(c.getType(), a.getType(), 'copy type');
-	t.is(c.getZNear(), a.getZNear(), 'copy znear');
-	t.is(c.getZFar(), a.getZFar(), 'copy zfar');
-	t.is(c.getYFov(), a.getYFov(), 'copy yfov');
-	t.is(c.getAspectRatio(), a.getAspectRatio(), 'copy aspectRatio');
+		strictEqual(c.getName(), a.getName(), 'copy name');
+		strictEqual(c.getType(), a.getType(), 'copy type');
+		strictEqual(c.getZNear(), a.getZNear(), 'copy znear');
+		strictEqual(c.getZFar(), a.getZFar(), 'copy zfar');
+		strictEqual(c.getYFov(), a.getYFov(), 'copy yfov');
+		strictEqual(c.getAspectRatio(), a.getAspectRatio(), 'copy aspectRatio');
 
-	c.copy(b);
+		c.copy(b);
 
-	t.is(c.getName(), b.getName(), 'copy name');
-	t.is(c.getType(), b.getType(), 'copy type');
-	t.is(c.getZNear(), b.getZNear(), 'copy znear');
-	t.is(c.getZFar(), b.getZFar(), 'copy zfar');
-	t.is(c.getXMag(), b.getXMag(), 'copy xmag');
-	t.is(c.getYMag(), b.getYMag(), 'copy ymag');
+		strictEqual(c.getName(), b.getName(), 'copy name');
+		strictEqual(c.getType(), b.getType(), 'copy type');
+		strictEqual(c.getZNear(), b.getZNear(), 'copy znear');
+		strictEqual(c.getZFar(), b.getZFar(), 'copy zfar');
+		strictEqual(c.getXMag(), b.getXMag(), 'copy xmag');
+		strictEqual(c.getYMag(), b.getYMag(), 'copy ymag');
+	});
 });

--- a/packages/core/test/properties/material.test.ts
+++ b/packages/core/test/properties/material.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import {
 	Document,
 	Format,
@@ -8,356 +10,357 @@ import {
 	TextureInfo,
 } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const { R, G, B, A } = TextureChannel;
 
-test('properties', (t) => {
-	const document = new Document();
+describe('Material', () => {
+	test('properties', () => {
+		const document = new Document();
 
-	const mat = document.createMaterial('mat').setDoubleSided(true).setAlphaMode('MASK').setAlphaCutoff(0.33);
+		const mat = document.createMaterial('mat').setDoubleSided(true).setAlphaMode('MASK').setAlphaCutoff(0.33);
 
-	t.is(mat.getDoubleSided(), true, 'doubleSided');
-	t.is(mat.getAlphaMode(), 'MASK', 'alphaMode');
-	t.is(mat.getAlphaCutoff(), 0.33, 'alphaCutoff');
-});
+		strictEqual(mat.getDoubleSided(), true, 'doubleSided');
+		strictEqual(mat.getAlphaMode(), 'MASK', 'alphaMode');
+		strictEqual(mat.getAlphaCutoff(), 0.33, 'alphaCutoff');
+	});
 
-test('factors', (t) => {
-	const document = new Document();
+	test('factors', () => {
+		const document = new Document();
 
-	const mat = document
-		.createMaterial('mat')
-		.setBaseColorFactor([1, 0, 0, 1])
-		.setEmissiveFactor([0.5, 0.5, 0.5])
-		.setMetallicFactor(0.1)
-		.setRoughnessFactor(0.9);
+		const mat = document
+			.createMaterial('mat')
+			.setBaseColorFactor([1, 0, 0, 1])
+			.setEmissiveFactor([0.5, 0.5, 0.5])
+			.setMetallicFactor(0.1)
+			.setRoughnessFactor(0.9);
 
-	t.deepEqual(mat.getBaseColorFactor(), [1, 0, 0, 1], 'baseColorFactor');
-	t.deepEqual(mat.getEmissiveFactor(), [0.5, 0.5, 0.5], 'emissiveFactor');
-	t.is(mat.getMetallicFactor(), 0.1, 'metallicFactor');
-	t.is(mat.getRoughnessFactor(), 0.9, 'roughnessFactor');
-});
+		deepEqual(mat.getBaseColorFactor(), [1, 0, 0, 1], 'baseColorFactor');
+		deepEqual(mat.getEmissiveFactor(), [0.5, 0.5, 0.5], 'emissiveFactor');
+		strictEqual(mat.getMetallicFactor(), 0.1, 'metallicFactor');
+		strictEqual(mat.getRoughnessFactor(), 0.9, 'roughnessFactor');
+	});
 
-test('textures', (t) => {
-	const document = new Document();
+	test('textures', () => {
+		const document = new Document();
 
-	const baseColor = document.createTexture('baseColor');
-	const emissive = document.createTexture('emissive');
-	const normal = document.createTexture('normal');
-	const metalRough = document.createTexture('metalRough');
-	const occlusion = document.createTexture('occlusion');
+		const baseColor = document.createTexture('baseColor');
+		const emissive = document.createTexture('emissive');
+		const normal = document.createTexture('normal');
+		const metalRough = document.createTexture('metalRough');
+		const occlusion = document.createTexture('occlusion');
 
-	const mat = document
-		.createMaterial('mat')
-		.setBaseColorTexture(baseColor)
-		.setEmissiveTexture(emissive)
-		.setNormalTexture(normal)
-		.setNormalScale(0.85)
-		.setMetallicRoughnessTexture(metalRough)
-		.setOcclusionTexture(occlusion)
-		.setOcclusionStrength(0.4);
+		const mat = document
+			.createMaterial('mat')
+			.setBaseColorTexture(baseColor)
+			.setEmissiveTexture(emissive)
+			.setNormalTexture(normal)
+			.setNormalScale(0.85)
+			.setMetallicRoughnessTexture(metalRough)
+			.setOcclusionTexture(occlusion)
+			.setOcclusionStrength(0.4);
 
-	t.is(mat.getBaseColorTexture(), baseColor, 'baseColorTexture');
-	t.is(mat.getEmissiveTexture(), emissive, 'emissiveTexture');
-	t.is(mat.getNormalTexture(), normal, 'normalTexture');
-	t.is(mat.getNormalScale(), 0.85, 'normalTexture.scale');
-	t.is(mat.getMetallicRoughnessTexture(), metalRough, 'metallicRoughnessTexture');
-	t.is(mat.getOcclusionTexture(), occlusion, 'occlusionTexture');
-	t.is(mat.getOcclusionStrength(), 0.4, 'occlusionTexture.strength');
-});
+		strictEqual(mat.getBaseColorTexture(), baseColor, 'baseColorTexture');
+		strictEqual(mat.getEmissiveTexture(), emissive, 'emissiveTexture');
+		strictEqual(mat.getNormalTexture(), normal, 'normalTexture');
+		strictEqual(mat.getNormalScale(), 0.85, 'normalTexture.scale');
+		strictEqual(mat.getMetallicRoughnessTexture(), metalRough, 'metallicRoughnessTexture');
+		strictEqual(mat.getOcclusionTexture(), occlusion, 'occlusionTexture');
+		strictEqual(mat.getOcclusionStrength(), 0.4, 'occlusionTexture.strength');
+	});
 
-test('texture samplers', (t) => {
-	const document = new Document();
+	test('texture samplers', () => {
+		const document = new Document();
 
-	const mat = document.createMaterial('mat');
-	const baseColor = document.createTexture('baseColor');
-	const emissive = document.createTexture('emissive');
+		const mat = document.createMaterial('mat');
+		const baseColor = document.createTexture('baseColor');
+		const emissive = document.createTexture('emissive');
 
-	t.is(mat.getBaseColorTextureInfo(), null, 'default baseColorTexture sampler');
-	t.is(mat.getEmissiveTextureInfo(), null, 'default emissiveTexture sampler');
-	t.is(mat.getNormalTextureInfo(), null, 'default normalTexture sampler');
-	t.is(mat.getMetallicRoughnessTextureInfo(), null, 'default metalRoughTexture sampler');
-	t.is(mat.getOcclusionTextureInfo(), null, 'default occlusionTexture sampler');
+		strictEqual(mat.getBaseColorTextureInfo(), null, 'default baseColorTexture sampler');
+		strictEqual(mat.getEmissiveTextureInfo(), null, 'default emissiveTexture sampler');
+		strictEqual(mat.getNormalTextureInfo(), null, 'default normalTexture sampler');
+		strictEqual(mat.getMetallicRoughnessTextureInfo(), null, 'default metalRoughTexture sampler');
+		strictEqual(mat.getOcclusionTextureInfo(), null, 'default occlusionTexture sampler');
 
-	mat.setBaseColorTexture(baseColor)
-		.getBaseColorTextureInfo()
-		.setWrapS(TextureInfo.WrapMode.REPEAT)
-		.setWrapT(TextureInfo.WrapMode.CLAMP_TO_EDGE);
+		mat.setBaseColorTexture(baseColor)
+			.getBaseColorTextureInfo()
+			.setWrapS(TextureInfo.WrapMode.REPEAT)
+			.setWrapT(TextureInfo.WrapMode.CLAMP_TO_EDGE);
 
-	mat.setEmissiveTexture(emissive)
-		.getEmissiveTextureInfo()
-		.setMinFilter(TextureInfo.MinFilter.LINEAR)
-		.setMagFilter(TextureInfo.MagFilter.NEAREST);
+		mat.setEmissiveTexture(emissive)
+			.getEmissiveTextureInfo()
+			.setMinFilter(TextureInfo.MinFilter.LINEAR)
+			.setMagFilter(TextureInfo.MagFilter.NEAREST);
 
-	t.is(mat.getBaseColorTextureInfo().getWrapS(), TextureInfo.WrapMode.REPEAT, 'wrapS');
-	t.is(mat.getBaseColorTextureInfo().getWrapT(), TextureInfo.WrapMode.CLAMP_TO_EDGE, 'wrapT');
-	t.is(mat.getEmissiveTextureInfo().getMinFilter(), TextureInfo.MinFilter.LINEAR, 'minFilter');
-	t.is(mat.getEmissiveTextureInfo().getMagFilter(), TextureInfo.MagFilter.NEAREST, 'magFilter');
-	t.is(mat.getNormalTextureInfo(), null, 'unchanged normalTexture sampler');
-	t.is(mat.getMetallicRoughnessTextureInfo(), null, 'unchanged metallicRoughnessTexture sampler');
-	t.is(mat.getOcclusionTextureInfo(), null, 'unchanged occlusionTexture sampler');
-});
+		strictEqual(mat.getBaseColorTextureInfo().getWrapS(), TextureInfo.WrapMode.REPEAT, 'wrapS');
+		strictEqual(mat.getBaseColorTextureInfo().getWrapT(), TextureInfo.WrapMode.CLAMP_TO_EDGE, 'wrapT');
+		strictEqual(mat.getEmissiveTextureInfo().getMinFilter(), TextureInfo.MinFilter.LINEAR, 'minFilter');
+		strictEqual(mat.getEmissiveTextureInfo().getMagFilter(), TextureInfo.MagFilter.NEAREST, 'magFilter');
+		strictEqual(mat.getNormalTextureInfo(), null, 'unchanged normalTexture sampler');
+		strictEqual(mat.getMetallicRoughnessTextureInfo(), null, 'unchanged metallicRoughnessTexture sampler');
+		strictEqual(mat.getOcclusionTextureInfo(), null, 'unchanged occlusionTexture sampler');
+	});
 
-test('texture info', (t) => {
-	const document = new Document();
+	test('texture info', () => {
+		const document = new Document();
 
-	const mat = document.createMaterial('mat');
-	const baseColor = document.createTexture('baseColor');
-	const emissive = document.createTexture('emissive');
+		const mat = document.createMaterial('mat');
+		const baseColor = document.createTexture('baseColor');
+		const emissive = document.createTexture('emissive');
 
-	t.is(mat.getBaseColorTextureInfo(), null, 'default baseColorTexture info');
-	t.is(mat.getEmissiveTextureInfo(), null, 'default emissiveTexture info');
-	t.is(mat.getNormalTextureInfo(), null, 'default normalTexture info');
-	t.is(mat.getMetallicRoughnessTextureInfo(), null, 'default metallicRoughnessTexture info');
-	t.is(mat.getOcclusionTextureInfo(), null, 'default occlusionTexture info');
+		strictEqual(mat.getBaseColorTextureInfo(), null, 'default baseColorTexture info');
+		strictEqual(mat.getEmissiveTextureInfo(), null, 'default emissiveTexture info');
+		strictEqual(mat.getNormalTextureInfo(), null, 'default normalTexture info');
+		strictEqual(mat.getMetallicRoughnessTextureInfo(), null, 'default metallicRoughnessTexture info');
+		strictEqual(mat.getOcclusionTextureInfo(), null, 'default occlusionTexture info');
 
-	mat.setBaseColorTexture(baseColor).getBaseColorTextureInfo().setTexCoord(0);
+		mat.setBaseColorTexture(baseColor).getBaseColorTextureInfo().setTexCoord(0);
 
-	mat.setEmissiveTexture(emissive).getEmissiveTextureInfo().setTexCoord(1);
+		mat.setEmissiveTexture(emissive).getEmissiveTextureInfo().setTexCoord(1);
 
-	t.is(mat.getBaseColorTextureInfo().getTexCoord(), 0, 'baseColorTexture.texCoord');
-	t.is(mat.getEmissiveTextureInfo().getTexCoord(), 1, 'emissiveTexture.texCoord');
-	t.is(mat.getNormalTextureInfo(), null, 'unchanged normalTexture info');
-	t.is(mat.getMetallicRoughnessTextureInfo(), null, 'unchanged metallicRoughnessTexture info');
-	t.is(mat.getOcclusionTextureInfo(), null, 'unchanged occlusionTexture info');
-});
+		strictEqual(mat.getBaseColorTextureInfo().getTexCoord(), 0, 'baseColorTexture.texCoord');
+		strictEqual(mat.getEmissiveTextureInfo().getTexCoord(), 1, 'emissiveTexture.texCoord');
+		strictEqual(mat.getNormalTextureInfo(), null, 'unchanged normalTexture info');
+		strictEqual(mat.getMetallicRoughnessTextureInfo(), null, 'unchanged metallicRoughnessTexture info');
+		strictEqual(mat.getOcclusionTextureInfo(), null, 'unchanged occlusionTexture info');
+	});
 
-test('texture linking', (t) => {
-	const document = new Document();
+	test('texture linking', () => {
+		const document = new Document();
 
-	const tex1 = document.createTexture('tex1');
-	const tex2 = document.createTexture('tex2');
-	const tex3 = document.createTexture('tex3');
+		const tex1 = document.createTexture('tex1');
+		const tex2 = document.createTexture('tex2');
+		const tex3 = document.createTexture('tex3');
 
-	const mat = document.createMaterial('mat');
+		const mat = document.createMaterial('mat');
 
-	const toType = (p: Property): string => p.propertyType;
+		const toType = (p: Property): string => p.propertyType;
 
-	mat.setBaseColorTexture(tex1);
-	t.is(mat.getBaseColorTexture(), tex1, 'sets baseColorTexture');
-	t.deepEqual(tex1.listParents().map(toType), ['Root', 'Material'], 'links baseColorTexture');
+		mat.setBaseColorTexture(tex1);
+		strictEqual(mat.getBaseColorTexture(), tex1, 'sets baseColorTexture');
+		deepEqual(tex1.listParents().map(toType), ['Root', 'Material'], 'links baseColorTexture');
 
-	mat.setNormalTexture(tex2);
-	t.is(mat.getNormalTexture(), tex2, 'sets normalTexture');
-	t.deepEqual(tex1.listParents().map(toType), ['Root', 'Material'], 'links normalTexture');
-	t.deepEqual(tex2.listParents().map(toType), ['Root', 'Material'], 'links normalTexture');
+		mat.setNormalTexture(tex2);
+		strictEqual(mat.getNormalTexture(), tex2, 'sets normalTexture');
+		deepEqual(tex1.listParents().map(toType), ['Root', 'Material'], 'links normalTexture');
+		deepEqual(tex2.listParents().map(toType), ['Root', 'Material'], 'links normalTexture');
 
-	mat.setBaseColorTexture(tex3);
-	t.is(mat.getBaseColorTexture(), tex3, 'overwrites baseColorTexture');
-	t.deepEqual(tex1.listParents().map(toType), ['Root'], 'unlinks old baseColorTexture');
-	t.deepEqual(tex3.listParents().map(toType), ['Root', 'Material'], 'links new baseColorTexture');
+		mat.setBaseColorTexture(tex3);
+		strictEqual(mat.getBaseColorTexture(), tex3, 'overwrites baseColorTexture');
+		deepEqual(tex1.listParents().map(toType), ['Root'], 'unlinks old baseColorTexture');
+		deepEqual(tex3.listParents().map(toType), ['Root', 'Material'], 'links new baseColorTexture');
 
-	mat.setBaseColorTexture(null);
-	t.is(mat.getBaseColorTexture(), null, 'deletes baseColorTexture');
-	t.deepEqual(tex3.listParents().map(toType), ['Root'], 'unlinks old baseColorTexture');
-});
+		mat.setBaseColorTexture(null);
+		strictEqual(mat.getBaseColorTexture(), null, 'deletes baseColorTexture');
+		deepEqual(tex3.listParents().map(toType), ['Root'], 'unlinks old baseColorTexture');
+	});
 
-test('texture info linking', (t) => {
-	const document = new Document();
+	test('texture info linking', () => {
+		const document = new Document();
 
-	const mat = document.createMaterial('mat');
-	const tex1 = document.createTexture('tex1');
-	const tex2 = document.createTexture('tex2');
-	const tex3 = document.createTexture('tex3');
+		const mat = document.createMaterial('mat');
+		const tex1 = document.createTexture('tex1');
+		const tex2 = document.createTexture('tex2');
+		const tex3 = document.createTexture('tex3');
 
-	t.is(mat.getBaseColorTextureInfo(), null, 'textureInfo == null');
+		strictEqual(mat.getBaseColorTextureInfo(), null, 'textureInfo == null');
 
-	mat.setBaseColorTexture(tex1);
-	mat.getBaseColorTextureInfo().setTexCoord(2);
+		mat.setBaseColorTexture(tex1);
+		mat.getBaseColorTextureInfo().setTexCoord(2);
 
-	const textureInfo = mat.getBaseColorTextureInfo();
-	t.truthy(textureInfo, 'textureInfo != null');
-	t.is(textureInfo.getTexCoord(), 2, 'textureInfo.texCoord === 2');
+		const textureInfo = mat.getBaseColorTextureInfo();
+		ok(textureInfo, 'textureInfo != null');
+		strictEqual(textureInfo.getTexCoord(), 2, 'textureInfo.texCoord === 2');
 
-	mat.setBaseColorTexture(tex2);
-	t.is(mat.getBaseColorTextureInfo(), textureInfo, 'textureInfo unchanged');
+		mat.setBaseColorTexture(tex2);
+		strictEqual(mat.getBaseColorTextureInfo(), textureInfo, 'textureInfo unchanged');
 
-	mat.setBaseColorTexture(null);
-	t.is(mat.getBaseColorTextureInfo(), null, 'textureInfo == null');
+		mat.setBaseColorTexture(null);
+		strictEqual(mat.getBaseColorTextureInfo(), null, 'textureInfo == null');
 
-	mat.setBaseColorTexture(tex3);
-	t.is(mat.getBaseColorTextureInfo(), textureInfo, 'textureInfo unchanged');
+		mat.setBaseColorTexture(tex3);
+		strictEqual(mat.getBaseColorTextureInfo(), textureInfo, 'textureInfo unchanged');
 
-	const baseColorTextureInfo = mat.getBaseColorTextureInfo();
-	mat.dispose();
-	t.is(baseColorTextureInfo.isDisposed(), true, 'textureInfo disposed with material');
-});
+		const baseColorTextureInfo = mat.getBaseColorTextureInfo();
+		mat.dispose();
+		strictEqual(baseColorTextureInfo.isDisposed(), true, 'textureInfo disposed with material');
+	});
 
-test('texture channels', (t) => {
-	const document = new Document();
-	const graph = document.getGraph();
+	test('texture channels', () => {
+		const document = new Document();
+		const graph = document.getGraph();
 
-	const baseColorTexture = document.createTexture('baseColorTexture');
-	const normalTexture = document.createTexture('normalTexture');
-	const occlusionTexture = document.createTexture('occlusionTexture');
-	const metallicRoughnessTexture = document.createTexture('metallicRoughnessTexture');
+		const baseColorTexture = document.createTexture('baseColorTexture');
+		const normalTexture = document.createTexture('normalTexture');
+		const occlusionTexture = document.createTexture('occlusionTexture');
+		const metallicRoughnessTexture = document.createTexture('metallicRoughnessTexture');
 
-	const mat = document
-		.createMaterial('mat')
-		.setBaseColorTexture(baseColorTexture)
-		.setNormalTexture(normalTexture)
-		.setOcclusionTexture(occlusionTexture)
-		.setMetallicRoughnessTexture(metallicRoughnessTexture);
+		const mat = document
+			.createMaterial('mat')
+			.setBaseColorTexture(baseColorTexture)
+			.setNormalTexture(normalTexture)
+			.setOcclusionTexture(occlusionTexture)
+			.setMetallicRoughnessTexture(metallicRoughnessTexture);
 
-	function getChannels(texture: Texture): number {
-		let mask = 0x0000;
-		for (const edge of graph.listParentEdges(texture)) {
-			const { channels } = edge.getAttributes() as { channels: number | undefined };
+		function getChannels(texture: Texture): number {
+			let mask = 0x0000;
+			for (const edge of graph.listParentEdges(texture)) {
+				const { channels } = edge.getAttributes() as { channels: number | undefined };
 
-			if (channels) {
-				mask |= channels;
-				continue;
+				if (channels) {
+					mask |= channels;
+					continue;
+				}
+
+				if (edge.getParent().propertyType !== PropertyType.ROOT) {
+					throw new Error(`Missing attribute ".channels" on link, "${edge.getName()}".`);
+				}
 			}
-
-			if (edge.getParent().propertyType !== PropertyType.ROOT) {
-				throw new Error(`Missing attribute ".channels" on link, "${edge.getName()}".`);
-			}
+			return mask;
 		}
-		return mask;
-	}
 
-	t.is(getChannels(baseColorTexture), R | G | B | A, 'baseColorTexture channels');
-	t.is(getChannels(normalTexture), R | G | B, 'normalTexture channels');
-	t.is(getChannels(occlusionTexture), R, 'occlusionTexture channels');
-	t.is(getChannels(metallicRoughnessTexture), G | B, 'metallicRoughnessTexture channels');
+		strictEqual(getChannels(baseColorTexture), R | G | B | A, 'baseColorTexture channels');
+		strictEqual(getChannels(normalTexture), R | G | B, 'normalTexture channels');
+		strictEqual(getChannels(occlusionTexture), R, 'occlusionTexture channels');
+		strictEqual(getChannels(metallicRoughnessTexture), G | B, 'metallicRoughnessTexture channels');
 
-	mat.setMetallicRoughnessTexture(occlusionTexture);
+		mat.setMetallicRoughnessTexture(occlusionTexture);
 
-	t.is(getChannels(occlusionTexture), R | G | B, 'O/R/M channels');
-});
+		strictEqual(getChannels(occlusionTexture), R | G | B, 'O/R/M channels');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const tex = document.createTexture('MyTex');
-	const mat = document
-		.createMaterial('MyMat')
-		.setAlphaMode('BLEND')
-		.setAlphaCutoff(0.5)
-		.setBaseColorFactor([1, 0, 1, 0.5])
-		.setBaseColorTexture(tex)
-		.setMetallicFactor(0)
-		.setRoughnessFactor(0.9)
-		.setMetallicRoughnessTexture(tex)
-		.setNormalScale(0.9)
-		.setNormalTexture(tex)
-		.setOcclusionStrength(1.5)
-		.setOcclusionTexture(tex)
-		.setEmissiveFactor([2, 2, 2])
-		.setEmissiveTexture(tex);
-	mat.getBaseColorTextureInfo()
-		.setTexCoord(2)
-		.setMagFilter(TextureInfo.MagFilter.LINEAR)
-		.setMinFilter(TextureInfo.MinFilter.NEAREST)
-		.setWrapS(TextureInfo.WrapMode.REPEAT)
-		.setWrapT(TextureInfo.WrapMode.MIRRORED_REPEAT);
+	test('copy', () => {
+		const document = new Document();
+		const tex = document.createTexture('MyTex');
+		const mat = document
+			.createMaterial('MyMat')
+			.setAlphaMode('BLEND')
+			.setAlphaCutoff(0.5)
+			.setBaseColorFactor([1, 0, 1, 0.5])
+			.setBaseColorTexture(tex)
+			.setMetallicFactor(0)
+			.setRoughnessFactor(0.9)
+			.setMetallicRoughnessTexture(tex)
+			.setNormalScale(0.9)
+			.setNormalTexture(tex)
+			.setOcclusionStrength(1.5)
+			.setOcclusionTexture(tex)
+			.setEmissiveFactor([2, 2, 2])
+			.setEmissiveTexture(tex);
+		mat.getBaseColorTextureInfo()
+			.setTexCoord(2)
+			.setMagFilter(TextureInfo.MagFilter.LINEAR)
+			.setMinFilter(TextureInfo.MinFilter.NEAREST)
+			.setWrapS(TextureInfo.WrapMode.REPEAT)
+			.setWrapT(TextureInfo.WrapMode.MIRRORED_REPEAT);
 
-	const mat2 = document.createMaterial().copy(mat);
+		const mat2 = document.createMaterial().copy(mat);
 
-	t.is(mat2.getName(), 'MyMat', 'copy name');
-	t.is(mat2.getAlphaMode(), 'BLEND', 'copy AlphaMode');
-	t.is(mat2.getAlphaCutoff(), 0.5, 'copy AlphaCutoff');
-	t.deepEqual(mat2.getBaseColorFactor(), [1, 0, 1, 0.5], 'copy BaseColorFactor');
-	t.is(mat2.getBaseColorTexture(), tex, 'copy BaseColorTexture');
-	t.is(mat2.getMetallicFactor(), 0, 'copy MetallicFactor');
-	t.is(mat2.getRoughnessFactor(), 0.9, 'copy RoughnessFactor');
-	t.is(mat2.getMetallicRoughnessTexture(), tex, 'copy MetallicRoughnessTexture');
-	t.is(mat2.getNormalScale(), 0.9, 'copy NormalScale');
-	t.is(mat2.getNormalTexture(), tex, 'copy NormalTexture');
-	t.is(mat2.getOcclusionStrength(), 1.5, 'copy OcclusionStrength');
-	t.is(mat2.getOcclusionTexture(), tex, 'copy OcclusionTexture');
-	t.deepEqual(mat2.getEmissiveFactor(), [2, 2, 2], 'copy EmissiveFactor');
-	t.is(mat2.getEmissiveTexture(), tex, 'copy EmissiveTexture');
+		strictEqual(mat2.getName(), 'MyMat', 'copy name');
+		strictEqual(mat2.getAlphaMode(), 'BLEND', 'copy AlphaMode');
+		strictEqual(mat2.getAlphaCutoff(), 0.5, 'copy AlphaCutoff');
+		deepEqual(mat2.getBaseColorFactor(), [1, 0, 1, 0.5], 'copy BaseColorFactor');
+		strictEqual(mat2.getBaseColorTexture(), tex, 'copy BaseColorTexture');
+		strictEqual(mat2.getMetallicFactor(), 0, 'copy MetallicFactor');
+		strictEqual(mat2.getRoughnessFactor(), 0.9, 'copy RoughnessFactor');
+		strictEqual(mat2.getMetallicRoughnessTexture(), tex, 'copy MetallicRoughnessTexture');
+		strictEqual(mat2.getNormalScale(), 0.9, 'copy NormalScale');
+		strictEqual(mat2.getNormalTexture(), tex, 'copy NormalTexture');
+		strictEqual(mat2.getOcclusionStrength(), 1.5, 'copy OcclusionStrength');
+		strictEqual(mat2.getOcclusionTexture(), tex, 'copy OcclusionTexture');
+		deepEqual(mat2.getEmissiveFactor(), [2, 2, 2], 'copy EmissiveFactor');
+		strictEqual(mat2.getEmissiveTexture(), tex, 'copy EmissiveTexture');
 
-	const textureInfo = mat2.getBaseColorTextureInfo();
-	t.is(textureInfo.getTexCoord(), 2, 'copy texCoord');
-	t.is(textureInfo.getMagFilter(), TextureInfo.MagFilter.LINEAR, 'magFilter');
-	t.is(textureInfo.getMinFilter(), TextureInfo.MinFilter.NEAREST, 'minFilter');
-	t.is(textureInfo.getWrapS(), TextureInfo.WrapMode.REPEAT, 'wrapS');
-	t.is(textureInfo.getWrapT(), TextureInfo.WrapMode.MIRRORED_REPEAT, 'wrapT');
-});
+		const textureInfo = mat2.getBaseColorTextureInfo();
+		strictEqual(textureInfo.getTexCoord(), 2, 'copy texCoord');
+		strictEqual(textureInfo.getMagFilter(), TextureInfo.MagFilter.LINEAR, 'magFilter');
+		strictEqual(textureInfo.getMinFilter(), TextureInfo.MinFilter.NEAREST, 'minFilter');
+		strictEqual(textureInfo.getWrapS(), TextureInfo.WrapMode.REPEAT, 'wrapS');
+		strictEqual(textureInfo.getWrapT(), TextureInfo.WrapMode.MIRRORED_REPEAT, 'wrapT');
+	});
 
-test('equals', (t) => {
-	const document = new Document();
-	const tex = document.createTexture('MyTex');
-	const mat = document
-		.createMaterial('MyMat')
-		.setAlphaMode('BLEND')
-		.setAlphaCutoff(0.5)
-		.setBaseColorFactor([1, 0, 1, 0.5])
-		.setBaseColorTexture(tex)
-		.setMetallicFactor(0)
-		.setRoughnessFactor(0.9)
-		.setMetallicRoughnessTexture(tex)
-		.setNormalScale(0.9)
-		.setNormalTexture(tex)
-		.setOcclusionStrength(1.5)
-		.setOcclusionTexture(tex)
-		.setEmissiveFactor([2, 2, 2])
-		.setEmissiveTexture(tex);
-	mat.getBaseColorTextureInfo()
-		.setTexCoord(2)
-		.setMagFilter(TextureInfo.MagFilter.LINEAR)
-		.setMinFilter(TextureInfo.MinFilter.NEAREST)
-		.setWrapS(TextureInfo.WrapMode.REPEAT)
-		.setWrapT(TextureInfo.WrapMode.MIRRORED_REPEAT);
+	test('equals', () => {
+		const document = new Document();
+		const tex = document.createTexture('MyTex');
+		const mat = document
+			.createMaterial('MyMat')
+			.setAlphaMode('BLEND')
+			.setAlphaCutoff(0.5)
+			.setBaseColorFactor([1, 0, 1, 0.5])
+			.setBaseColorTexture(tex)
+			.setMetallicFactor(0)
+			.setRoughnessFactor(0.9)
+			.setMetallicRoughnessTexture(tex)
+			.setNormalScale(0.9)
+			.setNormalTexture(tex)
+			.setOcclusionStrength(1.5)
+			.setOcclusionTexture(tex)
+			.setEmissiveFactor([2, 2, 2])
+			.setEmissiveTexture(tex);
+		mat.getBaseColorTextureInfo()
+			.setTexCoord(2)
+			.setMagFilter(TextureInfo.MagFilter.LINEAR)
+			.setMinFilter(TextureInfo.MinFilter.NEAREST)
+			.setWrapS(TextureInfo.WrapMode.REPEAT)
+			.setWrapT(TextureInfo.WrapMode.MIRRORED_REPEAT);
 
-	const mat2 = document.createMaterial();
+		const mat2 = document.createMaterial();
 
-	mat2.copy(mat);
-	t.is(mat.equals(mat), true, 'mat = mat');
-	t.is(mat.equals(mat2), true, 'mat ≅ mat2');
+		mat2.copy(mat);
+		strictEqual(mat.equals(mat), true, 'mat = mat');
+		strictEqual(mat.equals(mat2), true, 'mat ≅ mat2');
 
-	mat2.copy(mat).setAlphaMode('OPAQUE');
-	t.is(mat.equals(mat2), false, '.alphaMode ≠ .alphaMode');
+		mat2.copy(mat).setAlphaMode('OPAQUE');
+		strictEqual(mat.equals(mat2), false, '.alphaMode ≠ .alphaMode');
 
-	mat2.copy(mat).setBaseColorFactor([1, 1, 1, 0]);
-	t.is(mat.equals(mat2), false, '.baseColorFactor ≠ .baseColorFactor');
+		mat2.copy(mat).setBaseColorFactor([1, 1, 1, 0]);
+		strictEqual(mat.equals(mat2), false, '.baseColorFactor ≠ .baseColorFactor');
 
-	mat2.copy(mat).setBaseColorTexture(tex.clone());
-	t.is(mat.equals(mat2), true, '.baseColorTexture ≅ .baseColorTexture');
+		mat2.copy(mat).setBaseColorTexture(tex.clone());
+		strictEqual(mat.equals(mat2), true, '.baseColorTexture ≅ .baseColorTexture');
 
-	mat2.copy(mat).setBaseColorTexture(tex.clone().setURI('other.png'));
-	t.is(mat.equals(mat2), false, '.baseColorTexture ≠ .baseColorTexture');
+		mat2.copy(mat).setBaseColorTexture(tex.clone().setURI('other.png'));
+		strictEqual(mat.equals(mat2), false, '.baseColorTexture ≠ .baseColorTexture');
 
-	mat2.copy(mat).setBaseColorTexture(null);
-	t.is(mat.equals(mat2), false, '.baseColorTexture ≠ null');
+		mat2.copy(mat).setBaseColorTexture(null);
+		strictEqual(mat.equals(mat2), false, '.baseColorTexture ≠ null');
 
-	mat2.copy(mat).getBaseColorTextureInfo().setTexCoord(0);
-	t.is(mat.equals(mat2), false, '.baseColorTextureInfo ≠ .baseColorTextureInfo');
-});
+		mat2.copy(mat).getBaseColorTextureInfo().setTexCoord(0);
+		strictEqual(mat.equals(mat2), false, '.baseColorTextureInfo ≠ .baseColorTextureInfo');
+	});
 
-test('i/o', async (t) => {
-	const document = new Document();
-	document.createBuffer();
+	test('i/o', async () => {
+		const document = new Document();
+		document.createBuffer();
 
-	const createTexture = (name: string) =>
-		document.createTexture(name).setImage(new Uint8Array(10)).setMimeType('image/png');
+		const createTexture = (name: string) =>
+			document.createTexture(name).setImage(new Uint8Array(10)).setMimeType('image/png');
 
-	const baseColor = createTexture('baseColor');
-	const emissive = createTexture('emissive');
-	const normal = createTexture('normal');
-	const metalRough = createTexture('metalRough');
-	const occlusion = createTexture('occlusion');
+		const baseColor = createTexture('baseColor');
+		const emissive = createTexture('emissive');
+		const normal = createTexture('normal');
+		const metalRough = createTexture('metalRough');
+		const occlusion = createTexture('occlusion');
 
-	document
-		.createMaterial('mat')
-		.setBaseColorTexture(baseColor)
-		.setEmissiveTexture(emissive)
-		.setNormalTexture(normal)
-		.setNormalScale(0.85)
-		.setMetallicRoughnessTexture(metalRough)
-		.setOcclusionTexture(occlusion)
-		.setOcclusionStrength(0.4);
+		document
+			.createMaterial('mat')
+			.setBaseColorTexture(baseColor)
+			.setEmissiveTexture(emissive)
+			.setNormalTexture(normal)
+			.setNormalScale(0.85)
+			.setMetallicRoughnessTexture(metalRough)
+			.setOcclusionTexture(occlusion)
+			.setOcclusionStrength(0.4);
 
-	const io = await createPlatformIO();
-	const rtDocument = await io.readJSON(await io.writeJSON(document, { format: Format.GLB }));
-	const rtMat = rtDocument.getRoot().listMaterials()[0];
+		const io = await createPlatformIO();
+		const rtDocument = await io.readJSON(await io.writeJSON(document, { format: Format.GLB }));
+		const rtMat = rtDocument.getRoot().listMaterials()[0];
 
-	t.truthy(rtMat.getBaseColorTexture(), 'baseColorTexture');
-	t.truthy(rtMat.getEmissiveTexture(), 'emissiveTexture');
-	t.truthy(rtMat.getNormalTexture(), 'normalTexture');
-	t.is(rtMat.getNormalScale(), 0.85, 'normalTexture.scale');
-	t.truthy(rtMat.getMetallicRoughnessTexture(), 'metallicRoughnessTexture');
-	t.truthy(rtMat.getOcclusionTexture(), 'occlusionTexture');
-	t.is(rtMat.getOcclusionStrength(), 0.4, 'occlusionTexture.strength');
+		ok(rtMat.getBaseColorTexture(), 'baseColorTexture');
+		ok(rtMat.getEmissiveTexture(), 'emissiveTexture');
+		ok(rtMat.getNormalTexture(), 'normalTexture');
+		strictEqual(rtMat.getNormalScale(), 0.85, 'normalTexture.scale');
+		ok(rtMat.getMetallicRoughnessTexture(), 'metallicRoughnessTexture');
+		ok(rtMat.getOcclusionTexture(), 'occlusionTexture');
+		strictEqual(rtMat.getOcclusionStrength(), 0.4, 'occlusionTexture.strength');
+	});
 });

--- a/packages/core/test/properties/material.test.ts
+++ b/packages/core/test/properties/material.test.ts
@@ -13,7 +13,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const { R, G, B, A } = TextureChannel;
 
-describe('Material', () => {
+describe('core::Material', () => {
 	test('properties', () => {
 		const document = new Document();
 

--- a/packages/core/test/properties/mesh.test.ts
+++ b/packages/core/test/properties/mesh.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, Document, type GLTF, Primitive, type Property, VertexLayout } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Mesh', () => {
+describe('core::Mesh', () => {
 	test('basic', () => {
 		const document = new Document();
 		const mesh = document.createMesh('mesh');

--- a/packages/core/test/properties/mesh.test.ts
+++ b/packages/core/test/properties/mesh.test.ts
@@ -1,299 +1,302 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, type GLTF, Primitive, type Property, VertexLayout } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', (t) => {
-	const document = new Document();
-	const mesh = document.createMesh('mesh');
-	const prim = document.createPrimitive();
+describe('Mesh', () => {
+	test('basic', () => {
+		const document = new Document();
+		const mesh = document.createMesh('mesh');
+		const prim = document.createPrimitive();
 
-	mesh.addPrimitive(prim);
-	t.deepEqual(mesh.listPrimitives(), [prim], 'adds primitive');
+		mesh.addPrimitive(prim);
+		deepEqual(mesh.listPrimitives(), [prim], 'adds primitive');
 
-	mesh.removePrimitive(prim);
-	t.deepEqual(mesh.listPrimitives(), [], 'removes primitive');
-});
-
-test('primitive', (t) => {
-	const document = new Document();
-	const prim = document.createPrimitive();
-	const acc1 = document.createAccessor('acc1');
-	const acc2 = document.createAccessor('acc2');
-	const acc3 = document.createAccessor('acc3');
-
-	const toType = (p: Property): string => p.propertyType;
-
-	prim.setAttribute('POSITION', acc1);
-	t.is(prim.getAttribute('POSITION'), acc1, 'sets POSITION');
-	t.deepEqual(acc1.listParents().map(toType), ['Root', 'Primitive'], 'links POSITION');
-
-	prim.setAttribute('NORMAL', acc2);
-	t.is(prim.getAttribute('NORMAL'), acc2, 'sets NORMAL');
-	t.deepEqual(acc1.listParents().map(toType), ['Root', 'Primitive'], 'links NORMAL');
-	t.deepEqual(acc2.listParents().map(toType), ['Root', 'Primitive'], 'links NORMAL');
-
-	prim.setAttribute('POSITION', acc3);
-	t.is(prim.getAttribute('POSITION'), acc3, 'overwrites POSITION');
-	t.deepEqual(acc1.listParents().map(toType), ['Root'], 'unlinks old POSITION');
-	t.deepEqual(acc3.listParents().map(toType), ['Root', 'Primitive'], 'links new POSITION');
-
-	prim.setAttribute('POSITION', null);
-	t.is(prim.getAttribute('POSITION'), null, 'deletes POSITION');
-	t.deepEqual(acc3.listParents().map(toType), ['Root'], 'unlinks old POSITION');
-});
-
-test('primitive targets', async (t) => {
-	const document = new Document();
-	const mesh = document.createMesh('mesh');
-	const prim = document.createPrimitive();
-	const trg1 = document.createPrimitiveTarget('trg1');
-	const trg2 = document.createPrimitiveTarget('trg2');
-	const trg3 = document.createPrimitiveTarget('trg3');
-	const acc1 = document.createAccessor('acc1');
-	const acc2 = document.createAccessor('acc2');
-	const acc3 = document.createAccessor('acc3');
-	const buf = document.createBuffer('buf');
-
-	trg1.setAttribute('POSITION', acc1.setArray(new Float32Array([0, 0, 0])).setBuffer(buf));
-	trg2.setAttribute('POSITION', acc2.setArray(new Float32Array([0, 0, 0])).setBuffer(buf));
-	trg3.setAttribute('POSITION', acc3.setArray(new Float32Array([0, 0, 0])).setBuffer(buf));
-
-	prim.addTarget(trg1).addTarget(trg2).addTarget(trg3);
-
-	mesh.addPrimitive(prim);
-
-	const toType = (p: Property): string => p.propertyType;
-
-	t.deepEqual(acc1.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'links target attributes');
-	t.deepEqual(acc2.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'links target attributes');
-	t.deepEqual(acc3.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'links target attributes');
-
-	t.deepEqual(prim.listTargets(), [trg1, trg2, trg3], 'links targets');
-	t.deepEqual(trg1.listParents().map(toType), ['Primitive'], 'links targets');
-
-	const io = await createPlatformIO();
-	const options = { basename: 'targetTest' };
-	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, options)), options);
-	const meshDef = jsonDoc.json.meshes[0];
-
-	t.deepEqual(meshDef.extras.targetNames, ['trg1', 'trg2', 'trg3'], 'writes target names');
-	t.deepEqual(
-		meshDef.primitives[0].targets,
-		[{ POSITION: 0 }, { POSITION: 1 }, { POSITION: 2 }],
-		'writes target accessors',
-	);
-});
-
-test('copy', (t) => {
-	const document = new Document();
-	const mesh = document.createMesh('mesh').setWeights([1, 2, 3]).addPrimitive(document.createPrimitive());
-	const mesh2 = document.createMesh().copy(mesh);
-
-	t.deepEqual(mesh2.getWeights(), mesh.getWeights(), 'copy weights');
-	t.deepEqual(mesh2.listPrimitives(), mesh.listPrimitives(), 'copy primitives');
-});
-
-test('copy primitive', (t) => {
-	const document = new Document();
-	const prim = document
-		.createPrimitive()
-		.setAttribute('POSITION', document.createAccessor())
-		.setIndices(document.createAccessor())
-		.setMode(3)
-		.setMaterial(document.createMaterial())
-		.addTarget(document.createPrimitiveTarget())
-		.addTarget(document.createPrimitiveTarget());
-	const prim2 = document.createPrimitive().copy(prim);
-
-	t.is(prim2.getAttribute('POSITION'), prim2.getAttribute('POSITION'), 'copy attributes');
-	t.is(prim2.getIndices(), prim.getIndices(), 'copy indices');
-	t.is(prim2.getMode(), prim.getMode(), 'copy mode');
-	t.is(prim2.getMaterial(), prim.getMaterial(), 'copy material');
-	t.deepEqual(prim2.listTargets(), prim.listTargets(), 'copy targets');
-});
-
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const doc = new Document();
-	doc.createMesh('A')
-		.setExtras({ foo: 1, bar: 2 })
-		.addPrimitive(doc.createPrimitive().setExtras({ baz: 3 }));
-
-	const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
-
-	t.deepEqual(doc.getRoot().listMeshes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores mesh extras');
-	t.deepEqual(doc2.getRoot().listMeshes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips mesh extras');
-
-	const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
-	const prim2 = doc2.getRoot().listMeshes()[0].listPrimitives()[0];
-	t.deepEqual(prim.getExtras(), { baz: 3 }, 'stores prim extras');
-	t.deepEqual(prim2.getExtras(), { baz: 3 }, 'roundtrips prim extras');
-});
-
-test('empty i/o', async (t) => {
-	// Technically meshes must have primitives for the file to be valid, but we'll test that
-	// reading/writing works anyway.
-
-	const document = new Document();
-	document.createMesh('EmptyMesh').setWeights([1, 0, 0, 0]);
-
-	const io = await createPlatformIO();
-	let rtDocument = await io.readJSON(await io.writeJSON(document, {}));
-	let rtMesh = rtDocument.getRoot().listMeshes()[0];
-
-	t.deepEqual(rtMesh.listPrimitives(), [], 'primitives');
-	t.deepEqual(rtMesh.getName(), 'EmptyMesh', 'name');
-	t.deepEqual(rtMesh.getWeights(), [1, 0, 0, 0], 'weights');
-
-	rtDocument = await io.readJSON({
-		json: {
-			asset: { version: '2.0' },
-			meshes: [
-				{
-					name: 'EmptyMesh.2',
-					weights: [0, 0, 1, 0],
-				} as unknown as GLTF.IMesh,
-			],
-		},
-		resources: {},
+		mesh.removePrimitive(prim);
+		deepEqual(mesh.listPrimitives(), [], 'removes primitive');
 	});
-	rtMesh = rtDocument.getRoot().listMeshes()[0];
 
-	t.deepEqual(rtMesh.listPrimitives(), [], 'primitives');
-	t.deepEqual(rtMesh.getName(), 'EmptyMesh.2', 'name');
-	t.deepEqual(rtMesh.getWeights(), [0, 0, 1, 0], 'weights');
-});
+	test('primitive', () => {
+		const document = new Document();
+		const prim = document.createPrimitive();
+		const acc1 = document.createAccessor('acc1');
+		const acc2 = document.createAccessor('acc2');
+		const acc3 = document.createAccessor('acc3');
 
-test('primitive i/o', async (t) => {
-	const document = new Document();
-	const prim = document.createPrimitive();
-	const buffer = document.createBuffer();
+		const toType = (p: Property): string => p.propertyType;
 
-	prim.setMode(Primitive.Mode.POINTS)
-		.setAttribute(
-			'POSITION',
-			document
-				.createAccessor()
-				.setArray(new Float32Array([0, 0, 0]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_0',
-			document
-				.createAccessor()
-				.setArray(new Uint8Array([128, 128, 128]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_1',
-			document
-				.createAccessor()
-				.setArray(new Uint16Array([64, 64, 64]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_2',
-			document
-				.createAccessor()
-				.setArray(new Uint32Array([32, 32, 32]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_3',
-			document
-				.createAccessor()
-				.setArray(new Int16Array([16, 16, 16]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_4',
-			document
-				.createAccessor()
-				.setArray(new Int8Array([8, 8, 8]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
+		prim.setAttribute('POSITION', acc1);
+		strictEqual(prim.getAttribute('POSITION'), acc1, 'sets POSITION');
+		deepEqual(acc1.listParents().map(toType), ['Root', 'Primitive'], 'links POSITION');
+
+		prim.setAttribute('NORMAL', acc2);
+		strictEqual(prim.getAttribute('NORMAL'), acc2, 'sets NORMAL');
+		deepEqual(acc1.listParents().map(toType), ['Root', 'Primitive'], 'links NORMAL');
+		deepEqual(acc2.listParents().map(toType), ['Root', 'Primitive'], 'links NORMAL');
+
+		prim.setAttribute('POSITION', acc3);
+		strictEqual(prim.getAttribute('POSITION'), acc3, 'overwrites POSITION');
+		deepEqual(acc1.listParents().map(toType), ['Root'], 'unlinks old POSITION');
+		deepEqual(acc3.listParents().map(toType), ['Root', 'Primitive'], 'links new POSITION');
+
+		prim.setAttribute('POSITION', null);
+		strictEqual(prim.getAttribute('POSITION'), null, 'deletes POSITION');
+		deepEqual(acc3.listParents().map(toType), ['Root'], 'unlinks old POSITION');
+	});
+
+	test('primitive targets', async () => {
+		const document = new Document();
+		const mesh = document.createMesh('mesh');
+		const prim = document.createPrimitive();
+		const trg1 = document.createPrimitiveTarget('trg1');
+		const trg2 = document.createPrimitiveTarget('trg2');
+		const trg3 = document.createPrimitiveTarget('trg3');
+		const acc1 = document.createAccessor('acc1');
+		const acc2 = document.createAccessor('acc2');
+		const acc3 = document.createAccessor('acc3');
+		const buf = document.createBuffer('buf');
+
+		trg1.setAttribute('POSITION', acc1.setArray(new Float32Array([0, 0, 0])).setBuffer(buf));
+		trg2.setAttribute('POSITION', acc2.setArray(new Float32Array([0, 0, 0])).setBuffer(buf));
+		trg3.setAttribute('POSITION', acc3.setArray(new Float32Array([0, 0, 0])).setBuffer(buf));
+
+		prim.addTarget(trg1).addTarget(trg2).addTarget(trg3);
+
+		mesh.addPrimitive(prim);
+
+		const toType = (p: Property): string => p.propertyType;
+
+		deepEqual(acc1.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'links target attributes');
+		deepEqual(acc2.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'links target attributes');
+		deepEqual(acc3.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'links target attributes');
+
+		deepEqual(prim.listTargets(), [trg1, trg2, trg3], 'links targets');
+		deepEqual(trg1.listParents().map(toType), ['Primitive'], 'links targets');
+
+		const io = await createPlatformIO();
+		const options = { basename: 'targetTest' };
+		const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, options)), options);
+		const meshDef = jsonDoc.json.meshes[0];
+
+		deepEqual(meshDef.extras.targetNames, ['trg1', 'trg2', 'trg3'], 'writes target names');
+		deepEqual(
+			meshDef.primitives[0].targets,
+			[{ POSITION: 0 }, { POSITION: 1 }, { POSITION: 2 }],
+			'writes target accessors',
+		);
+	});
+
+	test('copy', () => {
+		const document = new Document();
+		const mesh = document.createMesh('mesh').setWeights([1, 2, 3]).addPrimitive(document.createPrimitive());
+		const mesh2 = document.createMesh().copy(mesh);
+
+		deepEqual(mesh2.getWeights(), mesh.getWeights(), 'copy weights');
+		deepEqual(mesh2.listPrimitives(), mesh.listPrimitives(), 'copy primitives');
+	});
+
+	test('copy primitive', () => {
+		const document = new Document();
+		const prim = document
+			.createPrimitive()
+			.setAttribute('POSITION', document.createAccessor())
+			.setIndices(document.createAccessor())
+			.setMode(3)
+			.setMaterial(document.createMaterial())
+			.addTarget(document.createPrimitiveTarget())
+			.addTarget(document.createPrimitiveTarget());
+		const prim2 = document.createPrimitive().copy(prim);
+
+		strictEqual(prim2.getAttribute('POSITION'), prim2.getAttribute('POSITION'), 'copy attributes');
+		strictEqual(prim2.getIndices(), prim.getIndices(), 'copy indices');
+		strictEqual(prim2.getMode(), prim.getMode(), 'copy mode');
+		strictEqual(prim2.getMaterial(), prim.getMaterial(), 'copy material');
+		deepEqual(prim2.listTargets(), prim.listTargets(), 'copy targets');
+	});
+
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const doc = new Document();
+		doc.createMesh('A')
+			.setExtras({ foo: 1, bar: 2 })
+			.addPrimitive(doc.createPrimitive().setExtras({ baz: 3 }));
+
+		const doc2 = await io.readJSON(await io.writeJSON(doc, { basename: 'test' }));
+
+		deepEqual(doc.getRoot().listMeshes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores mesh extras');
+		deepEqual(doc2.getRoot().listMeshes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips mesh extras');
+
+		const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+		const prim2 = doc2.getRoot().listMeshes()[0].listPrimitives()[0];
+		deepEqual(prim.getExtras(), { baz: 3 }, 'stores prim extras');
+		deepEqual(prim2.getExtras(), { baz: 3 }, 'roundtrips prim extras');
+	});
+
+	test('empty i/o', async () => {
+		// Technically meshes must have primitives for the file to be valid, but we'll test that
+		// reading/writing works anyway.
+
+		const document = new Document();
+		document.createMesh('EmptyMesh').setWeights([1, 0, 0, 0]);
+
+		const io = await createPlatformIO();
+		let rtDocument = await io.readJSON(await io.writeJSON(document, {}));
+		let rtMesh = rtDocument.getRoot().listMeshes()[0];
+
+		deepEqual(rtMesh.listPrimitives(), [], 'primitives');
+		deepEqual(rtMesh.getName(), 'EmptyMesh', 'name');
+		deepEqual(rtMesh.getWeights(), [1, 0, 0, 0], 'weights');
+
+		rtDocument = await io.readJSON({
+			json: {
+				asset: { version: '2.0' },
+				meshes: [
+					{
+						name: 'EmptyMesh.2',
+						weights: [0, 0, 1, 0],
+					} as unknown as GLTF.IMesh,
+				],
+			},
+			resources: {},
+		});
+		rtMesh = rtDocument.getRoot().listMeshes()[0];
+
+		deepEqual(rtMesh.listPrimitives(), [], 'primitives');
+		deepEqual(rtMesh.getName(), 'EmptyMesh.2', 'name');
+		deepEqual(rtMesh.getWeights(), [0, 0, 1, 0], 'weights');
+	});
+
+	test('primitive i/o', async () => {
+		const document = new Document();
+		const prim = document.createPrimitive();
+		const buffer = document.createBuffer();
+
+		prim.setMode(Primitive.Mode.POINTS)
+			.setAttribute(
+				'POSITION',
+				document
+					.createAccessor()
+					.setArray(new Float32Array([0, 0, 0]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_0',
+				document
+					.createAccessor()
+					.setArray(new Uint8Array([128, 128, 128]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_1',
+				document
+					.createAccessor()
+					.setArray(new Uint16Array([64, 64, 64]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_2',
+				document
+					.createAccessor()
+					.setArray(new Uint32Array([32, 32, 32]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_3',
+				document
+					.createAccessor()
+					.setArray(new Int16Array([16, 16, 16]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_4',
+				document
+					.createAccessor()
+					.setArray(new Int8Array([8, 8, 8]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			);
+
+		document.createMesh().addPrimitive(prim);
+
+		const io = await createPlatformIO();
+		const rtDocument = await io.readBinary(await io.writeBinary(document));
+		const rtPrim = rtDocument.getRoot().listMeshes()[0].listPrimitives()[0];
+
+		deepEqual(rtPrim.getAttribute('POSITION').getArray(), new Float32Array([0, 0, 0]), 'float32');
+		deepEqual(rtPrim.getAttribute('COLOR_0').getArray(), new Uint8Array([128, 128, 128]), 'uint8');
+		deepEqual(rtPrim.getAttribute('COLOR_1').getArray(), new Uint16Array([64, 64, 64]), 'uint16');
+		deepEqual(rtPrim.getAttribute('COLOR_2').getArray(), new Uint32Array([32, 32, 32]), 'uint32');
+		deepEqual(rtPrim.getAttribute('COLOR_3').getArray(), new Int16Array([16, 16, 16]), 'int8');
+		deepEqual(rtPrim.getAttribute('COLOR_4').getArray(), new Int8Array([8, 8, 8]), 'int8');
+	});
+
+	test('primitive vertex layout', async () => {
+		const document = new Document();
+		const prim = document.createPrimitive();
+		const buffer = document.createBuffer();
+
+		prim.setMode(Primitive.Mode.POINTS)
+			.setAttribute(
+				'POSITION',
+				document
+					.createAccessor()
+					.setArray(new Float32Array([0, 0, 0]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_0',
+				document
+					.createAccessor()
+					.setArray(new Uint8Array([128, 128, 128]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_1',
+				document
+					.createAccessor()
+					.setArray(new Uint16Array([64, 64, 64]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			)
+			.setAttribute(
+				'COLOR_2',
+				document
+					.createAccessor()
+					.setArray(new Uint32Array([32, 32, 32]))
+					.setType(Accessor.Type.VEC3)
+					.setBuffer(buffer),
+			);
+
+		document.createMesh().addPrimitive(prim);
+
+		const io = await createPlatformIO();
+
+		io.setVertexLayout(VertexLayout.INTERLEAVED);
+		const interleavedJSON = await io.binaryToJSON(await io.writeBinary(document));
+		deepEqual(
+			interleavedJSON.json.bufferViews,
+			[{ buffer: 0, target: 34962, byteOffset: 0, byteLength: 36, byteStride: 36 }],
+			'interleaved buffer byte length',
 		);
 
-	document.createMesh().addPrimitive(prim);
-
-	const io = await createPlatformIO();
-	const rtDocument = await io.readBinary(await io.writeBinary(document));
-	const rtPrim = rtDocument.getRoot().listMeshes()[0].listPrimitives()[0];
-
-	t.deepEqual(rtPrim.getAttribute('POSITION').getArray(), new Float32Array([0, 0, 0]), 'float32');
-	t.deepEqual(rtPrim.getAttribute('COLOR_0').getArray(), new Uint8Array([128, 128, 128]), 'uint8');
-	t.deepEqual(rtPrim.getAttribute('COLOR_1').getArray(), new Uint16Array([64, 64, 64]), 'uint16');
-	t.deepEqual(rtPrim.getAttribute('COLOR_2').getArray(), new Uint32Array([32, 32, 32]), 'uint32');
-	t.deepEqual(rtPrim.getAttribute('COLOR_3').getArray(), new Int16Array([16, 16, 16]), 'int8');
-	t.deepEqual(rtPrim.getAttribute('COLOR_4').getArray(), new Int8Array([8, 8, 8]), 'int8');
-});
-
-test('primitive vertex layout', async (t) => {
-	const document = new Document();
-	const prim = document.createPrimitive();
-	const buffer = document.createBuffer();
-
-	prim.setMode(Primitive.Mode.POINTS)
-		.setAttribute(
-			'POSITION',
-			document
-				.createAccessor()
-				.setArray(new Float32Array([0, 0, 0]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_0',
-			document
-				.createAccessor()
-				.setArray(new Uint8Array([128, 128, 128]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_1',
-			document
-				.createAccessor()
-				.setArray(new Uint16Array([64, 64, 64]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
-		)
-		.setAttribute(
-			'COLOR_2',
-			document
-				.createAccessor()
-				.setArray(new Uint32Array([32, 32, 32]))
-				.setType(Accessor.Type.VEC3)
-				.setBuffer(buffer),
+		io.setVertexLayout(VertexLayout.SEPARATE);
+		const separateJSON = await io.binaryToJSON(await io.writeBinary(document));
+		deepEqual(
+			separateJSON.json.bufferViews,
+			[
+				{ buffer: 0, target: 34962, byteOffset: 0, byteLength: 12, byteStride: 12 },
+				{ buffer: 0, target: 34962, byteOffset: 12, byteLength: 4, byteStride: 4 },
+				{ buffer: 0, target: 34962, byteOffset: 16, byteLength: 8, byteStride: 8 },
+				{ buffer: 0, target: 34962, byteOffset: 24, byteLength: 12, byteStride: 12 },
+			],
+			'separate buffer byte length',
 		);
-
-	document.createMesh().addPrimitive(prim);
-
-	const io = await createPlatformIO();
-
-	io.setVertexLayout(VertexLayout.INTERLEAVED);
-	const interleavedJSON = await io.binaryToJSON(await io.writeBinary(document));
-	t.deepEqual(
-		interleavedJSON.json.bufferViews,
-		[{ buffer: 0, target: 34962, byteOffset: 0, byteLength: 36, byteStride: 36 }],
-		'interleaved buffer byte length',
-	);
-
-	io.setVertexLayout(VertexLayout.SEPARATE);
-	const separateJSON = await io.binaryToJSON(await io.writeBinary(document));
-	t.deepEqual(
-		separateJSON.json.bufferViews,
-		[
-			{ buffer: 0, target: 34962, byteOffset: 0, byteLength: 12, byteStride: 12 },
-			{ buffer: 0, target: 34962, byteOffset: 12, byteLength: 4, byteStride: 4 },
-			{ buffer: 0, target: 34962, byteOffset: 16, byteLength: 8, byteStride: 8 },
-			{ buffer: 0, target: 34962, byteOffset: 24, byteLength: 12, byteStride: 12 },
-		],
-		'separate buffer byte length',
-	);
+	});
 });

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -4,7 +4,7 @@ import { Document, MathUtils, type mat4, type vec3, type vec4 } from '@gltf-tran
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Node', () => {
+describe('core::Node', () => {
 	test('parent', () => {
 		const document = new Document();
 		const a = document.createNode('A');

--- a/packages/core/test/properties/node.test.ts
+++ b/packages/core/test/properties/node.test.ts
@@ -1,163 +1,166 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, MathUtils, type mat4, type vec3, type vec4 } from '@gltf-transform/core';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('parent', (t) => {
-	const document = new Document();
-	const a = document.createNode('A');
-	const b = document.createNode('B');
-	const c = document.createNode('C');
+describe('Node', () => {
+	test('parent', () => {
+		const document = new Document();
+		const a = document.createNode('A');
+		const b = document.createNode('B');
+		const c = document.createNode('C');
 
-	// 1. adding node as child of node must de-parent from <=1 node [and N scenes, tested in scene.test.ts]
-	// 2. adding node as child of scene must de-parent from <=1 node [also tested in scene.test.ts]
+		// 1. adding node as child of node must de-parent from <=1 node [and N scenes, tested in scene.test.ts]
+		// 2. adding node as child of scene must de-parent from <=1 node [also tested in scene.test.ts]
 
-	a.addChild(c);
-	b.addChild(c);
+		a.addChild(c);
+		b.addChild(c);
 
-	t.deepEqual(a.listChildren(), [], 'removes child from 1st parent');
-	t.deepEqual(b.listChildren(), [c], 'adds child to 2nd parent');
-});
+		deepEqual(a.listChildren(), [], 'removes child from 1st parent');
+		deepEqual(b.listChildren(), [c], 'adds child to 2nd parent');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const node = document
-		.createNode('MyNode')
-		.setTranslation([1, 2, 3])
-		.setRotation([1, 0, 1, 0])
-		.setScale([2, 2, 2])
-		.setWeights([1.5, 1.5])
-		.setCamera(document.createCamera())
-		.setMesh(document.createMesh())
-		.setSkin(document.createSkin())
-		.addChild(document.createNode('OtherNode'));
+	test('copy', () => {
+		const document = new Document();
+		const node = document
+			.createNode('MyNode')
+			.setTranslation([1, 2, 3])
+			.setRotation([1, 0, 1, 0])
+			.setScale([2, 2, 2])
+			.setWeights([1.5, 1.5])
+			.setCamera(document.createCamera())
+			.setMesh(document.createMesh())
+			.setSkin(document.createSkin())
+			.addChild(document.createNode('OtherNode'));
 
-	// See {@link Node.copy}.
-	t.throws(() => document.createNode().copy(node), { message: /Node cannot be copied/i }, 'cannot copy node');
-});
+		// See {@link Node.copy}.
+		throws(() => document.createNode().copy(node), { message: /Node cannot be copied/i }, 'cannot copy node');
+	});
 
-test('traverse', (t) => {
-	const document = new Document();
-	const disposed = document.createNode('Four');
-	const node = document
-		.createNode('One')
-		.addChild(document.createNode('Two').addChild(document.createNode('Three').addChild(disposed)));
-	disposed.dispose();
+	test('traverse', () => {
+		const document = new Document();
+		const disposed = document.createNode('Four');
+		const node = document
+			.createNode('One')
+			.addChild(document.createNode('Two').addChild(document.createNode('Three').addChild(disposed)));
+		disposed.dispose();
 
-	let count = 0;
-	node.traverse((_) => count++);
-	t.is(count, 3, 'traverses all nodes');
-});
+		let count = 0;
+		node.traverse((_) => count++);
+		strictEqual(count, 3, 'traverses all nodes');
+	});
 
-test('getWorldMatrix', (t) => {
-	const document = new Document();
-	const a = document.createNode('A').setTranslation([10, 0, 0]);
-	const b = document.createNode('B').setTranslation([0, 5, 0]);
-	a.addChild(b);
+	test('getWorldMatrix', () => {
+		const document = new Document();
+		const a = document.createNode('A').setTranslation([10, 0, 0]);
+		const b = document.createNode('B').setTranslation([0, 5, 0]);
+		a.addChild(b);
 
-	t.deepEqual(b.getWorldTranslation(), [10, 5, 0], 'inherit translated position');
-	t.deepEqual(b.getWorldRotation(), [0, 0, 0, 1], 'default rotation');
-	t.deepEqual(b.getWorldScale(), [1, 1, 1], 'default scale');
-	t.deepEqual(b.getWorldMatrix(), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 5, 0, 1], 'getWorldMatrix');
+		deepEqual(b.getWorldTranslation(), [10, 5, 0], 'inherit translated position');
+		deepEqual(b.getWorldRotation(), [0, 0, 0, 1], 'default rotation');
+		deepEqual(b.getWorldScale(), [1, 1, 1], 'default scale');
+		deepEqual(b.getWorldMatrix(), [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 5, 0, 1], 'getWorldMatrix');
 
-	b.setTranslation([0, 0, 1]);
-	a.setTranslation([0, 0, 0]).setRotation([0.7071, 0, 0.7071, 0]);
+		b.setTranslation([0, 0, 1]);
+		a.setTranslation([0, 0, 0]).setRotation([0.7071, 0, 0.7071, 0]);
 
-	const pos = b.getWorldTranslation();
-	t.deepEqual(pos[0].toFixed(3), '1.000', 'inherit rotated position.x');
-	t.deepEqual(pos[1].toFixed(3), '0.000', 'inherit rotated position.y');
-	t.deepEqual(pos[2].toFixed(3), '0.000', 'inherit rotated position.z');
-});
+		const pos = b.getWorldTranslation();
+		deepEqual(pos[0].toFixed(3), '1.000', 'inherit rotated position.x');
+		deepEqual(pos[1].toFixed(3), '0.000', 'inherit rotated position.y');
+		deepEqual(pos[2].toFixed(3), '0.000', 'inherit rotated position.z');
+	});
 
-test('setMatrix', (t) => {
-	const document = new Document();
-	const node = document.createNode('A').setTranslation([99, 99, 99]);
+	test('setMatrix', () => {
+		const document = new Document();
+		const node = document.createNode('A').setTranslation([99, 99, 99]);
 
-	const pos = [1, 2, 3] as vec3;
-	const rot = [0, 0, 0, 1] as vec4;
-	const scl = [10, 10, 10] as vec3;
-	const mat = MathUtils.compose(pos, rot, scl, [] as unknown as mat4);
+		const pos = [1, 2, 3] as vec3;
+		const rot = [0, 0, 0, 1] as vec4;
+		const scl = [10, 10, 10] as vec3;
+		const mat = MathUtils.compose(pos, rot, scl, [] as unknown as mat4);
 
-	node.setMatrix(mat);
+		node.setMatrix(mat);
 
-	const posOut = node.getTranslation().map((v) => v.toFixed(1));
-	const rotOut = node.getRotation().map((v) => v.toFixed(1));
-	const sclOut = node.getScale().map((v) => v.toFixed(1));
+		const posOut = node.getTranslation().map((v) => v.toFixed(1));
+		const rotOut = node.getRotation().map((v) => v.toFixed(1));
+		const sclOut = node.getScale().map((v) => v.toFixed(1));
 
-	t.deepEqual(posOut, ['1.0', '2.0', '3.0'], 'translation');
-	t.deepEqual(rotOut, ['0.0', '0.0', '0.0', '1.0'], 'rotation');
-	t.deepEqual(sclOut, ['10.0', '10.0', '10.0'], 'scale');
-});
+		deepEqual(posOut, ['1.0', '2.0', '3.0'], 'translation');
+		deepEqual(rotOut, ['0.0', '0.0', '0.0', '1.0'], 'rotation');
+		deepEqual(sclOut, ['10.0', '10.0', '10.0'], 'scale');
+	});
 
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document.createNode('A').setExtras({ foo: 1, bar: 2 });
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document.createNode('A').setExtras({ foo: 1, bar: 2 });
 
-	const doc2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
+		const doc2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
 
-	t.deepEqual(document.getRoot().listNodes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
-	t.deepEqual(doc2.getRoot().listNodes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
-});
+		deepEqual(document.getRoot().listNodes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
+		deepEqual(doc2.getRoot().listNodes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+	});
 
-test('identity transforms', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
+	test('identity transforms', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
 
-	document.createNode('A');
-	document.createNode('B').setTranslation([1, 2, 1]);
-	document.createNode('C').setTranslation([1, 2, 1]).setRotation([1, 0, 0, 0]).setScale([1, 2, 1]);
+		document.createNode('A');
+		document.createNode('B').setTranslation([1, 2, 1]);
+		document.createNode('C').setTranslation([1, 2, 1]).setRotation([1, 0, 0, 0]).setScale([1, 2, 1]);
 
-	const { nodes } = (await io.writeJSON(document, { basename: 'test' })).json;
+		const { nodes } = (await io.writeJSON(document, { basename: 'test' })).json;
 
-	const a = nodes.find((n) => n.name === 'A');
-	const b = nodes.find((n) => n.name === 'B');
-	const c = nodes.find((n) => n.name === 'C');
+		const a = nodes.find((n) => n.name === 'A');
+		const b = nodes.find((n) => n.name === 'B');
+		const c = nodes.find((n) => n.name === 'C');
 
-	t.deepEqual(
-		a,
-		{
-			name: 'A',
-		},
-		'exclude identity transforms',
-	);
+		deepEqual(
+			a,
+			{
+				name: 'A',
+			},
+			'exclude identity transforms',
+		);
 
-	t.deepEqual(
-		b,
-		{
-			name: 'B',
-			translation: [1, 2, 1],
-		},
-		'has only set transform info',
-	);
+		deepEqual(
+			b,
+			{
+				name: 'B',
+				translation: [1, 2, 1],
+			},
+			'has only set transform info',
+		);
 
-	t.deepEqual(
-		c,
-		{
-			name: 'C',
-			translation: [1, 2, 1],
-			rotation: [1, 0, 0, 0],
-			scale: [1, 2, 1],
-		},
-		'has transform info',
-	);
-});
+		deepEqual(
+			c,
+			{
+				name: 'C',
+				translation: [1, 2, 1],
+				rotation: [1, 0, 0, 0],
+				scale: [1, 2, 1],
+			},
+			'has transform info',
+		);
+	});
 
-test('getParentNode', (t) => {
-	const srcDocument = new Document();
-	const srcNodeA = srcDocument.createNode('A');
-	const srcNodeB = srcDocument.createNode('B');
-	const srcNodeC = srcDocument.createNode('C');
-	srcNodeA.addChild(srcNodeB).addChild(srcNodeC);
+	test('getParentNode', () => {
+		const srcDocument = new Document();
+		const srcNodeA = srcDocument.createNode('A');
+		const srcNodeB = srcDocument.createNode('B');
+		const srcNodeC = srcDocument.createNode('C');
+		srcNodeA.addChild(srcNodeB).addChild(srcNodeC);
 
-	t.deepEqual(srcNodeA.listChildren(), [srcNodeB, srcNodeC], 'a.listChildren()');
-	t.is(srcNodeB.getParentNode(), srcNodeA, 'b.getParentNode()');
-	t.is(srcNodeC.getParentNode(), srcNodeA, 'c.getParentNode()');
+		deepEqual(srcNodeA.listChildren(), [srcNodeB, srcNodeC], 'a.listChildren()');
+		strictEqual(srcNodeB.getParentNode(), srcNodeA, 'b.getParentNode()');
+		strictEqual(srcNodeC.getParentNode(), srcNodeA, 'c.getParentNode()');
 
-	const dstDocument = cloneDocument(srcDocument);
-	const [dstNodeA, dstNodeB, dstNodeC] = dstDocument.getRoot().listNodes();
+		const dstDocument = cloneDocument(srcDocument);
+		const [dstNodeA, dstNodeB, dstNodeC] = dstDocument.getRoot().listNodes();
 
-	t.deepEqual(dstNodeA.listChildren(), [dstNodeB, dstNodeC], 'a.listChildren()');
-	t.is(dstNodeB.getParentNode(), dstNodeA, 'b.getParentNode()');
-	t.is(dstNodeC.getParentNode(), dstNodeA, 'c.getParentNode()');
+		deepEqual(dstNodeA.listChildren(), [dstNodeB, dstNodeC], 'a.listChildren()');
+		strictEqual(dstNodeB.getParentNode(), dstNodeA, 'b.getParentNode()');
+		strictEqual(dstNodeC.getParentNode(), dstNodeA, 'c.getParentNode()');
+	});
 });

--- a/packages/core/test/properties/primitive-target.test.ts
+++ b/packages/core/test/properties/primitive-target.test.ts
@@ -4,7 +4,7 @@ import { Document, type Property } from '@gltf-transform/core';
 
 const toType = (p: Property): string => p.propertyType;
 
-describe('PrimitiveTarget', () => {
+describe('core::PrimitiveTarget', () => {
 	test('basic', () => {
 		const doc = new Document();
 		const prim1 = doc.createPrimitiveTarget();

--- a/packages/core/test/properties/primitive-target.test.ts
+++ b/packages/core/test/properties/primitive-target.test.ts
@@ -1,20 +1,23 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type Property } from '@gltf-transform/core';
-import test from 'ava';
 
 const toType = (p: Property): string => p.propertyType;
 
-test('basic', (t) => {
-	const doc = new Document();
-	const prim1 = doc.createPrimitiveTarget();
-	const acc1 = doc.createAccessor('acc1');
-	prim1.setAttribute('POSITION', acc1);
-	const prim2 = prim1.clone();
+describe('PrimitiveTarget', () => {
+	test('basic', () => {
+		const doc = new Document();
+		const prim1 = doc.createPrimitiveTarget();
+		const acc1 = doc.createAccessor('acc1');
+		prim1.setAttribute('POSITION', acc1);
+		const prim2 = prim1.clone();
 
-	t.is(prim1.getAttribute('POSITION'), acc1, 'sets POSITION');
-	t.is(prim2.getAttribute('POSITION'), acc1, 'sets POSITION');
-	t.deepEqual(acc1.listParents().map(toType), ['Root', 'PrimitiveTarget', 'PrimitiveTarget'], 'links POSITION');
+		strictEqual(prim1.getAttribute('POSITION'), acc1, 'sets POSITION');
+		strictEqual(prim2.getAttribute('POSITION'), acc1, 'sets POSITION');
+		deepEqual(acc1.listParents().map(toType), ['Root', 'PrimitiveTarget', 'PrimitiveTarget'], 'links POSITION');
 
-	prim1.setAttribute('POSITION', null);
-	t.is(prim1.getAttribute('POSITION'), null, 'unsets POSITION');
-	t.deepEqual(acc1.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'unlinks POSITION');
+		prim1.setAttribute('POSITION', null);
+		strictEqual(prim1.getAttribute('POSITION'), null, 'unsets POSITION');
+		deepEqual(acc1.listParents().map(toType), ['Root', 'PrimitiveTarget'], 'unlinks POSITION');
+	});
 });

--- a/packages/core/test/properties/property.test.ts
+++ b/packages/core/test/properties/property.test.ts
@@ -1,65 +1,68 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type vec3 } from '@gltf-transform/core';
-import test from 'ava';
 
-test('equals', async (t) => {
-	const document = new Document();
-	const nodeA = document.createNode();
-	const nodeB = document.createNode();
+describe('Property', () => {
+	test('equals', async () => {
+		const document = new Document();
+		const nodeA = document.createNode();
+		const nodeB = document.createNode();
 
-	t.truthy(nodeA.equals(nodeB), 'empty extras');
+		ok(nodeA.equals(nodeB), 'empty extras');
 
-	nodeA.setExtras({ a: 1 });
-	nodeB.setExtras({ a: 1 });
+		nodeA.setExtras({ a: 1 });
+		nodeB.setExtras({ a: 1 });
 
-	t.truthy(nodeA.equals(nodeB), 'same extras');
+		ok(nodeA.equals(nodeB), 'same extras');
 
-	nodeB.setExtras({ a: 1, b: 2 });
+		nodeB.setExtras({ a: 1, b: 2 });
 
-	t.falsy(nodeA.equals(nodeB), 'different extras');
-});
+		strictEqual(nodeA.equals(nodeB), false, 'different extras');
+	});
 
-test('internal arrays', async (t) => {
-	const document = new Document();
-	const translation = [0, 0, 0] as vec3;
-	const node = document.createNode('A').setTranslation(translation);
+	test('internal arrays', async () => {
+		const document = new Document();
+		const translation = [0, 0, 0] as vec3;
+		const node = document.createNode('A').setTranslation(translation);
 
-	t.deepEqual(node.getTranslation(), [0, 0, 0], 'stores original value');
+		deepEqual(node.getTranslation(), [0, 0, 0], 'stores original value');
 
-	// Array literals (vector, quaternion, color, …) must be stored as copies.
-	translation[1] = 0.5;
+		// Array literals (vector, quaternion, color, …) must be stored as copies.
+		translation[1] = 0.5;
 
-	t.deepEqual(node.getTranslation(), [0, 0, 0], 'unchanged by external mutation');
-});
+		deepEqual(node.getTranslation(), [0, 0, 0], 'unchanged by external mutation');
+	});
 
-test('listParents', async (t) => {
-	const document = new Document();
-	const root = document.getRoot();
-	const nodeA = document.createNode('NodeA');
-	const nodeB = document.createNode('NodeB');
-	const sceneA = document.createScene('SceneA').addChild(nodeA).addChild(nodeB);
-	const sceneB = document.createScene('SceneB').addChild(nodeA).addChild(nodeB);
-	root.setDefaultScene(sceneA);
+	test('listParents', async () => {
+		const document = new Document();
+		const root = document.getRoot();
+		const nodeA = document.createNode('NodeA');
+		const nodeB = document.createNode('NodeB');
+		const sceneA = document.createScene('SceneA').addChild(nodeA).addChild(nodeB);
+		const sceneB = document.createScene('SceneB').addChild(nodeA).addChild(nodeB);
+		root.setDefaultScene(sceneA);
 
-	t.deepEqual(root.listParents(), []);
-	t.deepEqual(sceneA.listParents(), [root]);
-	t.deepEqual(nodeA.listParents(), [root, sceneA, sceneB]);
-	t.deepEqual(nodeB.listParents(), [root, sceneA, sceneB]);
-});
+		deepEqual(root.listParents(), []);
+		deepEqual(sceneA.listParents(), [root]);
+		deepEqual(nodeA.listParents(), [root, sceneA, sceneB]);
+		deepEqual(nodeB.listParents(), [root, sceneA, sceneB]);
+	});
 
-test('listChildren', async (t) => {
-	const document = new Document();
-	const root = document.getRoot();
-	const nodeA = document.createNode('NodeA');
-	const nodeB = document.createNode('NodeB');
-	const sceneA = document.createScene('SceneA').addChild(nodeA).addChild(nodeB);
-	const sceneB = document.createScene('SceneB').addChild(nodeA).addChild(nodeB);
-	root.setDefaultScene(sceneA);
+	test('listChildren', async () => {
+		const document = new Document();
+		const root = document.getRoot();
+		const nodeA = document.createNode('NodeA');
+		const nodeB = document.createNode('NodeB');
+		const sceneA = document.createScene('SceneA').addChild(nodeA).addChild(nodeB);
+		const sceneB = document.createScene('SceneB').addChild(nodeA).addChild(nodeB);
+		root.setDefaultScene(sceneA);
 
-	const graph = document.getGraph();
+		const graph = document.getGraph();
 
-	t.deepEqual(graph.listChildren(root), [nodeA, nodeB, sceneA, sceneB]);
-	t.deepEqual(graph.listChildren(sceneA), [nodeA, nodeB]);
-	t.deepEqual(graph.listChildren(sceneB), [nodeA, nodeB]);
-	t.deepEqual(graph.listChildren(nodeA), []);
-	t.deepEqual(graph.listChildren(nodeB), []);
+		deepEqual(graph.listChildren(root), [nodeA, nodeB, sceneA, sceneB]);
+		deepEqual(graph.listChildren(sceneA), [nodeA, nodeB]);
+		deepEqual(graph.listChildren(sceneB), [nodeA, nodeB]);
+		deepEqual(graph.listChildren(nodeA), []);
+		deepEqual(graph.listChildren(nodeB), []);
+	});
 });

--- a/packages/core/test/properties/property.test.ts
+++ b/packages/core/test/properties/property.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, ok, strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { Document, type vec3 } from '@gltf-transform/core';
 
-describe('Property', () => {
+describe('core::Property', () => {
 	test('equals', async () => {
 		const document = new Document();
 		const nodeA = document.createNode();

--- a/packages/core/test/properties/root.test.ts
+++ b/packages/core/test/properties/root.test.ts
@@ -1,118 +1,121 @@
+import { deepEqual, ok, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type JSONDocument } from '@gltf-transform/core';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', (t) => {
-	const document = new Document();
-	const accessor = document.createAccessor();
-	const animation = document.createAnimation();
-	const buffer = document.createBuffer();
-	const camera = document.createCamera();
-	const material = document.createMaterial();
-	const mesh = document.createMesh();
-	const node = document.createNode();
-	const scene = document.createScene();
-	const skin = document.createSkin();
-	const texture = document.createTexture();
+describe('Root', () => {
+	test('basic', () => {
+		const document = new Document();
+		const accessor = document.createAccessor();
+		const animation = document.createAnimation();
+		const buffer = document.createBuffer();
+		const camera = document.createCamera();
+		const material = document.createMaterial();
+		const mesh = document.createMesh();
+		const node = document.createNode();
+		const scene = document.createScene();
+		const skin = document.createSkin();
+		const texture = document.createTexture();
 
-	t.deepEqual(document.getRoot().listAccessors(), [accessor], 'listAccessors()');
-	t.deepEqual(document.getRoot().listAnimations(), [animation], 'listAnimations()');
-	t.deepEqual(document.getRoot().listBuffers(), [buffer], 'listBuffers()');
-	t.deepEqual(document.getRoot().listCameras(), [camera], 'listCameras()');
-	t.deepEqual(document.getRoot().listMaterials(), [material], 'listMaterials()');
-	t.deepEqual(document.getRoot().listMeshes(), [mesh], 'listMeshes()');
-	t.deepEqual(document.getRoot().listNodes(), [node], 'listNodes()');
-	t.deepEqual(document.getRoot().listScenes(), [scene], 'listScenes()');
-	t.deepEqual(document.getRoot().listSkins(), [skin], 'listSkins()');
-	t.deepEqual(document.getRoot().listTextures(), [texture], 'listTextures()');
+		deepEqual(document.getRoot().listAccessors(), [accessor], 'listAccessors()');
+		deepEqual(document.getRoot().listAnimations(), [animation], 'listAnimations()');
+		deepEqual(document.getRoot().listBuffers(), [buffer], 'listBuffers()');
+		deepEqual(document.getRoot().listCameras(), [camera], 'listCameras()');
+		deepEqual(document.getRoot().listMaterials(), [material], 'listMaterials()');
+		deepEqual(document.getRoot().listMeshes(), [mesh], 'listMeshes()');
+		deepEqual(document.getRoot().listNodes(), [node], 'listNodes()');
+		deepEqual(document.getRoot().listScenes(), [scene], 'listScenes()');
+		deepEqual(document.getRoot().listSkins(), [skin], 'listSkins()');
+		deepEqual(document.getRoot().listTextures(), [texture], 'listTextures()');
 
-	const root2 = cloneDocument(document).getRoot();
-	t.deepEqual(root2.listAccessors().length, 1, 'listAccessors()');
-	t.deepEqual(root2.listAnimations().length, 1, 'listAnimations()');
-	t.deepEqual(root2.listBuffers().length, 1, 'listBuffers()');
-	t.deepEqual(root2.listCameras().length, 1, 'listCameras()');
-	t.deepEqual(root2.listMaterials().length, 1, 'listMaterials()');
-	t.deepEqual(root2.listMeshes().length, 1, 'listMeshes()');
-	t.deepEqual(root2.listNodes().length, 1, 'listNodes()');
-	t.deepEqual(root2.listScenes().length, 1, 'listScenes()');
-	t.deepEqual(root2.listSkins().length, 1, 'listSkins()');
-	t.deepEqual(root2.listTextures().length, 1, 'listTextures()');
+		const root2 = cloneDocument(document).getRoot();
+		deepEqual(root2.listAccessors().length, 1, 'listAccessors()');
+		deepEqual(root2.listAnimations().length, 1, 'listAnimations()');
+		deepEqual(root2.listBuffers().length, 1, 'listBuffers()');
+		deepEqual(root2.listCameras().length, 1, 'listCameras()');
+		deepEqual(root2.listMaterials().length, 1, 'listMaterials()');
+		deepEqual(root2.listMeshes().length, 1, 'listMeshes()');
+		deepEqual(root2.listNodes().length, 1, 'listNodes()');
+		deepEqual(root2.listScenes().length, 1, 'listScenes()');
+		deepEqual(root2.listSkins().length, 1, 'listSkins()');
+		deepEqual(root2.listTextures().length, 1, 'listTextures()');
 
-	t.throws(() => root2.clone(), undefined, 'no cloning');
-	t.throws(() => root2.copy(document.getRoot()), undefined, 'no direct copy');
-});
+		throws(() => root2.clone(), undefined, 'no cloning');
+		throws(() => root2.copy(document.getRoot()), undefined, 'no direct copy');
+	});
 
-test('default scene', async (t) => {
-	const document = new Document();
-	const root = document.getRoot();
-	const sceneA = document.createScene('A');
-	const sceneB = document.createScene('B');
-	const io = await createPlatformIO();
+	test('default scene', async () => {
+		const document = new Document();
+		const root = document.getRoot();
+		const sceneA = document.createScene('A');
+		const sceneB = document.createScene('B');
+		const io = await createPlatformIO();
 
-	t.is(root.getDefaultScene(), null, 'default scene initially null');
+		strictEqual(root.getDefaultScene(), null, 'default scene initially null');
 
-	root.setDefaultScene(sceneA);
-	t.is(root.getDefaultScene(), sceneA, 'default scene = A');
+		root.setDefaultScene(sceneA);
+		strictEqual(root.getDefaultScene(), sceneA, 'default scene = A');
 
-	sceneA.dispose();
-	t.is(root.getDefaultScene(), null, 'default scene disposed');
+		sceneA.dispose();
+		strictEqual(root.getDefaultScene(), null, 'default scene disposed');
 
-	root.setDefaultScene(sceneB);
-	t.is(root.getDefaultScene(), sceneB, 'default scene = B');
+		root.setDefaultScene(sceneB);
+		strictEqual(root.getDefaultScene(), sceneB, 'default scene = B');
 
-	t.is(cloneDocument(document).getRoot().getDefaultScene().getName(), 'B', 'clone / copy persistence');
+		strictEqual(cloneDocument(document).getRoot().getDefaultScene().getName(), 'B', 'clone / copy persistence');
 
-	t.is(
-		(await io.readJSON(await io.writeJSON(document, {}))).getRoot().getDefaultScene().getName(),
-		'B',
-		'read / write persistence',
-	);
-});
+		strictEqual(
+			(await io.readJSON(await io.writeJSON(document, {}))).getRoot().getDefaultScene().getName(),
+			'B',
+			'read / write persistence',
+		);
+	});
 
-test('clone child of root', (t) => {
-	const document = new Document();
-	const a = document.createAccessor();
-	const b = a.clone();
-	const c = b.clone();
+	test('clone child of root', () => {
+		const document = new Document();
+		const a = document.createAccessor();
+		const b = a.clone();
+		const c = b.clone();
 
-	t.deepEqual(document.getRoot().listAccessors(), [a, b, c], 'clones are attached to Root');
-});
+		deepEqual(document.getRoot().listAccessors(), [a, b, c], 'clones are attached to Root');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
 
-	const jsonDocNoExtras = await io.writeJSON(document);
-	document.getRoot().setExtras({ custom: 'value' });
-	const jsonDocExtras = await io.writeJSON(document);
+		const jsonDocNoExtras = await io.writeJSON(document);
+		document.getRoot().setExtras({ custom: 'value' });
+		const jsonDocExtras = await io.writeJSON(document);
 
-	const rtDocNoExtras = await io.readJSON(jsonDocNoExtras);
-	const rtDocExtras = await io.readJSON(jsonDocExtras);
+		const rtDocNoExtras = await io.readJSON(jsonDocNoExtras);
+		const rtDocExtras = await io.readJSON(jsonDocExtras);
 
-	t.is(jsonDocNoExtras.json.extras, undefined, 'no empty extras');
-	t.deepEqual(jsonDocExtras.json.extras, { custom: 'value' }, 'write extras');
-	t.deepEqual(rtDocNoExtras.getRoot().getExtras(), {}, 'round trip no extras');
-	t.deepEqual(rtDocExtras.getRoot().getExtras(), { custom: 'value' }, 'round trip extras');
-});
+		strictEqual(jsonDocNoExtras.json.extras, undefined, 'no empty extras');
+		deepEqual(jsonDocExtras.json.extras, { custom: 'value' }, 'write extras');
+		deepEqual(rtDocNoExtras.getRoot().getExtras(), {}, 'round trip no extras');
+		deepEqual(rtDocExtras.getRoot().getExtras(), { custom: 'value' }, 'round trip extras');
+	});
 
-test('asset', async (t) => {
-	const document = new Document();
-	const root = document.getRoot();
-	const io = await createPlatformIO();
+	test('asset', async () => {
+		const document = new Document();
+		const root = document.getRoot();
+		const io = await createPlatformIO();
 
-	let jsonDoc: JSONDocument;
-	let generator: string;
+		let jsonDoc: JSONDocument;
+		let generator: string;
 
-	jsonDoc = await io.writeJSON(document);
-	generator = jsonDoc.json.asset.generator;
-	t.true(/^glTF-Transform.*/i.test(generator), 'write default generator');
+		jsonDoc = await io.writeJSON(document);
+		generator = jsonDoc.json.asset.generator;
+		ok(/^glTF-Transform.*/i.test(generator), 'write default generator');
 
-	root.getAsset().generator = 'Custom Tool v123';
-	jsonDoc = await io.writeJSON(document);
-	generator = jsonDoc.json.asset.generator;
-	t.true(/^Custom Tool.*/i.test(generator), 'write custom generator');
+		root.getAsset().generator = 'Custom Tool v123';
+		jsonDoc = await io.writeJSON(document);
+		generator = jsonDoc.json.asset.generator;
+		ok(/^Custom Tool.*/i.test(generator), 'write custom generator');
 
-	generator = (await io.readJSON(jsonDoc)).getRoot().getAsset().generator;
-	t.true(/^glTF-Transform.*/i.test(generator), 'read default generator');
+		generator = (await io.readJSON(jsonDoc)).getRoot().getAsset().generator;
+		ok(/^glTF-Transform.*/i.test(generator), 'read default generator');
+	});
 });

--- a/packages/core/test/properties/root.test.ts
+++ b/packages/core/test/properties/root.test.ts
@@ -4,7 +4,7 @@ import { Document, type JSONDocument } from '@gltf-transform/core';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Root', () => {
+describe('core::Root', () => {
 	test('basic', () => {
 		const document = new Document();
 		const accessor = document.createAccessor();

--- a/packages/core/test/properties/scene.test.ts
+++ b/packages/core/test/properties/scene.test.ts
@@ -1,67 +1,70 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type Property } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const toName = (p: Property) => p.getName();
 
-test('parent', (t) => {
-	const document = new Document();
-	const sceneA = document.createScene('SceneA');
-	const sceneB = document.createScene('SceneB');
-	const nodeA = document.createNode('NodeA');
-	const nodeB = document.createNode('NodeB');
+describe('Scene', () => {
+	test('parent', () => {
+		const document = new Document();
+		const sceneA = document.createScene('SceneA');
+		const sceneB = document.createScene('SceneB');
+		const nodeA = document.createNode('NodeA');
+		const nodeB = document.createNode('NodeB');
 
-	// 1. adding node as child of node must de-parent from N scenes [and <=1 node, tested in node.test.ts]
-	// 2. adding node as child of scene must de-parent from <=1 node [but not scenes]
+		// 1. adding node as child of node must de-parent from N scenes [and <=1 node, tested in node.test.ts]
+		// 2. adding node as child of scene must de-parent from <=1 node [but not scenes]
 
-	sceneA.addChild(nodeA);
-	sceneB.addChild(nodeA);
+		sceneA.addChild(nodeA);
+		sceneB.addChild(nodeA);
 
-	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneA');
-	t.deepEqual(sceneB.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneB');
+		deepEqual(sceneA.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneA');
+		deepEqual(sceneB.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneB');
 
-	nodeB.addChild(nodeA);
+		nodeB.addChild(nodeA);
 
-	t.deepEqual(sceneA.listChildren().map(toName), [], 'SceneA = ∅');
-	t.deepEqual(sceneB.listChildren().map(toName), [], 'SceneB = ∅');
-	t.deepEqual(nodeB.listChildren().map(toName), ['NodeA'], 'NodeA ∈ NodeB');
+		deepEqual(sceneA.listChildren().map(toName), [], 'SceneA = ∅');
+		deepEqual(sceneB.listChildren().map(toName), [], 'SceneB = ∅');
+		deepEqual(nodeB.listChildren().map(toName), ['NodeA'], 'NodeA ∈ NodeB');
 
-	sceneA.addChild(nodeA);
+		sceneA.addChild(nodeA);
 
-	t.deepEqual(sceneA.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneA');
-	t.deepEqual(sceneB.listChildren().map(toName), [], 'SceneB = ∅');
-	t.deepEqual(nodeB.listChildren().map(toName), [], 'NodeB = ∅');
-});
+		deepEqual(sceneA.listChildren().map(toName), ['NodeA'], 'NodeA ∈ SceneA');
+		deepEqual(sceneB.listChildren().map(toName), [], 'SceneB = ∅');
+		deepEqual(nodeB.listChildren().map(toName), [], 'NodeB = ∅');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const scene = document
-		.createScene('MyScene')
-		.addChild(document.createNode('Node1'))
-		.addChild(document.createNode('Node2'));
-	// See {@link Scene.copy}.
-	t.throws(() => document.createScene().copy(scene), { message: /Scene cannot be copied/i }, 'cannot copy scene');
-});
+	test('copy', () => {
+		const document = new Document();
+		const scene = document
+			.createScene('MyScene')
+			.addChild(document.createNode('Node1'))
+			.addChild(document.createNode('Node2'));
+		// See {@link Scene.copy}.
+		throws(() => document.createScene().copy(scene), { message: /Scene cannot be copied/i }, 'cannot copy scene');
+	});
 
-test('traverse', (t) => {
-	const document = new Document();
-	const scene = document
-		.createScene('MyScene')
-		.addChild(document.createNode('Node1'))
-		.addChild(document.createNode('Node2'));
+	test('traverse', () => {
+		const document = new Document();
+		const scene = document
+			.createScene('MyScene')
+			.addChild(document.createNode('Node1'))
+			.addChild(document.createNode('Node2'));
 
-	let count = 0;
-	scene.traverse((_) => count++);
-	t.is(count, 2, 'traverses all nodes');
-});
+		let count = 0;
+		scene.traverse((_) => count++);
+		strictEqual(count, 2, 'traverses all nodes');
+	});
 
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document.createScene('A').setExtras({ foo: 1, bar: 2 });
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document.createScene('A').setExtras({ foo: 1, bar: 2 });
 
-	const doc2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
+		const doc2 = await io.readJSON(await io.writeJSON(document, { basename: 'test' }));
 
-	t.deepEqual(document.getRoot().listScenes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
-	t.deepEqual(doc2.getRoot().listScenes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+		deepEqual(document.getRoot().listScenes()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
+		deepEqual(doc2.getRoot().listScenes()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+	});
 });

--- a/packages/core/test/properties/scene.test.ts
+++ b/packages/core/test/properties/scene.test.ts
@@ -5,7 +5,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const toName = (p: Property) => p.getName();
 
-describe('Scene', () => {
+describe('core::Scene', () => {
 	test('parent', () => {
 		const document = new Document();
 		const sceneA = document.createScene('SceneA');

--- a/packages/core/test/properties/skin.test.ts
+++ b/packages/core/test/properties/skin.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, AnimationChannel, Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Skin', () => {
+describe('core::Skin', () => {
 	test('basic', async () => {
 		const document = new Document();
 

--- a/packages/core/test/properties/skin.test.ts
+++ b/packages/core/test/properties/skin.test.ts
@@ -1,108 +1,115 @@
+import { deepEqual, notStrictEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, AnimationChannel, Document } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document();
+describe('Skin', () => {
+	test('basic', async () => {
+		const document = new Document();
 
-	const joints = [document.createNode('joint1'), document.createNode('joint2'), document.createNode('joint3')];
+		const joints = [document.createNode('joint1'), document.createNode('joint2'), document.createNode('joint3')];
 
-	document.createBuffer('skinBuffer').setURI('skinTest.bin');
+		document.createBuffer('skinBuffer').setURI('skinTest.bin');
 
-	const ibm = document
-		.createAccessor('ibm')
-		.setType(Accessor.Type.MAT4)
-		.setArray(
-			new Float32Array([
-				1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+		const ibm = document
+			.createAccessor('ibm')
+			.setType(Accessor.Type.MAT4)
+			.setArray(
+				new Float32Array([
+					1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
 
-				2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1,
+					2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1,
 
-				3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1,
-			]),
+					3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, 1,
+				]),
+			);
+
+		const skin = document
+			.createSkin('testSkin')
+			.addJoint(joints[0])
+			.addJoint(joints[1])
+			.addJoint(joints[2])
+			.setSkeleton(joints[0])
+			.setInverseBindMatrices(ibm);
+
+		document.createNode('armature').addChild(joints[0]).addChild(joints[1]).addChild(joints[2]).setSkin(skin);
+
+		const sampler = document
+			.createAnimationSampler()
+			.setInput(document.createAccessor().setArray(new Uint8Array([0, 1, 2])))
+			.setOutput(document.createAccessor().setArray(new Uint8Array([0, 0, 0, 1, 1, 1, 2, 2, 2])));
+		const channel = document
+			.createAnimationChannel()
+			.setSampler(sampler)
+			.setTargetNode(joints[0])
+			.setTargetPath(AnimationChannel.TargetPath.TRANSLATION);
+		document.createAnimation().addChannel(channel).addSampler(sampler);
+
+		const io = await createPlatformIO();
+		const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, {})));
+
+		deepEqual(
+			jsonDoc.json.nodes[3],
+			{
+				name: 'armature',
+				skin: 0,
+				children: [0, 1, 2],
+			},
+			'attaches skin to node',
 		);
 
-	const skin = document
-		.createSkin('testSkin')
-		.addJoint(joints[0])
-		.addJoint(joints[1])
-		.addJoint(joints[2])
-		.setSkeleton(joints[0])
-		.setInverseBindMatrices(ibm);
+		deepEqual(
+			jsonDoc.json.skins[0],
+			{
+				name: 'testSkin',
+				inverseBindMatrices: 0,
+				joints: [0, 1, 2],
+				skeleton: 0,
+			},
+			'defines skin',
+		);
 
-	document.createNode('armature').addChild(joints[0]).addChild(joints[1]).addChild(joints[2]).setSkin(skin);
+		const ibmAccessor = jsonDoc.json.accessors[jsonDoc.json.skins[0].inverseBindMatrices];
+		const inputAccessor = jsonDoc.json.accessors[jsonDoc.json.animations[0].samplers[0].input];
+		notStrictEqual(
+			ibmAccessor.bufferView,
+			inputAccessor.bufferView,
+			'stores IBMs and animation in different buffer views',
+		);
 
-	const sampler = document
-		.createAnimationSampler()
-		.setInput(document.createAccessor().setArray(new Uint8Array([0, 1, 2])))
-		.setOutput(document.createAccessor().setArray(new Uint8Array([0, 0, 0, 1, 1, 1, 2, 2, 2])));
-	const channel = document
-		.createAnimationChannel()
-		.setSampler(sampler)
-		.setTargetNode(joints[0])
-		.setTargetPath(AnimationChannel.TargetPath.TRANSLATION);
-	document.createAnimation().addChannel(channel).addSampler(sampler);
+		const actualIBM = new Float32Array(jsonDoc.resources['skinTest.bin'].slice(0, 192).buffer);
+		deepEqual(Array.from(actualIBM), Array.from(ibm.getArray()), 'stores skin IBMs');
+	});
 
-	const io = await createPlatformIO();
-	const jsonDoc = await io.writeJSON(await io.readJSON(await io.writeJSON(document, {})));
+	test('copy', () => {
+		const document = new Document();
+		const a = document
+			.createSkin('MySkin')
+			.addJoint(document.createNode())
+			.addJoint(document.createNode())
+			.setSkeleton(document.createNode())
+			.setInverseBindMatrices(document.createAccessor());
+		const b = document.createSkin().copy(a);
 
-	t.deepEqual(
-		jsonDoc.json.nodes[3],
-		{
-			name: 'armature',
-			skin: 0,
-			children: [0, 1, 2],
-		},
-		'attaches skin to node',
-	);
+		strictEqual(b.getName(), a.getName(), 'copy name');
+		deepEqual(b.listJoints(), a.listJoints(), 'copy joints');
+		strictEqual(b.getSkeleton(), a.getSkeleton(), 'copy skeleton');
+		strictEqual(b.getInverseBindMatrices(), a.getInverseBindMatrices(), 'copy inverseBindMatrices');
 
-	t.deepEqual(
-		jsonDoc.json.skins[0],
-		{
-			name: 'testSkin',
-			inverseBindMatrices: 0,
-			joints: [0, 1, 2],
-			skeleton: 0,
-		},
-		'defines skin',
-	);
+		a.copy(document.createSkin());
 
-	const ibmAccessor = jsonDoc.json.accessors[jsonDoc.json.skins[0].inverseBindMatrices];
-	const inputAccessor = jsonDoc.json.accessors[jsonDoc.json.animations[0].samplers[0].input];
-	t.not(ibmAccessor.bufferView, inputAccessor.bufferView, 'stores IBMs and animation in different buffer views');
+		strictEqual(a.getSkeleton(), null, 'unset skeleton');
+		strictEqual(a.getInverseBindMatrices(), null, 'unset inverseBindMatrices');
+	});
 
-	const actualIBM = new Float32Array(jsonDoc.resources['skinTest.bin'].slice(0, 192).buffer);
-	t.deepEqual(Array.from(actualIBM), Array.from(ibm.getArray()), 'stores skin IBMs');
-});
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document.createSkin('A').setExtras({ foo: 1, bar: 2 });
 
-test('copy', (t) => {
-	const document = new Document();
-	const a = document
-		.createSkin('MySkin')
-		.addJoint(document.createNode())
-		.addJoint(document.createNode())
-		.setSkeleton(document.createNode())
-		.setInverseBindMatrices(document.createAccessor());
-	const b = document.createSkin().copy(a);
+		const doc2 = await io.readJSON(await io.writeJSON(document));
 
-	t.is(b.getName(), a.getName(), 'copy name');
-	t.deepEqual(b.listJoints(), a.listJoints(), 'copy joints');
-	t.is(b.getSkeleton(), a.getSkeleton(), 'copy skeleton');
-	t.is(b.getInverseBindMatrices(), a.getInverseBindMatrices(), 'copy inverseBindMatrices');
-
-	a.copy(document.createSkin());
-
-	t.is(a.getSkeleton(), null, 'unset skeleton');
-	t.is(a.getInverseBindMatrices(), null, 'unset inverseBindMatrices');
-});
-
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document.createSkin('A').setExtras({ foo: 1, bar: 2 });
-
-	const doc2 = await io.readJSON(await io.writeJSON(document));
-
-	t.deepEqual(document.getRoot().listSkins()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
-	t.deepEqual(doc2.getRoot().listSkins()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+		deepEqual(document.getRoot().listSkins()[0].getExtras(), { foo: 1, bar: 2 }, 'stores extras');
+		deepEqual(doc2.getRoot().listSkins()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrips extras');
+	});
 });

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document, Format, type JSONDocument, TextureInfo } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
 
-describe('Texture', () => {
+describe('core::Texture', () => {
 	test('read', async () => {
 		const jsonDoc = {
 			json: {

--- a/packages/core/test/properties/texture.test.ts
+++ b/packages/core/test/properties/texture.test.ts
@@ -1,148 +1,151 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, Format, type JSONDocument, TextureInfo } from '@gltf-transform/core';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('read', async (t) => {
-	const jsonDoc = {
-		json: {
-			asset: { version: '2.0' },
-			textures: [{ source: 0, sampler: 0 }, { source: 1 }, { source: 0 }],
-			samplers: [{ wrapS: 33071 }],
-			images: [{ uri: 'tex1.png' }, { uri: 'tex2.jpeg' }],
-			materials: [
-				{ normalTexture: { index: 0 }, occlusionTexture: { index: 2 } },
-				{ normalTexture: { index: 1 } },
+describe('Texture', () => {
+	test('read', async () => {
+		const jsonDoc = {
+			json: {
+				asset: { version: '2.0' },
+				textures: [{ source: 0, sampler: 0 }, { source: 1 }, { source: 0 }],
+				samplers: [{ wrapS: 33071 }],
+				images: [{ uri: 'tex1.png' }, { uri: 'tex2.jpeg' }],
+				materials: [
+					{ normalTexture: { index: 0 }, occlusionTexture: { index: 2 } },
+					{ normalTexture: { index: 1 } },
+				],
+			},
+			resources: {
+				'tex1.png': new Uint8Array(1),
+				'tex2.jpeg': new Uint8Array(2),
+			},
+		};
+
+		const io = await createPlatformIO();
+		const document = await io.readJSON(jsonDoc as unknown as JSONDocument);
+		const root = document.getRoot();
+		const mat1 = root.listMaterials()[0];
+		const mat2 = root.listMaterials()[1];
+
+		strictEqual(root.listTextures().length, 2, 'reads two textures');
+		strictEqual(mat1.getNormalTexture().getURI(), 'tex1.png', 'assigns texture');
+		strictEqual(mat1.getOcclusionTexture().getURI(), 'tex1.png', 'reuses texture');
+		strictEqual(mat1.getNormalTextureInfo().getWrapS(), 33071, 'assigns sampler properties');
+		strictEqual(mat1.getOcclusionTextureInfo().getWrapS(), 10497, 'keeps default sampler properties');
+		strictEqual(mat2.getNormalTexture().getURI(), 'tex2.jpeg', 'assigns 2nd texture');
+		strictEqual(root.listTextures()[0].getMimeType(), 'image/png', 'assigns "image/png" MIME type');
+		strictEqual(root.listTextures()[1].getMimeType(), 'image/jpeg', 'assigns "image/jpeg" MIME type');
+	});
+
+	test('write', async () => {
+		const document = new Document();
+		document.createBuffer();
+		const image1 = new Uint8Array(1);
+		const image2 = new Uint8Array(2);
+		const image3 = new Uint8Array(3);
+		const texture1 = document.createTexture('tex1').setImage(image1).setURI('tex1.png');
+		const texture2 = document.createTexture('tex2').setImage(image2).setMimeType('image/jpeg');
+		const texture3 = document.createTexture('tex2').setImage(image3).setMimeType('image/jpeg'); // reused name
+		document
+			.createMaterial('mat1')
+			.setBaseColorTexture(texture1)
+			.setNormalTexture(texture2)
+			.setOcclusionTexture(texture3);
+		document
+			.createMaterial('mat2')
+			.setBaseColorTexture(texture1)
+			.getBaseColorTextureInfo()
+			.setWrapS(TextureInfo.WrapMode.CLAMP_TO_EDGE);
+
+		const io = await createPlatformIO();
+		const jsonDoc = await io.writeJSON(document, { basename: '' });
+
+		strictEqual('basename.bin' in jsonDoc.resources, false, 'external image resources');
+		ok('tex1.png' in jsonDoc.resources, 'writes tex1.png');
+		ok('normal_1.jpg' in jsonDoc.resources, 'writes default-named normal map');
+		ok('occlusion_1.jpg' in jsonDoc.resources, 'writes default-named occlusion map');
+		strictEqual(jsonDoc.json.images.length, 3, 'reuses images');
+		strictEqual(jsonDoc.json.textures.length, 4, 'writes textures');
+		strictEqual(jsonDoc.json.samplers.length, 2, 'reuses samplers');
+	});
+
+	test('copy', () => {
+		const document = new Document();
+		const tex = document
+			.createTexture('MyTexture')
+			.setImage(new Uint8Array(2))
+			.setMimeType('image/gif')
+			.setURI('path/to/image.gif');
+
+		const tex2 = document.createTexture().copy(tex);
+		strictEqual(tex2.getName(), 'MyTexture', 'copy name');
+		deepEqual(tex2.getImage(), tex.getImage(), 'copy image');
+		strictEqual(tex2.getMimeType(), 'image/gif', 'copy mimeType');
+		strictEqual(tex2.getURI(), 'path/to/image.gif', 'copy URI');
+	});
+
+	test('extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document.createBuffer();
+		document.createTexture('A').setExtras({ foo: 1, bar: 2 }).setImage(new Uint8Array(10)).setMimeType('image/png');
+
+		const doc2 = await io.readJSON(await io.writeJSON(document));
+
+		deepEqual(document.getRoot().listTextures()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
+		deepEqual(doc2.getRoot().listTextures()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');
+	});
+
+	test('textureInfo extras', async () => {
+		const io = await createPlatformIO();
+		const document = new Document();
+		document.createBuffer();
+		const texture = document
+			.createTexture('A')
+			.setExtras({ foo: 1, bar: 2 })
+			.setImage(new Uint8Array(10))
+			.setMimeType('image/png');
+		const material = document.createMaterial().setBaseColorTexture(texture);
+		material.getBaseColorTextureInfo()!.setExtras({ textureInfoID: 12345 });
+		const doc2 = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = doc2.getRoot().listMaterials()[0];
+
+		deepEqual(material.getBaseColorTextureInfo()!.getExtras(), { textureInfoID: 12345 }, 'storage');
+		deepEqual(rtMaterial.getBaseColorTextureInfo()!.getExtras(), { textureInfoID: 12345 }, 'roundtrip');
+	});
+
+	test('padding', async () => {
+		// Ensure that buffer views are padded to 8-byte boundaries. See:
+		// https://github.com/KhronosGroup/glTF/issues/1935
+
+		const document = new Document();
+		document.createBuffer();
+		document.createTexture().setImage(new Uint8Array(17)).setMimeType('image/png');
+		document.createTexture().setImage(new Uint8Array(21)).setMimeType('image/png');
+		document.createTexture().setImage(new Uint8Array(20)).setMimeType('image/png');
+
+		const io = await createPlatformIO();
+		const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
+
+		deepEqual(
+			jsonDoc.json.images,
+			[
+				{ bufferView: 0, mimeType: 'image/png' },
+				{ bufferView: 1, mimeType: 'image/png' },
+				{ bufferView: 2, mimeType: 'image/png' },
 			],
-		},
-		resources: {
-			'tex1.png': new Uint8Array(1),
-			'tex2.jpeg': new Uint8Array(2),
-		},
-	};
-
-	const io = await createPlatformIO();
-	const document = await io.readJSON(jsonDoc as unknown as JSONDocument);
-	const root = document.getRoot();
-	const mat1 = root.listMaterials()[0];
-	const mat2 = root.listMaterials()[1];
-
-	t.is(root.listTextures().length, 2, 'reads two textures');
-	t.is(mat1.getNormalTexture().getURI(), 'tex1.png', 'assigns texture');
-	t.is(mat1.getOcclusionTexture().getURI(), 'tex1.png', 'reuses texture');
-	t.is(mat1.getNormalTextureInfo().getWrapS(), 33071, 'assigns sampler properties');
-	t.is(mat1.getOcclusionTextureInfo().getWrapS(), 10497, 'keeps default sampler properties');
-	t.is(mat2.getNormalTexture().getURI(), 'tex2.jpeg', 'assigns 2nd texture');
-	t.is(root.listTextures()[0].getMimeType(), 'image/png', 'assigns "image/png" MIME type');
-	t.is(root.listTextures()[1].getMimeType(), 'image/jpeg', 'assigns "image/jpeg" MIME type');
-});
-
-test('write', async (t) => {
-	const document = new Document();
-	document.createBuffer();
-	const image1 = new Uint8Array(1);
-	const image2 = new Uint8Array(2);
-	const image3 = new Uint8Array(3);
-	const texture1 = document.createTexture('tex1').setImage(image1).setURI('tex1.png');
-	const texture2 = document.createTexture('tex2').setImage(image2).setMimeType('image/jpeg');
-	const texture3 = document.createTexture('tex2').setImage(image3).setMimeType('image/jpeg'); // reused name
-	document
-		.createMaterial('mat1')
-		.setBaseColorTexture(texture1)
-		.setNormalTexture(texture2)
-		.setOcclusionTexture(texture3);
-	document
-		.createMaterial('mat2')
-		.setBaseColorTexture(texture1)
-		.getBaseColorTextureInfo()
-		.setWrapS(TextureInfo.WrapMode.CLAMP_TO_EDGE);
-
-	const io = await createPlatformIO();
-	const jsonDoc = await io.writeJSON(document, { basename: '' });
-
-	t.false('basename.bin' in jsonDoc.resources, 'external image resources');
-	t.true('tex1.png' in jsonDoc.resources, 'writes tex1.png');
-	t.true('normal_1.jpg' in jsonDoc.resources, 'writes default-named normal map');
-	t.true('occlusion_1.jpg' in jsonDoc.resources, 'writes default-named occlusion map');
-	t.is(jsonDoc.json.images.length, 3, 'reuses images');
-	t.is(jsonDoc.json.textures.length, 4, 'writes textures');
-	t.is(jsonDoc.json.samplers.length, 2, 'reuses samplers');
-});
-
-test('copy', (t) => {
-	const document = new Document();
-	const tex = document
-		.createTexture('MyTexture')
-		.setImage(new Uint8Array(2))
-		.setMimeType('image/gif')
-		.setURI('path/to/image.gif');
-
-	const tex2 = document.createTexture().copy(tex);
-	t.is(tex2.getName(), 'MyTexture', 'copy name');
-	t.deepEqual(tex2.getImage(), tex.getImage(), 'copy image');
-	t.is(tex2.getMimeType(), 'image/gif', 'copy mimeType');
-	t.is(tex2.getURI(), 'path/to/image.gif', 'copy URI');
-});
-
-test('extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document.createBuffer();
-	document.createTexture('A').setExtras({ foo: 1, bar: 2 }).setImage(new Uint8Array(10)).setMimeType('image/png');
-
-	const doc2 = await io.readJSON(await io.writeJSON(document));
-
-	t.deepEqual(document.getRoot().listTextures()[0].getExtras(), { foo: 1, bar: 2 }, 'storage');
-	t.deepEqual(doc2.getRoot().listTextures()[0].getExtras(), { foo: 1, bar: 2 }, 'roundtrip');
-});
-
-test('textureInfo extras', async (t) => {
-	const io = await createPlatformIO();
-	const document = new Document();
-	document.createBuffer();
-	const texture = document
-		.createTexture('A')
-		.setExtras({ foo: 1, bar: 2 })
-		.setImage(new Uint8Array(10))
-		.setMimeType('image/png');
-	const material = document.createMaterial().setBaseColorTexture(texture);
-	material.getBaseColorTextureInfo()!.setExtras({ textureInfoID: 12345 });
-	const doc2 = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = doc2.getRoot().listMaterials()[0];
-
-	t.deepEqual(material.getBaseColorTextureInfo()!.getExtras(), { textureInfoID: 12345 }, 'storage');
-	t.deepEqual(rtMaterial.getBaseColorTextureInfo()!.getExtras(), { textureInfoID: 12345 }, 'roundtrip');
-});
-
-test('padding', async (t) => {
-	// Ensure that buffer views are padded to 8-byte boundaries. See:
-	// https://github.com/KhronosGroup/glTF/issues/1935
-
-	const document = new Document();
-	document.createBuffer();
-	document.createTexture().setImage(new Uint8Array(17)).setMimeType('image/png');
-	document.createTexture().setImage(new Uint8Array(21)).setMimeType('image/png');
-	document.createTexture().setImage(new Uint8Array(20)).setMimeType('image/png');
-
-	const io = await createPlatformIO();
-	const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
-
-	t.deepEqual(
-		jsonDoc.json.images,
-		[
-			{ bufferView: 0, mimeType: 'image/png' },
-			{ bufferView: 1, mimeType: 'image/png' },
-			{ bufferView: 2, mimeType: 'image/png' },
-		],
-		'images',
-	);
-	t.deepEqual(
-		jsonDoc.json.bufferViews,
-		[
-			{ buffer: 0, byteOffset: 0, byteLength: 17 },
-			{ buffer: 0, byteOffset: 24, byteLength: 21 },
-			{ buffer: 0, byteOffset: 48, byteLength: 20 },
-		],
-		'bufferViews',
-	);
-	t.deepEqual(jsonDoc.json.buffers, [{ byteLength: 72 }], 'buffers');
+			'images',
+		);
+		deepEqual(
+			jsonDoc.json.bufferViews,
+			[
+				{ buffer: 0, byteOffset: 0, byteLength: 17 },
+				{ buffer: 0, byteOffset: 24, byteLength: 21 },
+				{ buffer: 0, byteOffset: 48, byteLength: 20 },
+			],
+			'bufferViews',
+		);
+		deepEqual(jsonDoc.json.buffers, [{ byteLength: 72 }], 'buffers');
+	});
 });

--- a/packages/core/test/utils/buffer-utils.test.ts
+++ b/packages/core/test/utils/buffer-utils.test.ts
@@ -6,7 +6,7 @@ const IS_NODEJS = typeof window === 'undefined';
 
 const HELLO_WORLD = 'data:application/octet-stream;base64,aGVsbG8gd29ybGQ=';
 
-describe('BufferUtils', () => {
+describe('core::BufferUtils', () => {
 	test('web', () => {
 		if (IS_NODEJS) return;
 		strictEqual(

--- a/packages/core/test/utils/buffer-utils.test.ts
+++ b/packages/core/test/utils/buffer-utils.test.ts
@@ -1,30 +1,31 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { BufferUtils } from '@gltf-transform/core';
-import test from 'ava';
 
 const IS_NODEJS = typeof window === 'undefined';
 
 const HELLO_WORLD = 'data:application/octet-stream;base64,aGVsbG8gd29ybGQ=';
 
-test('web', (t) => {
-	if (IS_NODEJS) return t.pass();
-	t.is(
+test('web', () => {
+	if (IS_NODEJS) return;
+	strictEqual(
 		BufferUtils.decodeText(BufferUtils.createBufferFromDataURI(HELLO_WORLD)),
 		'hello world',
 		'createBufferFromDataURI',
 	);
-	t.is(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
+	strictEqual(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
 });
 
-test('node.js', (t) => {
-	if (!IS_NODEJS) return t.pass();
-	t.is(
+test('node.js', () => {
+	if (!IS_NODEJS) return;
+	strictEqual(
 		BufferUtils.decodeText(BufferUtils.createBufferFromDataURI(HELLO_WORLD)),
 		'hello world',
 		'createBufferFromDataURI',
 	);
-	t.is(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
+	strictEqual(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
 
 	const buffer = new Uint8Array([1, 2]);
-	t.is(BufferUtils.equals(buffer, buffer), true, 'equals strict');
-	t.is(BufferUtils.equals(buffer, new Uint8Array([1])), false, 'equals by length');
+	strictEqual(BufferUtils.equals(buffer, buffer), true, 'equals strict');
+	strictEqual(BufferUtils.equals(buffer, new Uint8Array([1])), false, 'equals by length');
 });

--- a/packages/core/test/utils/buffer-utils.test.ts
+++ b/packages/core/test/utils/buffer-utils.test.ts
@@ -1,31 +1,33 @@
 import { strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { BufferUtils } from '@gltf-transform/core';
 
 const IS_NODEJS = typeof window === 'undefined';
 
 const HELLO_WORLD = 'data:application/octet-stream;base64,aGVsbG8gd29ybGQ=';
 
-test('web', () => {
-	if (IS_NODEJS) return;
-	strictEqual(
-		BufferUtils.decodeText(BufferUtils.createBufferFromDataURI(HELLO_WORLD)),
-		'hello world',
-		'createBufferFromDataURI',
-	);
-	strictEqual(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
-});
+describe('BufferUtils', () => {
+	test('web', () => {
+		if (IS_NODEJS) return;
+		strictEqual(
+			BufferUtils.decodeText(BufferUtils.createBufferFromDataURI(HELLO_WORLD)),
+			'hello world',
+			'createBufferFromDataURI',
+		);
+		strictEqual(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
+	});
 
-test('node.js', () => {
-	if (!IS_NODEJS) return;
-	strictEqual(
-		BufferUtils.decodeText(BufferUtils.createBufferFromDataURI(HELLO_WORLD)),
-		'hello world',
-		'createBufferFromDataURI',
-	);
-	strictEqual(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
+	test('node.js', () => {
+		if (!IS_NODEJS) return;
+		strictEqual(
+			BufferUtils.decodeText(BufferUtils.createBufferFromDataURI(HELLO_WORLD)),
+			'hello world',
+			'createBufferFromDataURI',
+		);
+		strictEqual(BufferUtils.decodeText(BufferUtils.encodeText('hey')), 'hey', 'encode/decode');
 
-	const buffer = new Uint8Array([1, 2]);
-	strictEqual(BufferUtils.equals(buffer, buffer), true, 'equals strict');
-	strictEqual(BufferUtils.equals(buffer, new Uint8Array([1])), false, 'equals by length');
+		const buffer = new Uint8Array([1, 2]);
+		strictEqual(BufferUtils.equals(buffer, buffer), true, 'equals strict');
+		strictEqual(BufferUtils.equals(buffer, new Uint8Array([1])), false, 'equals by length');
+	});
 });

--- a/packages/core/test/utils/color-utils.test.ts
+++ b/packages/core/test/utils/color-utils.test.ts
@@ -2,7 +2,7 @@ import { deepEqual, strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { ColorUtils } from '@gltf-transform/core';
 
-describe('ColorUtils', () => {
+describe('core::ColorUtils', () => {
 	test('basic', () => {
 		deepEqual(ColorUtils.hexToFactor(0xff0000, []), [1, 0, 0], 'hexToFactor');
 		deepEqual(ColorUtils.factorToHex([1, 0, 0]), 16646144, 'factorToHex');

--- a/packages/core/test/utils/color-utils.test.ts
+++ b/packages/core/test/utils/color-utils.test.ts
@@ -1,18 +1,20 @@
 import { deepEqual, strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { ColorUtils } from '@gltf-transform/core';
 
-test('basic', () => {
-	deepEqual(ColorUtils.hexToFactor(0xff0000, []), [1, 0, 0], 'hexToFactor');
-	deepEqual(ColorUtils.factorToHex([1, 0, 0]), 16646144, 'factorToHex');
+describe('ColorUtils', () => {
+	test('basic', () => {
+		deepEqual(ColorUtils.hexToFactor(0xff0000, []), [1, 0, 0], 'hexToFactor');
+		deepEqual(ColorUtils.factorToHex([1, 0, 0]), 16646144, 'factorToHex');
 
-	const linear = ColorUtils.convertSRGBToLinear([0.5, 0.5, 0.5], []);
-	strictEqual(linear[0].toFixed(4), '0.2140', 'convertSRGBToLinear[0]');
-	strictEqual(linear[1].toFixed(4), '0.2140', 'convertSRGBToLinear[1]');
-	strictEqual(linear[2].toFixed(4), '0.2140', 'convertSRGBToLinear[2]');
+		const linear = ColorUtils.convertSRGBToLinear([0.5, 0.5, 0.5], []);
+		strictEqual(linear[0].toFixed(4), '0.2140', 'convertSRGBToLinear[0]');
+		strictEqual(linear[1].toFixed(4), '0.2140', 'convertSRGBToLinear[1]');
+		strictEqual(linear[2].toFixed(4), '0.2140', 'convertSRGBToLinear[2]');
 
-	const srgb = ColorUtils.convertLinearToSRGB([0.5, 0.5, 0.5], []);
-	strictEqual(srgb[0].toFixed(4), '0.7354', 'convertLinearToSRGB[0]');
-	strictEqual(srgb[1].toFixed(4), '0.7354', 'convertLinearToSRGB[1]');
-	strictEqual(srgb[2].toFixed(4), '0.7354', 'convertLinearToSRGB[2]');
+		const srgb = ColorUtils.convertLinearToSRGB([0.5, 0.5, 0.5], []);
+		strictEqual(srgb[0].toFixed(4), '0.7354', 'convertLinearToSRGB[0]');
+		strictEqual(srgb[1].toFixed(4), '0.7354', 'convertLinearToSRGB[1]');
+		strictEqual(srgb[2].toFixed(4), '0.7354', 'convertLinearToSRGB[2]');
+	});
 });

--- a/packages/core/test/utils/color-utils.test.ts
+++ b/packages/core/test/utils/color-utils.test.ts
@@ -1,17 +1,18 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { ColorUtils } from '@gltf-transform/core';
-import test from 'ava';
 
-test('basic', (t) => {
-	t.deepEqual(ColorUtils.hexToFactor(0xff0000, []), [1, 0, 0], 'hexToFactor');
-	t.deepEqual(ColorUtils.factorToHex([1, 0, 0]), 16646144, 'factorToHex');
+test('basic', () => {
+	deepEqual(ColorUtils.hexToFactor(0xff0000, []), [1, 0, 0], 'hexToFactor');
+	deepEqual(ColorUtils.factorToHex([1, 0, 0]), 16646144, 'factorToHex');
 
 	const linear = ColorUtils.convertSRGBToLinear([0.5, 0.5, 0.5], []);
-	t.is(linear[0].toFixed(4), '0.2140', 'convertSRGBToLinear[0]');
-	t.is(linear[1].toFixed(4), '0.2140', 'convertSRGBToLinear[1]');
-	t.is(linear[2].toFixed(4), '0.2140', 'convertSRGBToLinear[2]');
+	strictEqual(linear[0].toFixed(4), '0.2140', 'convertSRGBToLinear[0]');
+	strictEqual(linear[1].toFixed(4), '0.2140', 'convertSRGBToLinear[1]');
+	strictEqual(linear[2].toFixed(4), '0.2140', 'convertSRGBToLinear[2]');
 
 	const srgb = ColorUtils.convertLinearToSRGB([0.5, 0.5, 0.5], []);
-	t.is(srgb[0].toFixed(4), '0.7354', 'convertLinearToSRGB[0]');
-	t.is(srgb[1].toFixed(4), '0.7354', 'convertLinearToSRGB[1]');
-	t.is(srgb[2].toFixed(4), '0.7354', 'convertLinearToSRGB[2]');
+	strictEqual(srgb[0].toFixed(4), '0.7354', 'convertLinearToSRGB[0]');
+	strictEqual(srgb[1].toFixed(4), '0.7354', 'convertLinearToSRGB[1]');
+	strictEqual(srgb[2].toFixed(4), '0.7354', 'convertLinearToSRGB[2]');
 });

--- a/packages/core/test/utils/file-utils.test.ts
+++ b/packages/core/test/utils/file-utils.test.ts
@@ -1,14 +1,15 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { FileUtils } from '@gltf-transform/core';
-import test from 'ava';
 
-test('basename', (t) => {
-	t.is(FileUtils.basename('http://foo.com/path/to/index.html'), 'index', 'URI');
-	t.is(FileUtils.basename('http://foo.com/path/to/index.test.suffix.html'), 'index.test.suffix', 'URI');
+test('basename', () => {
+	strictEqual(FileUtils.basename('http://foo.com/path/to/index.html'), 'index', 'URI');
+	strictEqual(FileUtils.basename('http://foo.com/path/to/index.test.suffix.html'), 'index.test.suffix', 'URI');
 });
 
-test('extension', (t) => {
-	t.is(FileUtils.extension('http://foo.com/path/to/index.html'), 'html', 'URI');
-	t.is(FileUtils.extension('data:image/png;base64,iVBORw0K'), 'png', 'PNG data URI');
-	t.is(FileUtils.extension('data:image/jpeg;base64,iVBORw0K'), 'jpg', 'JPEG data URI');
-	t.is(FileUtils.extension('data:application/octet-stream;base64,iVBORw0K'), 'bin', 'binary data URI');
+test('extension', () => {
+	strictEqual(FileUtils.extension('http://foo.com/path/to/index.html'), 'html', 'URI');
+	strictEqual(FileUtils.extension('data:image/png;base64,iVBORw0K'), 'png', 'PNG data URI');
+	strictEqual(FileUtils.extension('data:image/jpeg;base64,iVBORw0K'), 'jpg', 'JPEG data URI');
+	strictEqual(FileUtils.extension('data:application/octet-stream;base64,iVBORw0K'), 'bin', 'binary data URI');
 });

--- a/packages/core/test/utils/file-utils.test.ts
+++ b/packages/core/test/utils/file-utils.test.ts
@@ -1,15 +1,17 @@
 import { strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { FileUtils } from '@gltf-transform/core';
 
-test('basename', () => {
-	strictEqual(FileUtils.basename('http://foo.com/path/to/index.html'), 'index', 'URI');
-	strictEqual(FileUtils.basename('http://foo.com/path/to/index.test.suffix.html'), 'index.test.suffix', 'URI');
-});
+describe('FileUtils', () => {
+	test('basename', () => {
+		strictEqual(FileUtils.basename('http://foo.com/path/to/index.html'), 'index', 'URI');
+		strictEqual(FileUtils.basename('http://foo.com/path/to/index.test.suffix.html'), 'index.test.suffix', 'URI');
+	});
 
-test('extension', () => {
-	strictEqual(FileUtils.extension('http://foo.com/path/to/index.html'), 'html', 'URI');
-	strictEqual(FileUtils.extension('data:image/png;base64,iVBORw0K'), 'png', 'PNG data URI');
-	strictEqual(FileUtils.extension('data:image/jpeg;base64,iVBORw0K'), 'jpg', 'JPEG data URI');
-	strictEqual(FileUtils.extension('data:application/octet-stream;base64,iVBORw0K'), 'bin', 'binary data URI');
+	test('extension', () => {
+		strictEqual(FileUtils.extension('http://foo.com/path/to/index.html'), 'html', 'URI');
+		strictEqual(FileUtils.extension('data:image/png;base64,iVBORw0K'), 'png', 'PNG data URI');
+		strictEqual(FileUtils.extension('data:image/jpeg;base64,iVBORw0K'), 'jpg', 'JPEG data URI');
+		strictEqual(FileUtils.extension('data:application/octet-stream;base64,iVBORw0K'), 'bin', 'binary data URI');
+	});
 });

--- a/packages/core/test/utils/file-utils.test.ts
+++ b/packages/core/test/utils/file-utils.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { FileUtils } from '@gltf-transform/core';
 
-describe('FileUtils', () => {
+describe('core::FileUtils', () => {
 	test('basename', () => {
 		strictEqual(FileUtils.basename('http://foo.com/path/to/index.html'), 'index', 'URI');
 		strictEqual(FileUtils.basename('http://foo.com/path/to/index.test.suffix.html'), 'index.test.suffix', 'URI');

--- a/packages/core/test/utils/image-utils.test.ts
+++ b/packages/core/test/utils/image-utils.test.ts
@@ -1,5 +1,6 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { test } from 'node:test';
 import { BufferUtils, ImageUtils } from '@gltf-transform/core';
-import test from 'ava';
 import fs from 'fs';
 import ndarray from 'ndarray';
 import { savePixels } from 'ndarray-pixels';
@@ -8,17 +9,17 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('basic', async (t) => {
+test('basic', async () => {
 	let pixels = ndarray(new Uint8Array(100 * 50 * 4), [100, 50, 4]);
 	let image = await savePixels(pixels, 'image/png');
-	t.deepEqual(ImageUtils.getSize(image, 'image/png'), [100, 50], 'gets PNG size');
+	deepEqual(ImageUtils.getSize(image, 'image/png'), [100, 50], 'gets PNG size');
 
 	pixels = ndarray(new Uint8Array(16 * 32 * 4), [16, 32, 4]);
 	image = await savePixels(pixels, 'image/jpeg');
-	t.deepEqual(ImageUtils.getSize(image, 'image/jpeg'), [16, 32], 'gets JPEG size');
+	deepEqual(ImageUtils.getSize(image, 'image/jpeg'), [16, 32], 'gets JPEG size');
 });
 
-test('png', (t) => {
+test('png', () => {
 	const png = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.png'));
 	const fried = BufferUtils.concat([
 		new Uint8Array(12),
@@ -30,39 +31,39 @@ test('png', (t) => {
 	friedView.setUint32(32, 12, false);
 	friedView.setUint32(36, 12, false);
 
-	t.is(ImageUtils.getMimeType(png), 'image/png', 'detects image/png');
-	t.deepEqual(ImageUtils.getSize(png, 'image/png'), [256, 256], 'png');
-	t.deepEqual(ImageUtils.getSize(fried, 'image/png'), [12, 12], 'png (fried)');
-	t.is(ImageUtils.getChannels(png, 'image/png'), 4, 'png channels');
-	t.is(ImageUtils.getChannels(fried, 'image/png'), 4, 'png channels');
-	t.is(ImageUtils.getVRAMByteLength(png, 'image/png'), 349524, 'png gpu size');
-	t.is(ImageUtils.getVRAMByteLength(fried, 'image/png'), 760, 'png gpu size');
+	strictEqual(ImageUtils.getMimeType(png), 'image/png', 'detects image/png');
+	deepEqual(ImageUtils.getSize(png, 'image/png'), [256, 256], 'png');
+	deepEqual(ImageUtils.getSize(fried, 'image/png'), [12, 12], 'png (fried)');
+	strictEqual(ImageUtils.getChannels(png, 'image/png'), 4, 'png channels');
+	strictEqual(ImageUtils.getChannels(fried, 'image/png'), 4, 'png channels');
+	strictEqual(ImageUtils.getVRAMByteLength(png, 'image/png'), 349524, 'png gpu size');
+	strictEqual(ImageUtils.getVRAMByteLength(fried, 'image/png'), 760, 'png gpu size');
 });
 
-test('jpeg', (t) => {
+test('jpeg', () => {
 	const jpg = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.jpg'));
 	const array = new Uint8Array(100);
 	const view = new DataView(array.buffer, array.byteOffset);
 
-	t.is(ImageUtils.getMimeType(jpg), 'image/jpeg', 'detects image/jpeg');
-	t.deepEqual(ImageUtils.getSize(jpg, 'image/jpeg'), [256, 256], 'jpg size');
-	t.is(ImageUtils.getChannels(jpg, 'image/jpeg'), 3, 'jpg channels');
+	strictEqual(ImageUtils.getMimeType(jpg), 'image/jpeg', 'detects image/jpeg');
+	deepEqual(ImageUtils.getSize(jpg, 'image/jpeg'), [256, 256], 'jpg size');
+	strictEqual(ImageUtils.getChannels(jpg, 'image/jpeg'), 3, 'jpg channels');
 	// See https://github.com/donmccurdy/glTF-Transform/issues/151.
-	t.is(ImageUtils.getVRAMByteLength(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
+	strictEqual(ImageUtils.getVRAMByteLength(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
 
 	view.setUint16(4, 1000, false);
-	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'oob');
+	throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'oob');
 
 	view.setUint16(4, 12, false);
-	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'invalid');
+	throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'invalid');
 
 	view.setUint16(4, 94, false);
 	view.setUint8(94 + 4, 0xff);
-	t.throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'no size');
+	throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'no size');
 });
 
-test('extensions', (t) => {
-	t.is(ImageUtils.extensionToMimeType('jpg'), 'image/jpeg', 'extensionToMimeType, jpeg');
-	t.is(ImageUtils.mimeTypeToExtension('image/png'), 'png', 'mimeTypeToExtension, inferred');
-	t.is(ImageUtils.mimeTypeToExtension('image/jpeg'), 'jpg', 'mimeTypeToExtension, jpg');
+test('extensions', () => {
+	strictEqual(ImageUtils.extensionToMimeType('jpg'), 'image/jpeg', 'extensionToMimeType, jpeg');
+	strictEqual(ImageUtils.mimeTypeToExtension('image/png'), 'png', 'mimeTypeToExtension, inferred');
+	strictEqual(ImageUtils.mimeTypeToExtension('image/jpeg'), 'jpg', 'mimeTypeToExtension, jpg');
 });

--- a/packages/core/test/utils/image-utils.test.ts
+++ b/packages/core/test/utils/image-utils.test.ts
@@ -1,5 +1,5 @@
 import { deepEqual, strictEqual, throws } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { BufferUtils, ImageUtils } from '@gltf-transform/core';
 import fs from 'fs';
 import ndarray from 'ndarray';
@@ -9,61 +9,63 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('basic', async () => {
-	let pixels = ndarray(new Uint8Array(100 * 50 * 4), [100, 50, 4]);
-	let image = await savePixels(pixels, 'image/png');
-	deepEqual(ImageUtils.getSize(image, 'image/png'), [100, 50], 'gets PNG size');
+describe('ImageUtils', () => {
+	test('basic', async () => {
+		let pixels = ndarray(new Uint8Array(100 * 50 * 4), [100, 50, 4]);
+		let image = await savePixels(pixels, 'image/png');
+		deepEqual(ImageUtils.getSize(image, 'image/png'), [100, 50], 'gets PNG size');
 
-	pixels = ndarray(new Uint8Array(16 * 32 * 4), [16, 32, 4]);
-	image = await savePixels(pixels, 'image/jpeg');
-	deepEqual(ImageUtils.getSize(image, 'image/jpeg'), [16, 32], 'gets JPEG size');
-});
+		pixels = ndarray(new Uint8Array(16 * 32 * 4), [16, 32, 4]);
+		image = await savePixels(pixels, 'image/jpeg');
+		deepEqual(ImageUtils.getSize(image, 'image/jpeg'), [16, 32], 'gets JPEG size');
+	});
 
-test('png', () => {
-	const png = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.png'));
-	const fried = BufferUtils.concat([
-		new Uint8Array(12),
-		BufferUtils.encodeText('CgBI'),
-		new Uint8Array(16),
-		new Uint8Array(8),
-	]);
-	const friedView = new DataView(fried.buffer, fried.byteOffset);
-	friedView.setUint32(32, 12, false);
-	friedView.setUint32(36, 12, false);
+	test('png', () => {
+		const png = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.png'));
+		const fried = BufferUtils.concat([
+			new Uint8Array(12),
+			BufferUtils.encodeText('CgBI'),
+			new Uint8Array(16),
+			new Uint8Array(8),
+		]);
+		const friedView = new DataView(fried.buffer, fried.byteOffset);
+		friedView.setUint32(32, 12, false);
+		friedView.setUint32(36, 12, false);
 
-	strictEqual(ImageUtils.getMimeType(png), 'image/png', 'detects image/png');
-	deepEqual(ImageUtils.getSize(png, 'image/png'), [256, 256], 'png');
-	deepEqual(ImageUtils.getSize(fried, 'image/png'), [12, 12], 'png (fried)');
-	strictEqual(ImageUtils.getChannels(png, 'image/png'), 4, 'png channels');
-	strictEqual(ImageUtils.getChannels(fried, 'image/png'), 4, 'png channels');
-	strictEqual(ImageUtils.getVRAMByteLength(png, 'image/png'), 349524, 'png gpu size');
-	strictEqual(ImageUtils.getVRAMByteLength(fried, 'image/png'), 760, 'png gpu size');
-});
+		strictEqual(ImageUtils.getMimeType(png), 'image/png', 'detects image/png');
+		deepEqual(ImageUtils.getSize(png, 'image/png'), [256, 256], 'png');
+		deepEqual(ImageUtils.getSize(fried, 'image/png'), [12, 12], 'png (fried)');
+		strictEqual(ImageUtils.getChannels(png, 'image/png'), 4, 'png channels');
+		strictEqual(ImageUtils.getChannels(fried, 'image/png'), 4, 'png channels');
+		strictEqual(ImageUtils.getVRAMByteLength(png, 'image/png'), 349524, 'png gpu size');
+		strictEqual(ImageUtils.getVRAMByteLength(fried, 'image/png'), 760, 'png gpu size');
+	});
 
-test('jpeg', () => {
-	const jpg = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.jpg'));
-	const array = new Uint8Array(100);
-	const view = new DataView(array.buffer, array.byteOffset);
+	test('jpeg', () => {
+		const jpg = fs.readFileSync(path.join(__dirname, '..', 'in', 'test.jpg'));
+		const array = new Uint8Array(100);
+		const view = new DataView(array.buffer, array.byteOffset);
 
-	strictEqual(ImageUtils.getMimeType(jpg), 'image/jpeg', 'detects image/jpeg');
-	deepEqual(ImageUtils.getSize(jpg, 'image/jpeg'), [256, 256], 'jpg size');
-	strictEqual(ImageUtils.getChannels(jpg, 'image/jpeg'), 3, 'jpg channels');
-	// See https://github.com/donmccurdy/glTF-Transform/issues/151.
-	strictEqual(ImageUtils.getVRAMByteLength(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
+		strictEqual(ImageUtils.getMimeType(jpg), 'image/jpeg', 'detects image/jpeg');
+		deepEqual(ImageUtils.getSize(jpg, 'image/jpeg'), [256, 256], 'jpg size');
+		strictEqual(ImageUtils.getChannels(jpg, 'image/jpeg'), 3, 'jpg channels');
+		// See https://github.com/donmccurdy/glTF-Transform/issues/151.
+		strictEqual(ImageUtils.getVRAMByteLength(jpg, 'image/jpeg'), 349524, 'jpg gpu size');
 
-	view.setUint16(4, 1000, false);
-	throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'oob');
+		view.setUint16(4, 1000, false);
+		throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'oob');
 
-	view.setUint16(4, 12, false);
-	throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'invalid');
+		view.setUint16(4, 12, false);
+		throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'invalid');
 
-	view.setUint16(4, 94, false);
-	view.setUint8(94 + 4, 0xff);
-	throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'no size');
-});
+		view.setUint16(4, 94, false);
+		view.setUint8(94 + 4, 0xff);
+		throws(() => ImageUtils.getSize(array, 'image/jpeg'), undefined, 'no size');
+	});
 
-test('extensions', () => {
-	strictEqual(ImageUtils.extensionToMimeType('jpg'), 'image/jpeg', 'extensionToMimeType, jpeg');
-	strictEqual(ImageUtils.mimeTypeToExtension('image/png'), 'png', 'mimeTypeToExtension, inferred');
-	strictEqual(ImageUtils.mimeTypeToExtension('image/jpeg'), 'jpg', 'mimeTypeToExtension, jpg');
+	test('extensions', () => {
+		strictEqual(ImageUtils.extensionToMimeType('jpg'), 'image/jpeg', 'extensionToMimeType, jpeg');
+		strictEqual(ImageUtils.mimeTypeToExtension('image/png'), 'png', 'mimeTypeToExtension, inferred');
+		strictEqual(ImageUtils.mimeTypeToExtension('image/jpeg'), 'jpg', 'mimeTypeToExtension, jpg');
+	});
 });

--- a/packages/core/test/utils/image-utils.test.ts
+++ b/packages/core/test/utils/image-utils.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('ImageUtils', () => {
+describe('core::ImageUtils', () => {
 	test('basic', async () => {
 		let pixels = ndarray(new Uint8Array(100 * 50 * 4), [100, 50, 4]);
 		let image = await savePixels(pixels, 'image/png');

--- a/packages/core/test/utils/logger.test.ts
+++ b/packages/core/test/utils/logger.test.ts
@@ -1,37 +1,39 @@
 import { strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { Logger } from '@gltf-transform/core';
 
-test('basic', () => {
-	const { debug, info, warn, error } = console;
+describe('Logger', () => {
+	test('basic', () => {
+		const { debug, info, warn, error } = console;
 
-	const calls = { debug: 0, info: 0, warn: 0, error: 0 };
-	Object.assign(console, {
-		debug: () => calls.debug++,
-		info: () => calls.info++,
-		warn: () => calls.warn++,
-		error: () => calls.error++,
+		const calls = { debug: 0, info: 0, warn: 0, error: 0 };
+		Object.assign(console, {
+			debug: () => calls.debug++,
+			info: () => calls.info++,
+			warn: () => calls.warn++,
+			error: () => calls.error++,
+		});
+
+		let logger = new Logger(Logger.Verbosity.SILENT);
+		logger.debug('debug');
+		logger.info('info');
+		logger.warn('warn');
+		logger.error('error');
+		strictEqual(calls.debug, 0, 'no debug when silenced');
+		strictEqual(calls.info, 0, 'no info when silenced');
+		strictEqual(calls.warn, 0, 'no warn when silenced');
+		strictEqual(calls.error, 0, 'no error when silenced');
+
+		logger = new Logger(Logger.Verbosity.DEBUG);
+		logger.debug('debug');
+		logger.info('info');
+		logger.warn('warn');
+		logger.error('error');
+		strictEqual(calls.debug, 1, 'debug when not silenced');
+		strictEqual(calls.info, 1, 'info when not silenced');
+		strictEqual(calls.warn, 1, 'warn when not silenced');
+		strictEqual(calls.error, 1, 'error when not silenced');
+
+		Object.assign(console, { debug, info, warn, error });
 	});
-
-	let logger = new Logger(Logger.Verbosity.SILENT);
-	logger.debug('debug');
-	logger.info('info');
-	logger.warn('warn');
-	logger.error('error');
-	strictEqual(calls.debug, 0, 'no debug when silenced');
-	strictEqual(calls.info, 0, 'no info when silenced');
-	strictEqual(calls.warn, 0, 'no warn when silenced');
-	strictEqual(calls.error, 0, 'no error when silenced');
-
-	logger = new Logger(Logger.Verbosity.DEBUG);
-	logger.debug('debug');
-	logger.info('info');
-	logger.warn('warn');
-	logger.error('error');
-	strictEqual(calls.debug, 1, 'debug when not silenced');
-	strictEqual(calls.info, 1, 'info when not silenced');
-	strictEqual(calls.warn, 1, 'warn when not silenced');
-	strictEqual(calls.error, 1, 'error when not silenced');
-
-	Object.assign(console, { debug, info, warn, error });
 });

--- a/packages/core/test/utils/logger.test.ts
+++ b/packages/core/test/utils/logger.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { Logger } from '@gltf-transform/core';
 
-describe('Logger', () => {
+describe('core::Logger', () => {
 	test('basic', () => {
 		const { debug, info, warn, error } = console;
 

--- a/packages/core/test/utils/logger.test.ts
+++ b/packages/core/test/utils/logger.test.ts
@@ -1,7 +1,8 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Logger } from '@gltf-transform/core';
-import test from 'ava';
 
-test('basic', (t) => {
+test('basic', () => {
 	const { debug, info, warn, error } = console;
 
 	const calls = { debug: 0, info: 0, warn: 0, error: 0 };
@@ -17,20 +18,20 @@ test('basic', (t) => {
 	logger.info('info');
 	logger.warn('warn');
 	logger.error('error');
-	t.is(calls.debug, 0, 'no debug when silenced');
-	t.is(calls.info, 0, 'no info when silenced');
-	t.is(calls.warn, 0, 'no warn when silenced');
-	t.is(calls.error, 0, 'no error when silenced');
+	strictEqual(calls.debug, 0, 'no debug when silenced');
+	strictEqual(calls.info, 0, 'no info when silenced');
+	strictEqual(calls.warn, 0, 'no warn when silenced');
+	strictEqual(calls.error, 0, 'no error when silenced');
 
 	logger = new Logger(Logger.Verbosity.DEBUG);
 	logger.debug('debug');
 	logger.info('info');
 	logger.warn('warn');
 	logger.error('error');
-	t.is(calls.debug, 1, 'debug when not silenced');
-	t.is(calls.info, 1, 'info when not silenced');
-	t.is(calls.warn, 1, 'warn when not silenced');
-	t.is(calls.error, 1, 'error when not silenced');
+	strictEqual(calls.debug, 1, 'debug when not silenced');
+	strictEqual(calls.info, 1, 'info when not silenced');
+	strictEqual(calls.warn, 1, 'warn when not silenced');
+	strictEqual(calls.error, 1, 'error when not silenced');
 
 	Object.assign(console, { debug, info, warn, error });
 });

--- a/packages/core/test/utils/math-utils.test.ts
+++ b/packages/core/test/utils/math-utils.test.ts
@@ -1,32 +1,34 @@
 import { strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { MathUtils } from '@gltf-transform/core';
 
-test('identity', () => {
-	strictEqual(MathUtils.identity(25), 25, 'identity');
-});
+describe('MathUtils', () => {
+	test('identity', () => {
+		strictEqual(MathUtils.identity(25), 25, 'identity');
+	});
 
-test('clamp', () => {
-	strictEqual(MathUtils.clamp(0.5, 0, 1), 0.5, 'clamp(0.5, 0, 1) === 0.5');
-	strictEqual(MathUtils.clamp(-0.1, 0, 1), 0, 'clamp(-0.1, 0, 1) === 0.0');
-	strictEqual(MathUtils.clamp(1, 0, 1), 1, 'clamp(1, 0, 1) === 1');
-	strictEqual(MathUtils.clamp(Infinity, 0, 1), 1, 'clamp(Infinity, 0, 1) === 1');
-});
+	test('clamp', () => {
+		strictEqual(MathUtils.clamp(0.5, 0, 1), 0.5, 'clamp(0.5, 0, 1) === 0.5');
+		strictEqual(MathUtils.clamp(-0.1, 0, 1), 0, 'clamp(-0.1, 0, 1) === 0.0');
+		strictEqual(MathUtils.clamp(1, 0, 1), 1, 'clamp(1, 0, 1) === 1');
+		strictEqual(MathUtils.clamp(Infinity, 0, 1), 1, 'clamp(Infinity, 0, 1) === 1');
+	});
 
-test('decodeNormalizedInt', () => {
-	strictEqual(MathUtils.decodeNormalizedInt(25, 5126), 25, 'float');
-	strictEqual(MathUtils.decodeNormalizedInt(13107, 5123), 0.2, 'ushort');
-	strictEqual(MathUtils.decodeNormalizedInt(51, 5121), 0.2, 'ubyte');
-	strictEqual(MathUtils.decodeNormalizedInt(1000, 5122).toFixed(4), '0.0305', 'short');
-	strictEqual(MathUtils.decodeNormalizedInt(3, 5120).toFixed(4), '0.0236', 'byte');
-});
+	test('decodeNormalizedInt', () => {
+		strictEqual(MathUtils.decodeNormalizedInt(25, 5126), 25, 'float');
+		strictEqual(MathUtils.decodeNormalizedInt(13107, 5123), 0.2, 'ushort');
+		strictEqual(MathUtils.decodeNormalizedInt(51, 5121), 0.2, 'ubyte');
+		strictEqual(MathUtils.decodeNormalizedInt(1000, 5122).toFixed(4), '0.0305', 'short');
+		strictEqual(MathUtils.decodeNormalizedInt(3, 5120).toFixed(4), '0.0236', 'byte');
+	});
 
-test('encodeNormalizedInt', () => {
-	strictEqual(MathUtils.encodeNormalizedInt(25, 5126), 25, 'float');
-	strictEqual(MathUtils.encodeNormalizedInt(0.2, 5123), 13107, 'ushort');
-	strictEqual(MathUtils.encodeNormalizedInt(0.2, 5121), 51, 'ubyte');
-	strictEqual(MathUtils.encodeNormalizedInt(-0.5, 5121), 0, 'ubyte out of bounds');
-	strictEqual(MathUtils.encodeNormalizedInt(0.03053, 5122), 1000, 'short');
-	strictEqual(MathUtils.encodeNormalizedInt(0.0236, 5120), 3, 'byte');
-	strictEqual(MathUtils.encodeNormalizedInt(1.5, 5120), 127, 'byte out of bounds');
+	test('encodeNormalizedInt', () => {
+		strictEqual(MathUtils.encodeNormalizedInt(25, 5126), 25, 'float');
+		strictEqual(MathUtils.encodeNormalizedInt(0.2, 5123), 13107, 'ushort');
+		strictEqual(MathUtils.encodeNormalizedInt(0.2, 5121), 51, 'ubyte');
+		strictEqual(MathUtils.encodeNormalizedInt(-0.5, 5121), 0, 'ubyte out of bounds');
+		strictEqual(MathUtils.encodeNormalizedInt(0.03053, 5122), 1000, 'short');
+		strictEqual(MathUtils.encodeNormalizedInt(0.0236, 5120), 3, 'byte');
+		strictEqual(MathUtils.encodeNormalizedInt(1.5, 5120), 127, 'byte out of bounds');
+	});
 });

--- a/packages/core/test/utils/math-utils.test.ts
+++ b/packages/core/test/utils/math-utils.test.ts
@@ -1,31 +1,32 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { MathUtils } from '@gltf-transform/core';
-import test from 'ava';
 
-test('identity', (t) => {
-	t.is(MathUtils.identity(25), 25, 'identity');
+test('identity', () => {
+	strictEqual(MathUtils.identity(25), 25, 'identity');
 });
 
-test('clamp', (t) => {
-	t.is(MathUtils.clamp(0.5, 0, 1), 0.5, 'clamp(0.5, 0, 1) === 0.5');
-	t.is(MathUtils.clamp(-0.1, 0, 1), 0, 'clamp(-0.1, 0, 1) === 0.0');
-	t.is(MathUtils.clamp(1, 0, 1), 1, 'clamp(1, 0, 1) === 1');
-	t.is(MathUtils.clamp(Infinity, 0, 1), 1, 'clamp(Infinity, 0, 1) === 1');
+test('clamp', () => {
+	strictEqual(MathUtils.clamp(0.5, 0, 1), 0.5, 'clamp(0.5, 0, 1) === 0.5');
+	strictEqual(MathUtils.clamp(-0.1, 0, 1), 0, 'clamp(-0.1, 0, 1) === 0.0');
+	strictEqual(MathUtils.clamp(1, 0, 1), 1, 'clamp(1, 0, 1) === 1');
+	strictEqual(MathUtils.clamp(Infinity, 0, 1), 1, 'clamp(Infinity, 0, 1) === 1');
 });
 
-test('decodeNormalizedInt', (t) => {
-	t.is(MathUtils.decodeNormalizedInt(25, 5126), 25, 'float');
-	t.is(MathUtils.decodeNormalizedInt(13107, 5123), 0.2, 'ushort');
-	t.is(MathUtils.decodeNormalizedInt(51, 5121), 0.2, 'ubyte');
-	t.is(MathUtils.decodeNormalizedInt(1000, 5122).toFixed(4), '0.0305', 'short');
-	t.is(MathUtils.decodeNormalizedInt(3, 5120).toFixed(4), '0.0236', 'byte');
+test('decodeNormalizedInt', () => {
+	strictEqual(MathUtils.decodeNormalizedInt(25, 5126), 25, 'float');
+	strictEqual(MathUtils.decodeNormalizedInt(13107, 5123), 0.2, 'ushort');
+	strictEqual(MathUtils.decodeNormalizedInt(51, 5121), 0.2, 'ubyte');
+	strictEqual(MathUtils.decodeNormalizedInt(1000, 5122).toFixed(4), '0.0305', 'short');
+	strictEqual(MathUtils.decodeNormalizedInt(3, 5120).toFixed(4), '0.0236', 'byte');
 });
 
-test('encodeNormalizedInt', (t) => {
-	t.is(MathUtils.encodeNormalizedInt(25, 5126), 25, 'float');
-	t.is(MathUtils.encodeNormalizedInt(0.2, 5123), 13107, 'ushort');
-	t.is(MathUtils.encodeNormalizedInt(0.2, 5121), 51, 'ubyte');
-	t.is(MathUtils.encodeNormalizedInt(-0.5, 5121), 0, 'ubyte out of bounds');
-	t.is(MathUtils.encodeNormalizedInt(0.03053, 5122), 1000, 'short');
-	t.is(MathUtils.encodeNormalizedInt(0.0236, 5120), 3, 'byte');
-	t.is(MathUtils.encodeNormalizedInt(1.5, 5120), 127, 'byte out of bounds');
+test('encodeNormalizedInt', () => {
+	strictEqual(MathUtils.encodeNormalizedInt(25, 5126), 25, 'float');
+	strictEqual(MathUtils.encodeNormalizedInt(0.2, 5123), 13107, 'ushort');
+	strictEqual(MathUtils.encodeNormalizedInt(0.2, 5121), 51, 'ubyte');
+	strictEqual(MathUtils.encodeNormalizedInt(-0.5, 5121), 0, 'ubyte out of bounds');
+	strictEqual(MathUtils.encodeNormalizedInt(0.03053, 5122), 1000, 'short');
+	strictEqual(MathUtils.encodeNormalizedInt(0.0236, 5120), 3, 'byte');
+	strictEqual(MathUtils.encodeNormalizedInt(1.5, 5120), 127, 'byte out of bounds');
 });

--- a/packages/core/test/utils/math-utils.test.ts
+++ b/packages/core/test/utils/math-utils.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { MathUtils } from '@gltf-transform/core';
 
-describe('MathUtils', () => {
+describe('core::MathUtils', () => {
 	test('identity', () => {
 		strictEqual(MathUtils.identity(25), 25, 'identity');
 	});

--- a/packages/core/test/utils/uuid.test.ts
+++ b/packages/core/test/utils/uuid.test.ts
@@ -1,30 +1,32 @@
 import { strictEqual } from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, test } from 'node:test';
 import { uuid } from '@gltf-transform/core';
 
-test('basic', () => {
-	const set = new Set();
-	for (let i = 0; i < 1000; i++) {
-		set.add(uuid());
-	}
-	strictEqual(set.size, 1000, 'generates 1000 unique IDs');
-});
+describe('uuid', () => {
+	test('basic', () => {
+		const set = new Set();
+		for (let i = 0; i < 1000; i++) {
+			set.add(uuid());
+		}
+		strictEqual(set.size, 1000, 'generates 1000 unique IDs');
+	});
 
-test('conflict', () => {
-	const { random } = Math;
+	test('conflict', () => {
+		const { random } = Math;
 
-	// Number of elements must match ID length.
-	const values = [
-		0.12, 0.22, 0.32, 0.42, 0.52, 0.62, 0.11, 0.21, 0.31, 0.41, 0.51, 0.61, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.1, 0.2,
-		0.3, 0.4, 0.5, 0.6,
-	];
-	Math.random = (): number => values.pop();
+		// Number of elements must match ID length.
+		const values = [
+			0.12, 0.22, 0.32, 0.42, 0.52, 0.62, 0.11, 0.21, 0.31, 0.41, 0.51, 0.61, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.1,
+			0.2, 0.3, 0.4, 0.5, 0.6,
+		];
+		Math.random = (): number => values.pop();
 
-	const set = new Set();
-	for (let i = 0; i < 3; i++) {
-		set.add(uuid());
-	}
-	strictEqual(set.size, 3, 'generates 3 unique IDs');
+		const set = new Set();
+		for (let i = 0; i < 3; i++) {
+			set.add(uuid());
+		}
+		strictEqual(set.size, 3, 'generates 3 unique IDs');
 
-	Math.random = random;
+		Math.random = random;
+	});
 });

--- a/packages/core/test/utils/uuid.test.ts
+++ b/packages/core/test/utils/uuid.test.ts
@@ -2,7 +2,7 @@ import { strictEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { uuid } from '@gltf-transform/core';
 
-describe('uuid', () => {
+describe('core::uuid', () => {
 	test('basic', () => {
 		const set = new Set();
 		for (let i = 0; i < 1000; i++) {

--- a/packages/core/test/utils/uuid.test.ts
+++ b/packages/core/test/utils/uuid.test.ts
@@ -1,15 +1,16 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { uuid } from '@gltf-transform/core';
-import test from 'ava';
 
-test('basic', (t) => {
+test('basic', () => {
 	const set = new Set();
 	for (let i = 0; i < 1000; i++) {
 		set.add(uuid());
 	}
-	t.is(set.size, 1000, 'generates 1000 unique IDs');
+	strictEqual(set.size, 1000, 'generates 1000 unique IDs');
 });
 
-test('conflict', (t) => {
+test('conflict', () => {
 	const { random } = Math;
 
 	// Number of elements must match ID length.
@@ -23,7 +24,7 @@ test('conflict', (t) => {
 	for (let i = 0; i < 3; i++) {
 		set.add(uuid());
 	}
-	t.is(set.size, 3, 'generates 3 unique IDs');
+	strictEqual(set.size, 3, 'generates 3 unique IDs');
 
 	Math.random = random;
 });

--- a/packages/extensions/test/accessor-float16.test.ts
+++ b/packages/extensions/test/accessor-float16.test.ts
@@ -6,7 +6,7 @@ import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRAccessorFloat16', () => {
+describe('extensions::KHRAccessorFloat16', () => {
 	test('basic', async () => {
 		// TODO(v5): Remove after Node.js v22 reaches EOL, or adds Float16Array support.
 		if (typeof Float16Array === 'undefined') return;

--- a/packages/extensions/test/accessor-float16.test.ts
+++ b/packages/extensions/test/accessor-float16.test.ts
@@ -1,49 +1,52 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, NodeIO } from '@gltf-transform/core';
 import { KHRAccessorFloat16 } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	// TODO(v5): Remove after Node.js v22 reaches EOL, or adds Float16Array support.
-	if (typeof Float16Array === 'undefined') return t.pass();
+describe('KHRAccessorFloat16', () => {
+	test('basic', async () => {
+		// TODO(v5): Remove after Node.js v22 reaches EOL, or adds Float16Array support.
+		if (typeof Float16Array === 'undefined') return;
 
-	const document = new Document();
-	const io = new NodeIO().registerExtensions([KHRAccessorFloat16]);
+		const document = new Document();
+		const io = new NodeIO().registerExtensions([KHRAccessorFloat16]);
 
-	document.createExtension(KHRAccessorFloat16).setRequired(true);
+		document.createExtension(KHRAccessorFloat16).setRequired(true);
 
-	const buffer = document.createBuffer();
-	const position = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float16Array([0, 1, 2]))
-		.setBuffer(buffer);
-	const prim = document.createPrimitive().setAttribute('POSITION', position);
-	document.createMesh().addPrimitive(prim);
+		const buffer = document.createBuffer();
+		const position = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float16Array([0, 1, 2]))
+			.setBuffer(buffer);
+		const prim = document.createPrimitive().setAttribute('POSITION', position);
+		document.createMesh().addPrimitive(prim);
 
-	const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRAccessorFloat16.EXTENSION_NAME], 'writes extensionsUsed');
-	t.deepEqual(jsonDoc.json.extensionsRequired, [KHRAccessorFloat16.EXTENSION_NAME], 'writes extensionsRequired');
+		const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRAccessorFloat16.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(jsonDoc.json.extensionsRequired, [KHRAccessorFloat16.EXTENSION_NAME], 'writes extensionsRequired');
 
-	const rtDocument = await io.readJSON(jsonDoc);
+		const rtDocument = await io.readJSON(jsonDoc);
 
-	const rtExtensions = rtDocument.getRoot().listExtensionsRequired();
-	const rtExtension = rtExtensions.find((ext) => ext.extensionName === 'KHR_accessor_float16');
-	t.truthy(rtExtension, 'reads KHR_accessor_float16');
+		const rtExtensions = rtDocument.getRoot().listExtensionsRequired();
+		const rtExtension = rtExtensions.find((ext) => ext.extensionName === 'KHR_accessor_float16');
+		ok(rtExtension, 'reads KHR_accessor_float16');
 
-	const rtPrim = rtDocument.getRoot().listMeshes()[0].listPrimitives()[0];
-	const rtAccessor = rtPrim.getAttribute('POSITION');
+		const rtPrim = rtDocument.getRoot().listMeshes()[0].listPrimitives()[0];
+		const rtAccessor = rtPrim.getAttribute('POSITION');
 
-	t.is(rtAccessor.getComponentType(), Accessor.ComponentType.FLOAT16, 'componentType == FLOAT16');
-	t.true(rtAccessor.getArray() instanceof Float16Array, 'array instanceof Float16Array');
-	t.deepEqual(Array.from(rtAccessor.getArray()), [0, 1, 2], 'array contents');
-});
+		strictEqual(rtAccessor.getComponentType(), Accessor.ComponentType.FLOAT16, 'componentType == FLOAT16');
+		ok(rtAccessor.getArray() instanceof Float16Array, 'array instanceof Float16Array');
+		deepEqual(Array.from(rtAccessor.getArray()), [0, 1, 2], 'array contents');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	document.createExtension(KHRAccessorFloat16).setRequired(true);
+	test('copy', () => {
+		const document = new Document();
+		document.createExtension(KHRAccessorFloat16).setRequired(true);
 
-	t.is(cloneDocument(document).getRoot().listExtensionsUsed().length, 1, 'copy KHRAccessorFloat16');
+		strictEqual(cloneDocument(document).getRoot().listExtensionsUsed().length, 1, 'copy KHRAccessorFloat16');
+	});
 });

--- a/packages/extensions/test/accessor-float64.test.ts
+++ b/packages/extensions/test/accessor-float64.test.ts
@@ -6,7 +6,7 @@ import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRAccessorFloat64', () => {
+describe('extensions::KHRAccessorFloat64', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const io = new NodeIO().registerExtensions([KHRAccessorFloat64]);

--- a/packages/extensions/test/accessor-float64.test.ts
+++ b/packages/extensions/test/accessor-float64.test.ts
@@ -1,46 +1,49 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, NodeIO } from '@gltf-transform/core';
 import { KHRAccessorFloat64 } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const document = new Document();
-	const io = new NodeIO().registerExtensions([KHRAccessorFloat64]);
+describe('KHRAccessorFloat64', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const io = new NodeIO().registerExtensions([KHRAccessorFloat64]);
 
-	document.createExtension(KHRAccessorFloat64).setRequired(true);
+		document.createExtension(KHRAccessorFloat64).setRequired(true);
 
-	const buffer = document.createBuffer();
-	const position = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float64Array([0, 1, 2]))
-		.setBuffer(buffer);
-	const prim = document.createPrimitive().setAttribute('POSITION', position);
-	document.createMesh().addPrimitive(prim);
+		const buffer = document.createBuffer();
+		const position = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float64Array([0, 1, 2]))
+			.setBuffer(buffer);
+		const prim = document.createPrimitive().setAttribute('POSITION', position);
+		document.createMesh().addPrimitive(prim);
 
-	const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRAccessorFloat64.EXTENSION_NAME], 'writes extensionsUsed');
-	t.deepEqual(jsonDoc.json.extensionsRequired, [KHRAccessorFloat64.EXTENSION_NAME], 'writes extensionsRequired');
+		const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRAccessorFloat64.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(jsonDoc.json.extensionsRequired, [KHRAccessorFloat64.EXTENSION_NAME], 'writes extensionsRequired');
 
-	const rtDocument = await io.readJSON(jsonDoc);
+		const rtDocument = await io.readJSON(jsonDoc);
 
-	const rtExtensions = rtDocument.getRoot().listExtensionsRequired();
-	const rtExtension = rtExtensions.find((ext) => ext.extensionName === 'KHR_accessor_float64');
-	t.truthy(rtExtension, 'reads KHR_accessor_float64');
+		const rtExtensions = rtDocument.getRoot().listExtensionsRequired();
+		const rtExtension = rtExtensions.find((ext) => ext.extensionName === 'KHR_accessor_float64');
+		ok(rtExtension, 'reads KHR_accessor_float64');
 
-	const rtPrim = rtDocument.getRoot().listMeshes()[0].listPrimitives()[0];
-	const rtAccessor = rtPrim.getAttribute('POSITION');
+		const rtPrim = rtDocument.getRoot().listMeshes()[0].listPrimitives()[0];
+		const rtAccessor = rtPrim.getAttribute('POSITION');
 
-	t.is(rtAccessor.getComponentType(), Accessor.ComponentType.FLOAT64, 'componentType == FLOAT64');
-	t.true(rtAccessor.getArray() instanceof Float64Array, 'array instanceof Float64Array');
-	t.deepEqual(Array.from(rtAccessor.getArray()), [0, 1, 2], 'array contents');
-});
+		strictEqual(rtAccessor.getComponentType(), Accessor.ComponentType.FLOAT64, 'componentType == FLOAT64');
+		ok(rtAccessor.getArray() instanceof Float64Array, 'array instanceof Float64Array');
+		deepEqual(Array.from(rtAccessor.getArray()), [0, 1, 2], 'array contents');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	document.createExtension(KHRAccessorFloat64).setRequired(true);
+	test('copy', () => {
+		const document = new Document();
+		document.createExtension(KHRAccessorFloat64).setRequired(true);
 
-	t.is(cloneDocument(document).getRoot().listExtensionsUsed().length, 1, 'copy KHRAccessorFloat64');
+		strictEqual(cloneDocument(document).getRoot().listExtensionsUsed().length, 1, 'copy KHRAccessorFloat64');
+	});
 });

--- a/packages/extensions/test/draco-mesh-compression.test.ts
+++ b/packages/extensions/test/draco-mesh-compression.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('KHRDracoMeshCompression', () => {
+describe('extensions::KHRDracoMeshCompression', () => {
 	test('decoding', async () => {
 		const io = await createDecoderIO();
 		const document = await io.read(path.join(__dirname, 'in', 'BoxDraco.gltf'));

--- a/packages/extensions/test/draco-mesh-compression.test.ts
+++ b/packages/extensions/test/draco-mesh-compression.test.ts
@@ -1,353 +1,356 @@
+import { deepEqual, rejects, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, type Buffer, Document, Format, getBounds, NodeIO, Primitive } from '@gltf-transform/core';
 import { KHRDracoMeshCompression } from '@gltf-transform/extensions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import { createDecoderModule, createEncoderModule } from 'draco3dgltf';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('decoding', async (t) => {
-	const io = await createDecoderIO();
-	const document = await io.read(path.join(__dirname, 'in', 'BoxDraco.gltf'));
-	const bbox = getBounds(document.getRoot().listScenes()[0]);
-	t.deepEqual(
-		bbox.min.map((v) => +v.toFixed(3)),
-		[-0.5, -0.5, -0.5],
-		'decompress (min)',
-	);
-	t.deepEqual(
-		bbox.max.map((v) => +v.toFixed(3)),
-		[0.5, 0.5, 0.5],
-		'decompress (max)',
-	);
-});
+describe('KHRDracoMeshCompression', () => {
+	test('decoding', async () => {
+		const io = await createDecoderIO();
+		const document = await io.read(path.join(__dirname, 'in', 'BoxDraco.gltf'));
+		const bbox = getBounds(document.getRoot().listScenes()[0]);
+		deepEqual(
+			bbox.min.map((v) => +v.toFixed(3)),
+			[-0.5, -0.5, -0.5],
+			'decompress (min)',
+		);
+		deepEqual(
+			bbox.max.map((v) => +v.toFixed(3)),
+			[0.5, 0.5, 0.5],
+			'decompress (max)',
+		);
+	});
 
-test('encoding complete', async (t) => {
-	// Cases:
-	// (1) Entire primitive reused (share compressed buffer views).
-	// (2) All primitive accessors reused (share compressed buffer views).
+	test('encoding complete', async () => {
+		// Cases:
+		// (1) Entire primitive reused (share compressed buffer views).
+		// (2) All primitive accessors reused (share compressed buffer views).
 
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRDracoMeshCompression).setRequired(true);
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRDracoMeshCompression).setRequired(true);
 
-	const buffer = document.createBuffer();
-	const prim1 = createMeshPrimitive(document, buffer);
-	const prim2 = createMeshPrimitive(document, buffer);
+		const buffer = document.createBuffer();
+		const prim1 = createMeshPrimitive(document, buffer);
+		const prim2 = createMeshPrimitive(document, buffer);
 
-	const mesh = document.createMesh().addPrimitive(prim1).addPrimitive(prim2).addPrimitive(prim2.clone());
-	document.createNode().setMesh(mesh);
+		const mesh = document.createMesh().addPrimitive(prim1).addPrimitive(prim2).addPrimitive(prim2.clone());
+		document.createNode().setMesh(mesh);
 
-	let io = await createEncoderIO();
-	const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
-	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
+		let io = await createEncoderIO();
+		const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
+		const primitiveDefs = jsonDoc.json.meshes[0].primitives;
 
-	t.is(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
-	t.deepEqual(
-		primitiveDefs[0],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 0,
-			attributes: { POSITION: 1 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 0,
-					attributes: { POSITION: 0 },
+		strictEqual(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
+		deepEqual(
+			primitiveDefs[0],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 0,
+				attributes: { POSITION: 1 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 0,
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 1/4',
-	);
-	t.deepEqual(
-		primitiveDefs[1],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 2,
-			attributes: { POSITION: 3 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 1,
-					attributes: { POSITION: 0 },
+			'primitiveDef 1/4',
+		);
+		deepEqual(
+			primitiveDefs[1],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 2,
+				attributes: { POSITION: 3 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 1,
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 2/3',
-	);
-	t.deepEqual(
-		primitiveDefs[2],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 2, // shared.
-			attributes: { POSITION: 3 }, // shared.
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 1, // shared.
-					attributes: { POSITION: 0 },
+			'primitiveDef 2/3',
+		);
+		deepEqual(
+			primitiveDefs[2],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 2, // shared.
+				attributes: { POSITION: 3 }, // shared.
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 1, // shared.
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 3/3',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, ['KHR_draco_mesh_compression'], 'included in extensionsUsed');
+			'primitiveDef 3/3',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, ['KHR_draco_mesh_compression'], 'included in extensionsUsed');
 
-	io = await createDecoderIO();
-	const roundtripDoc = await io.readJSON(jsonDoc);
-	const roundtripNode = roundtripDoc.getRoot().listNodes()[0];
-	const bbox = getBounds(roundtripNode);
-	t.deepEqual(
-		bbox.min.map((v) => +v.toFixed(3)),
-		[0, -1, -1],
-		'round trip (min)',
-	);
-	t.deepEqual(
-		bbox.max.map((v) => +v.toFixed(3)),
-		[1, 1, 1],
-		'round trip (max)',
-	);
-});
+		io = await createDecoderIO();
+		const roundtripDoc = await io.readJSON(jsonDoc);
+		const roundtripNode = roundtripDoc.getRoot().listNodes()[0];
+		const bbox = getBounds(roundtripNode);
+		deepEqual(
+			bbox.min.map((v) => +v.toFixed(3)),
+			[0, -1, -1],
+			'round trip (min)',
+		);
+		deepEqual(
+			bbox.max.map((v) => +v.toFixed(3)),
+			[1, 1, 1],
+			'round trip (max)',
+		);
+	});
 
-test('encoding skipped', async (t) => {
-	// Cases:
-	// (1) Non-indexed.
-	// (2) Non-TRIANGLES.
+	test('encoding skipped', async () => {
+		// Cases:
+		// (1) Non-indexed.
+		// (2) Non-TRIANGLES.
 
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRDracoMeshCompression).setRequired(true);
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRDracoMeshCompression).setRequired(true);
 
-	const buffer = document.createBuffer();
-	const prim1 = createMeshPrimitive(document, buffer);
-	const prim2 = createMeshPrimitive(document, buffer);
+		const buffer = document.createBuffer();
+		const prim1 = createMeshPrimitive(document, buffer);
+		const prim2 = createMeshPrimitive(document, buffer);
 
-	prim1.getIndices().dispose();
-	prim2.setMode(Primitive.Mode.TRIANGLE_FAN);
+		prim1.getIndices().dispose();
+		prim2.setMode(Primitive.Mode.TRIANGLE_FAN);
 
-	const mesh = document.createMesh().addPrimitive(prim1).addPrimitive(prim2);
+		const mesh = document.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
-	const io = await createEncoderIO();
-	const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
-	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
+		const io = await createEncoderIO();
+		const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
+		const primitiveDefs = jsonDoc.json.meshes[0].primitives;
 
-	t.is(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
-	t.deepEqual(
-		primitiveDefs[0],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			attributes: { POSITION: 0 },
-		},
-		'primitiveDef 1/2',
-	);
-	t.deepEqual(
-		primitiveDefs[1],
-		{
-			mode: Primitive.Mode.TRIANGLE_FAN,
-			indices: 1,
-			attributes: { POSITION: 2 },
-		},
-		'primitiveDef 2/2',
-	);
-	t.falsy(jsonDoc.json.extensionsUsed, 'omitted from extensionsUsed');
-});
-
-test('encoding sparse', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRDracoMeshCompression).setRequired(true);
-
-	const buffer = document.createBuffer();
-	const sparseAccessor = document
-		.createAccessor()
-		.setArray(new Uint32Array([0, 0, 0, 0, 25, 0]))
-		.setSparse(true);
-	const prim = createMeshPrimitive(document, buffer).setAttribute('_SPARSE', sparseAccessor);
-	const mesh = document.createMesh().addPrimitive(prim);
-
-	const io = await createEncoderIO();
-	const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
-	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
-	const accessorDefs = jsonDoc.json.accessors;
-
-	t.is(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
-	t.deepEqual(
-		primitiveDefs[0],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 0,
-			attributes: { POSITION: 1, _SPARSE: 2 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 2,
-					attributes: { POSITION: 0 },
-				},
+		strictEqual(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
+		deepEqual(
+			primitiveDefs[0],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				attributes: { POSITION: 0 },
 			},
-		},
-		'primitiveDef',
-	);
-	t.is(accessorDefs[1].count, 6, 'POSITION count');
-	t.is(accessorDefs[2].count, 6, '_SPARSE count');
-	t.is(accessorDefs[1].sparse, undefined, 'POSITION not sparse');
-	t.is(accessorDefs[2].sparse.count, 1, '_SPARSE sparse');
-});
+			'primitiveDef 1/2',
+		);
+		deepEqual(
+			primitiveDefs[1],
+			{
+				mode: Primitive.Mode.TRIANGLE_FAN,
+				indices: 1,
+				attributes: { POSITION: 2 },
+			},
+			'primitiveDef 2/2',
+		);
+		strictEqual(jsonDoc.json.extensionsUsed, undefined, 'omitted from extensionsUsed');
+	});
 
-test('decoding sparse', async (t) => {
-	// See: https://github.com/donmccurdy/glTF-Transform/issues/1496
+	test('encoding sparse', async () => {
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRDracoMeshCompression).setRequired(true);
 
-	const io = await createDecoderIO();
-	const document = await io.read(path.join(__dirname, 'in', 'DracoSparseMesh.gltf'));
-	const root = document.getRoot();
-
-	t.is(root.listMeshes().length, 1, 'meshes.length = 1');
-	t.is(root.listMeshes()[0].listPrimitives().length, 1, 'meshes[0].primitives.length = 1');
-
-	const prim = root.listMeshes()[0].listPrimitives()[0];
-
-	const attributes = Object.fromEntries(
-		prim.listSemantics().map((semantic) => [semantic, prim.getAttribute(semantic)]),
-	);
-
-	t.is(attributes.POSITION.getType(), 'VEC3', 'prim.POSITION.type = VEC3');
-	t.is(attributes.POSITION.getCount(), 62, 'prim.POSITION.count = 62');
-
-	t.is(attributes.NORMAL.getType(), 'VEC3', 'prim.NORMAL.type = VEC3');
-	t.is(attributes.NORMAL.getCount(), 62, 'prim.NORMAL.count = 62');
-
-	t.is(attributes.JOINTS_0.getType(), 'VEC4', 'prim.JOINTS_0.type = VEC4');
-	t.is(attributes.JOINTS_0.getCount(), 62, 'prim.JOINTS_0.count = 62');
-
-	t.is(attributes.WEIGHTS_0.getType(), 'VEC4', 'prim.WEIGHTS_0.type = VEC4');
-	t.is(attributes.WEIGHTS_0.getCount(), 62, 'prim.WEIGHTS_0.count = 62');
-});
-
-test('mixed indices', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRDracoMeshCompression).setRequired(true);
-
-	const buffer = document.createBuffer();
-	const prim1 = createMeshPrimitive(document, buffer);
-	const prim2 = prim1.clone();
-
-	prim2.setIndices(
-		document
+		const buffer = document.createBuffer();
+		const sparseAccessor = document
 			.createAccessor()
-			.setArray(new Uint32Array([0, 1, 2, 3, 4, 5]))
-			.setBuffer(buffer),
-	);
+			.setArray(new Uint32Array([0, 0, 0, 0, 25, 0]))
+			.setSparse(true);
+		const prim = createMeshPrimitive(document, buffer).setAttribute('_SPARSE', sparseAccessor);
+		const mesh = document.createMesh().addPrimitive(prim);
 
-	document.createMesh().addPrimitive(prim1).addPrimitive(prim2);
+		const io = await createEncoderIO();
+		const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
+		const primitiveDefs = jsonDoc.json.meshes[0].primitives;
+		const accessorDefs = jsonDoc.json.accessors;
 
-	const io = await createEncoderIO();
-	const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
-	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
-
-	// The two primitives have different indices, and must be encoded as entirely separate buffer
-	// views. The shared attribute accessor is cloned.
-	t.deepEqual(
-		primitiveDefs[0],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 0,
-			attributes: { POSITION: 1 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 0,
-					attributes: { POSITION: 0 },
+		strictEqual(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
+		deepEqual(
+			primitiveDefs[0],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 0,
+				attributes: { POSITION: 1, _SPARSE: 2 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 2,
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 1/2',
-	);
-	t.deepEqual(
-		primitiveDefs[1],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 2,
-			attributes: { POSITION: 3 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 1,
-					attributes: { POSITION: 0 },
+			'primitiveDef',
+		);
+		strictEqual(accessorDefs[1].count, 6, 'POSITION count');
+		strictEqual(accessorDefs[2].count, 6, '_SPARSE count');
+		strictEqual(accessorDefs[1].sparse, undefined, 'POSITION not sparse');
+		strictEqual(accessorDefs[2].sparse.count, 1, '_SPARSE sparse');
+	});
+
+	test('decoding sparse', async () => {
+		// See: https://github.com/donmccurdy/glTF-Transform/issues/1496
+
+		const io = await createDecoderIO();
+		const document = await io.read(path.join(__dirname, 'in', 'DracoSparseMesh.gltf'));
+		const root = document.getRoot();
+
+		strictEqual(root.listMeshes().length, 1, 'meshes.length = 1');
+		strictEqual(root.listMeshes()[0].listPrimitives().length, 1, 'meshes[0].primitives.length = 1');
+
+		const prim = root.listMeshes()[0].listPrimitives()[0];
+
+		const attributes = Object.fromEntries(
+			prim.listSemantics().map((semantic) => [semantic, prim.getAttribute(semantic)]),
+		);
+
+		strictEqual(attributes.POSITION.getType(), 'VEC3', 'prim.POSITION.type = VEC3');
+		strictEqual(attributes.POSITION.getCount(), 62, 'prim.POSITION.count = 62');
+
+		strictEqual(attributes.NORMAL.getType(), 'VEC3', 'prim.NORMAL.type = VEC3');
+		strictEqual(attributes.NORMAL.getCount(), 62, 'prim.NORMAL.count = 62');
+
+		strictEqual(attributes.JOINTS_0.getType(), 'VEC4', 'prim.JOINTS_0.type = VEC4');
+		strictEqual(attributes.JOINTS_0.getCount(), 62, 'prim.JOINTS_0.count = 62');
+
+		strictEqual(attributes.WEIGHTS_0.getType(), 'VEC4', 'prim.WEIGHTS_0.type = VEC4');
+		strictEqual(attributes.WEIGHTS_0.getCount(), 62, 'prim.WEIGHTS_0.count = 62');
+	});
+
+	test('mixed indices', async () => {
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRDracoMeshCompression).setRequired(true);
+
+		const buffer = document.createBuffer();
+		const prim1 = createMeshPrimitive(document, buffer);
+		const prim2 = prim1.clone();
+
+		prim2.setIndices(
+			document
+				.createAccessor()
+				.setArray(new Uint32Array([0, 1, 2, 3, 4, 5]))
+				.setBuffer(buffer),
+		);
+
+		document.createMesh().addPrimitive(prim1).addPrimitive(prim2);
+
+		const io = await createEncoderIO();
+		const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
+		const primitiveDefs = jsonDoc.json.meshes[0].primitives;
+
+		// The two primitives have different indices, and must be encoded as entirely separate buffer
+		// views. The shared attribute accessor is cloned.
+		deepEqual(
+			primitiveDefs[0],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 0,
+				attributes: { POSITION: 1 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 0,
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 2/2',
-	);
-});
-
-test('mixed attributes', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRDracoMeshCompression).setRequired(true);
-
-	const buffer = document.createBuffer();
-	const prim1 = createMeshPrimitive(document, buffer);
-	const prim2 = prim1.clone();
-
-	prim2.setAttribute(
-		'COLOR_0',
-		document
-			.createAccessor()
-			.setType(Accessor.Type.VEC3)
-			.setArray(
-				new Float32Array([
-					0, 0, 0, 0.15, 0.15, 0.15, 0.3, 0.3, 0.3, 0.45, 0.45, 0.45, 0.6, 0.6, 0.6, 0.75, 0.75, 0.75,
-				]),
-			)
-			.setBuffer(buffer),
-	);
-
-	document.createMesh().addPrimitive(prim1).addPrimitive(prim2);
-
-	const io = await createEncoderIO();
-	const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
-	const primitiveDefs = jsonDoc.json.meshes[0].primitives;
-
-	// The two primitives have different attributes, and must be encoded as entirely separate
-	// buffer views. The shared indices accessor is cloned.
-	t.deepEqual(
-		primitiveDefs[0],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 0,
-			attributes: { POSITION: 1 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 0,
-					attributes: { POSITION: 0 },
+			'primitiveDef 1/2',
+		);
+		deepEqual(
+			primitiveDefs[1],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 2,
+				attributes: { POSITION: 3 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 1,
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 1/2',
-	);
-	// Order of attributes reverses, because shared POSITION is cloned.
-	t.deepEqual(
-		primitiveDefs[1],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			indices: 2,
-			attributes: { COLOR_0: 3, POSITION: 4 },
-			extensions: {
-				KHR_draco_mesh_compression: {
-					bufferView: 1,
-					attributes: { COLOR_0: 0, POSITION: 1 },
+			'primitiveDef 2/2',
+		);
+	});
+
+	test('mixed attributes', async () => {
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRDracoMeshCompression).setRequired(true);
+
+		const buffer = document.createBuffer();
+		const prim1 = createMeshPrimitive(document, buffer);
+		const prim2 = prim1.clone();
+
+		prim2.setAttribute(
+			'COLOR_0',
+			document
+				.createAccessor()
+				.setType(Accessor.Type.VEC3)
+				.setArray(
+					new Float32Array([
+						0, 0, 0, 0.15, 0.15, 0.15, 0.3, 0.3, 0.3, 0.45, 0.45, 0.45, 0.6, 0.6, 0.6, 0.75, 0.75, 0.75,
+					]),
+				)
+				.setBuffer(buffer),
+		);
+
+		document.createMesh().addPrimitive(prim1).addPrimitive(prim2);
+
+		const io = await createEncoderIO();
+		const jsonDoc = await io.writeJSON(document, { format: Format.GLB });
+		const primitiveDefs = jsonDoc.json.meshes[0].primitives;
+
+		// The two primitives have different attributes, and must be encoded as entirely separate
+		// buffer views. The shared indices accessor is cloned.
+		deepEqual(
+			primitiveDefs[0],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 0,
+				attributes: { POSITION: 1 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 0,
+						attributes: { POSITION: 0 },
+					},
 				},
 			},
-		},
-		'primitiveDef 2/2',
-	);
-});
+			'primitiveDef 1/2',
+		);
+		// Order of attributes reverses, because shared POSITION is cloned.
+		deepEqual(
+			primitiveDefs[1],
+			{
+				mode: Primitive.Mode.TRIANGLES,
+				indices: 2,
+				attributes: { COLOR_0: 3, POSITION: 4 },
+				extensions: {
+					KHR_draco_mesh_compression: {
+						bufferView: 1,
+						attributes: { COLOR_0: 0, POSITION: 1 },
+					},
+				},
+			},
+			'primitiveDef 2/2',
+		);
+	});
 
-test('non-primitive parent', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRDracoMeshCompression).setRequired(true);
+	test('non-primitive parent', async () => {
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRDracoMeshCompression).setRequired(true);
 
-	const prim = createMeshPrimitive(document, document.createBuffer());
-	prim.addTarget(document.createPrimitiveTarget().setAttribute('POSITION', prim.getAttribute('POSITION')));
-	document.createMesh().addPrimitive(prim);
+		const prim = createMeshPrimitive(document, document.createBuffer());
+		prim.addTarget(document.createPrimitiveTarget().setAttribute('POSITION', prim.getAttribute('POSITION')));
+		document.createMesh().addPrimitive(prim);
 
-	const io = await createEncoderIO();
-	await t.throwsAsync(
-		() => io.writeJSON(document, { format: Format.GLB }),
-		{ message: /indices or vertex attributes/ },
-		'invalid accessor reuse',
-	);
+		const io = await createEncoderIO();
+		await rejects(
+			() => io.writeJSON(document, { format: Format.GLB }),
+			{ message: /indices or vertex attributes/ },
+			'invalid accessor reuse',
+		);
+	});
 });
 
 function createMeshPrimitive(doc: Document, buffer: Buffer): Primitive {

--- a/packages/extensions/test/lights-punctual.test.ts
+++ b/packages/extensions/test/lights-punctual.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRLightsPunctual', () => {
+describe('extensions::KHRLightsPunctual', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const lightsExtension = document.createExtension(KHRLightsPunctual);

--- a/packages/extensions/test/lights-punctual.test.ts
+++ b/packages/extensions/test/lights-punctual.test.ts
@@ -1,130 +1,135 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRLightsPunctual, Light } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const document = new Document();
-	const lightsExtension = document.createExtension(KHRLightsPunctual);
-	const light = lightsExtension
-		.createLight()
-		.setType(Light.Type.SPOT)
-		.setIntensity(2.0)
-		.setColor([1, 2, 0])
-		.setRange(50)
-		.setInnerConeAngle(0.5)
-		.setOuterConeAngle(0.75);
+describe('KHRLightsPunctual', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const lightsExtension = document.createExtension(KHRLightsPunctual);
+		const light = lightsExtension
+			.createLight()
+			.setType(Light.Type.SPOT)
+			.setIntensity(2.0)
+			.setColor([1, 2, 0])
+			.setRange(50)
+			.setInnerConeAngle(0.5)
+			.setOuterConeAngle(0.75);
 
-	const node = document.createNode().setExtension('KHR_lights_punctual', light);
+		const node = document.createNode().setExtension('KHR_lights_punctual', light);
 
-	t.is(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
+		strictEqual(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).writeJSON(document, WRITER_OPTIONS);
-	const nodeDef = jsonDoc.json.nodes[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).writeJSON(document, WRITER_OPTIONS);
+		const nodeDef = jsonDoc.json.nodes[0];
 
-	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
-	t.deepEqual(jsonDoc.json.extensions, {
-		KHR_lights_punctual: {
-			lights: [
-				{
-					type: Light.Type.SPOT,
-					intensity: 2,
-					color: [1, 2, 0],
-					range: 50,
-					spot: {
-						innerConeAngle: 0.5,
-						outerConeAngle: 0.75,
+		deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
+		deepEqual(jsonDoc.json.extensions, {
+			KHR_lights_punctual: {
+				lights: [
+					{
+						type: Light.Type.SPOT,
+						intensity: 2,
+						color: [1, 2, 0],
+						range: 50,
+						spot: {
+							innerConeAngle: 0.5,
+							outerConeAngle: 0.75,
+						},
 					},
-				},
-			],
-		},
+				],
+			},
+		});
+
+		lightsExtension.dispose();
+		strictEqual(node.getExtension('KHR_lights_punctual'), null, 'light is detached');
+
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).readJSON(jsonDoc);
+		const roundtripNode = roundtripDoc.getRoot().listNodes().pop();
+		const light2 = roundtripNode.getExtension<Light>('KHR_lights_punctual');
+
+		strictEqual(light2.getType(), Light.Type.SPOT, 'reads type');
+		strictEqual(light2.getIntensity(), 2, 'reads intensity');
+		deepEqual(light2.getColor(), [1, 2, 0], 'reads color');
+		strictEqual(light2.getRange(), 50, 'reads range');
+		strictEqual(light2.getInnerConeAngle(), 0.5, 'reads innerConeAngle');
+		strictEqual(light2.getOuterConeAngle(), 0.75, 'reads outerConeAngle');
 	});
 
-	lightsExtension.dispose();
-	t.is(node.getExtension('KHR_lights_punctual'), null, 'light is detached');
+	test('copy', () => {
+		const document = new Document();
+		const lightsExtension = document.createExtension(KHRLightsPunctual);
+		const light = lightsExtension
+			.createLight()
+			.setType(Light.Type.SPOT)
+			.setIntensity(2.0)
+			.setColor([1, 2, 0])
+			.setRange(50)
+			.setInnerConeAngle(0.5)
+			.setOuterConeAngle(0.75);
+		document.createNode().setExtension('KHR_lights_punctual', light);
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRLightsPunctual]).readJSON(jsonDoc);
-	const roundtripNode = roundtripDoc.getRoot().listNodes().pop();
-	const light2 = roundtripNode.getExtension<Light>('KHR_lights_punctual');
-
-	t.is(light2.getType(), Light.Type.SPOT, 'reads type');
-	t.is(light2.getIntensity(), 2, 'reads intensity');
-	t.deepEqual(light2.getColor(), [1, 2, 0], 'reads color');
-	t.is(light2.getRange(), 50, 'reads range');
-	t.is(light2.getInnerConeAngle(), 0.5, 'reads innerConeAngle');
-	t.is(light2.getOuterConeAngle(), 0.75, 'reads outerConeAngle');
-});
-
-test('copy', (t) => {
-	const document = new Document();
-	const lightsExtension = document.createExtension(KHRLightsPunctual);
-	const light = lightsExtension
-		.createLight()
-		.setType(Light.Type.SPOT)
-		.setIntensity(2.0)
-		.setColor([1, 2, 0])
-		.setRange(50)
-		.setInnerConeAngle(0.5)
-		.setOuterConeAngle(0.75);
-	document.createNode().setExtension('KHR_lights_punctual', light);
-
-	const doc2 = cloneDocument(document);
-	const light2 = doc2.getRoot().listNodes()[0].getExtension<Light>('KHR_lights_punctual');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRLightsPunctual');
-	t.truthy(light2, 'copy light');
-	t.is(light2.getType(), Light.Type.SPOT, 'copy type');
-	t.is(light2.getIntensity(), 2, 'copy intensity');
-	t.deepEqual(light2.getColor(), [1, 2, 0], 'copy color');
-	t.is(light2.getRange(), 50, 'copy range');
-	t.is(light2.getInnerConeAngle(), 0.5, 'copy innerConeAngle');
-	t.is(light2.getOuterConeAngle(), 0.75, 'copy outerConeAngle');
-});
-
-test('i/o', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRLightsPunctual]);
-
-	const lightsExtension = document.createExtension(KHRLightsPunctual);
-	const light = lightsExtension.createLight().setType(Light.Type.POINT).setIntensity(2.0);
-
-	const node = document.createNode().setExtension('KHR_lights_punctual', light);
-
-	t.is(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
-
-	const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
-	const nodeDef = jsonDoc.json.nodes[0];
-
-	t.deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
-	t.deepEqual(jsonDoc.json.extensions, {
-		KHR_lights_punctual: {
-			lights: [{ type: 'point', intensity: 2 }], // omit range!
-		},
+		const doc2 = cloneDocument(document);
+		const light2 = doc2.getRoot().listNodes()[0].getExtension<Light>('KHR_lights_punctual');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRLightsPunctual');
+		ok(light2, 'copy light');
+		strictEqual(light2.getType(), Light.Type.SPOT, 'copy type');
+		strictEqual(light2.getIntensity(), 2, 'copy intensity');
+		deepEqual(light2.getColor(), [1, 2, 0], 'copy color');
+		strictEqual(light2.getRange(), 50, 'copy range');
+		strictEqual(light2.getInnerConeAngle(), 0.5, 'copy innerConeAngle');
+		strictEqual(light2.getOuterConeAngle(), 0.75, 'copy outerConeAngle');
 	});
-});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRLightsPunctual]);
+	test('i/o', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRLightsPunctual]);
 
-	const lightsExtension = document.createExtension(KHRLightsPunctual);
-	const light = lightsExtension.createLight().setExtras({ hello: 'world' });
+		const lightsExtension = document.createExtension(KHRLightsPunctual);
+		const light = lightsExtension.createLight().setType(Light.Type.POINT).setIntensity(2.0);
 
-	document.createNode().setExtension('KHR_lights_punctual', light);
+		const node = document.createNode().setExtension('KHR_lights_punctual', light);
 
-	const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
-	const lightsExtensionDef = jsonDoc.json.extensions['KHR_lights_punctual'] as { lights: Record<string, unknown>[] };
-	const lightDef = lightsExtensionDef.lights[0];
+		strictEqual(node.getExtension('KHR_lights_punctual'), light, 'light is attached');
 
-	t.deepEqual(lightDef.extras, { hello: 'world' }, 'writes light.extras');
+		const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
+		const nodeDef = jsonDoc.json.nodes[0];
 
-	const rtDocument = await io.readJSON(jsonDoc);
-	const rtLightsExtension = rtDocument.createExtension(KHRLightsPunctual);
-	const rtLight = rtLightsExtension.listProperties()[0] as Light;
+		deepEqual(nodeDef.extensions, { KHR_lights_punctual: { light: 0 } }, 'attaches light');
+		deepEqual(jsonDoc.json.extensions, {
+			KHR_lights_punctual: {
+				lights: [{ type: 'point', intensity: 2 }], // omit range!
+			},
+		});
+	});
 
-	t.deepEqual(rtLight.getExtras(), { hello: 'world' }, 'reads light.extras');
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRLightsPunctual]);
+
+		const lightsExtension = document.createExtension(KHRLightsPunctual);
+		const light = lightsExtension.createLight().setExtras({ hello: 'world' });
+
+		document.createNode().setExtension('KHR_lights_punctual', light);
+
+		const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
+		const lightsExtensionDef = jsonDoc.json.extensions['KHR_lights_punctual'] as {
+			lights: Record<string, unknown>[];
+		};
+		const lightDef = lightsExtensionDef.lights[0];
+
+		deepEqual(lightDef.extras, { hello: 'world' }, 'writes light.extras');
+
+		const rtDocument = await io.readJSON(jsonDoc);
+		const rtLightsExtension = rtDocument.createExtension(KHRLightsPunctual);
+		const rtLight = rtLightsExtension.listProperties()[0] as Light;
+
+		deepEqual(rtLight.getExtras(), { hello: 'world' }, 'reads light.extras');
+	});
 });

--- a/packages/extensions/test/materials-anisotropy.test.ts
+++ b/packages/extensions/test/materials-anisotropy.test.ts
@@ -1,132 +1,135 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { type Anisotropy, KHRMaterialsAnisotropy } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('factors', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsAnisotropy]);
+describe('KHRMaterialsAnisotropy', () => {
+	test('factors', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsAnisotropy]);
 
-	const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
-	const anisotropy = anisotropyExtension
-		.createAnisotropy()
-		.setAnisotropyStrength(0.9)
-		.setAnisotropyRotation(Math.PI / 3);
+		const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
+		const anisotropy = anisotropyExtension
+			.createAnisotropy()
+			.setAnisotropyStrength(0.9)
+			.setAnisotropyRotation(Math.PI / 3);
 
-	document
-		.createMaterial('MyAnisotropyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_anisotropy', anisotropy);
+		document
+			.createMaterial('MyAnisotropyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_anisotropy', anisotropy);
 
-	const roundtripDoc = await io.readJSON(await io.writeJSON(document));
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Anisotropy>('KHR_materials_anisotropy');
+		const roundtripDoc = await io.readJSON(await io.writeJSON(document));
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Anisotropy>('KHR_materials_anisotropy');
 
-	t.is(roundtripExt.getAnisotropyStrength(), 0.9, 'reads anisotropyStrength');
-	t.is(roundtripExt.getAnisotropyRotation(), Math.PI / 3, 'reads anisotropyRotation');
-});
+		strictEqual(roundtripExt.getAnisotropyStrength(), 0.9, 'reads anisotropyStrength');
+		strictEqual(roundtripExt.getAnisotropyRotation(), Math.PI / 3, 'reads anisotropyRotation');
+	});
 
-test('textures', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsAnisotropy]);
+	test('textures', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsAnisotropy]);
 
-	document.createBuffer();
-	const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
-	const anisotropy = anisotropyExtension
-		.createAnisotropy()
-		.setAnisotropyStrength(0.9)
-		.setAnisotropyRotation(Math.PI / 3)
-		.setAnisotropyTexture(document.createTexture().setImage(new Uint8Array(1)));
+		document.createBuffer();
+		const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
+		const anisotropy = anisotropyExtension
+			.createAnisotropy()
+			.setAnisotropyStrength(0.9)
+			.setAnisotropyRotation(Math.PI / 3)
+			.setAnisotropyTexture(document.createTexture().setImage(new Uint8Array(1)));
 
-	const material = document
-		.createMaterial('MyAnisotropyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_anisotropy', anisotropy);
+		const material = document
+			.createMaterial('MyAnisotropyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_anisotropy', anisotropy);
 
-	t.is(material.getExtension('KHR_materials_anisotropy'), anisotropy, 'anisotropy is attached');
+		strictEqual(material.getExtension('KHR_materials_anisotropy'), anisotropy, 'anisotropy is attached');
 
-	const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await io.writeJSON(document, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_anisotropy: {
-				anisotropyStrength: 0.9,
-				anisotropyRotation: Math.PI / 3,
-				anisotropyTexture: { index: 0 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_anisotropy: {
+					anisotropyStrength: 0.9,
+					anisotropyRotation: Math.PI / 3,
+					anisotropyTexture: { index: 0 },
+				},
 			},
-		},
-		'writes anisotropy extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsAnisotropy.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes anisotropy extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsAnisotropy.EXTENSION_NAME], 'writes extensionsUsed');
 
-	anisotropyExtension.dispose();
-	t.is(material.getExtension('KHR_materials_anisotropy'), null, 'anisotropy is detached');
+		anisotropyExtension.dispose();
+		strictEqual(material.getExtension('KHR_materials_anisotropy'), null, 'anisotropy is detached');
 
-	const roundtripDoc = await io.readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Anisotropy>('KHR_materials_anisotropy');
+		const roundtripDoc = await io.readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Anisotropy>('KHR_materials_anisotropy');
 
-	t.is(roundtripExt.getAnisotropyStrength(), 0.9, 'reads anisotropyStrength');
-	t.is(roundtripExt.getAnisotropyRotation(), Math.PI / 3, 'reads anisotropyRotation');
-	t.truthy(roundtripExt.getAnisotropyTexture(), 'reads anisotropyTexture');
-});
+		strictEqual(roundtripExt.getAnisotropyStrength(), 0.9, 'reads anisotropyStrength');
+		strictEqual(roundtripExt.getAnisotropyRotation(), Math.PI / 3, 'reads anisotropyRotation');
+		ok(roundtripExt.getAnisotropyTexture(), 'reads anisotropyTexture');
+	});
 
-test('disabled', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsAnisotropy]);
+	test('disabled', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsAnisotropy]);
 
-	document.createExtension(KHRMaterialsAnisotropy);
-	document.createMaterial();
+		document.createExtension(KHRMaterialsAnisotropy);
+		document.createMaterial();
 
-	const roundtripDoc = await io.readJSON(await io.writeJSON(document));
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	t.is(roundtripMat.getExtension('KHR_materials_anisotropy'), null, 'no effect when not attached');
-});
+		const roundtripDoc = await io.readJSON(await io.writeJSON(document));
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		strictEqual(roundtripMat.getExtension('KHR_materials_anisotropy'), null, 'no effect when not attached');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
-	const anisotropy = anisotropyExtension
-		.createAnisotropy()
-		.setAnisotropyStrength(0.9)
-		.setAnisotropyRotation(Math.PI / 3)
-		.setAnisotropyTexture(document.createTexture('ABC'));
-	document.createMaterial().setExtension('KHR_materials_anisotropy', anisotropy);
+	test('copy', () => {
+		const document = new Document();
+		const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
+		const anisotropy = anisotropyExtension
+			.createAnisotropy()
+			.setAnisotropyStrength(0.9)
+			.setAnisotropyRotation(Math.PI / 3)
+			.setAnisotropyTexture(document.createTexture('ABC'));
+		document.createMaterial().setExtension('KHR_materials_anisotropy', anisotropy);
 
-	const document2 = cloneDocument(document);
-	const anisotropy2 = document2.getRoot().listMaterials()[0].getExtension<Anisotropy>('KHR_materials_anisotropy');
-	t.is(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsAnisotropy');
-	t.truthy(anisotropy2, 'copy Anisotropy');
-	t.is(anisotropy2.getAnisotropyStrength(), 0.9, 'copy anisotropyStrength');
-	t.is(anisotropy2.getAnisotropyRotation(), Math.PI / 3, 'copy anisotropyRotation');
-	t.is(anisotropy2.getAnisotropyTexture().getName(), 'ABC', 'copy anisotropyTexture');
-});
+		const document2 = cloneDocument(document);
+		const anisotropy2 = document2.getRoot().listMaterials()[0].getExtension<Anisotropy>('KHR_materials_anisotropy');
+		strictEqual(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsAnisotropy');
+		ok(anisotropy2, 'copy Anisotropy');
+		strictEqual(anisotropy2.getAnisotropyStrength(), 0.9, 'copy anisotropyStrength');
+		strictEqual(anisotropy2.getAnisotropyRotation(), Math.PI / 3, 'copy anisotropyRotation');
+		strictEqual(anisotropy2.getAnisotropyTexture().getName(), 'ABC', 'copy anisotropyTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsAnisotropy]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsAnisotropy]);
 
-	const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
-	const anisotropy = anisotropyExtension.createAnisotropy().setExtras({ hello: 'world' });
+		const anisotropyExtension = document.createExtension(KHRMaterialsAnisotropy);
+		const anisotropy = anisotropyExtension.createAnisotropy().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_anisotropy', anisotropy);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_anisotropy', anisotropy);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Anisotropy>('KHR_materials_anisotropy');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Anisotropy>('KHR_materials_anisotropy');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-anisotropy.test.ts
+++ b/packages/extensions/test/materials-anisotropy.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsAnisotropy', () => {
+describe('extensions::KHRMaterialsAnisotropy', () => {
 	test('factors', async () => {
 		const document = new Document();
 		const io = await createPlatformIO();

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsClearcoat', () => {
+describe('extensions::KHRMaterialsClearcoat', () => {
 	test('factors', async () => {
 		const doc = new Document();
 		const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);

--- a/packages/extensions/test/materials-clearcoat.test.ts
+++ b/packages/extensions/test/materials-clearcoat.test.ts
@@ -1,135 +1,138 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type Clearcoat, KHRMaterialsClearcoat } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('factors', async (t) => {
-	const doc = new Document();
-	const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
-	const clearcoat = clearcoatExtension.createClearcoat().setClearcoatFactor(0.9).setClearcoatRoughnessFactor(0.1);
+describe('KHRMaterialsClearcoat', () => {
+	test('factors', async () => {
+		const doc = new Document();
+		const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
+		const clearcoat = clearcoatExtension.createClearcoat().setClearcoatFactor(0.9).setClearcoatRoughnessFactor(0.1);
 
-	doc.createMaterial('MyClearcoatMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_clearcoat', clearcoat);
+		doc.createMaterial('MyClearcoatMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_clearcoat', clearcoat);
 
-	const io = new NodeIO().registerExtensions([KHRMaterialsClearcoat]);
-	const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
+		const io = new NodeIO().registerExtensions([KHRMaterialsClearcoat]);
+		const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
 
-	t.is(roundtripExt.getClearcoatFactor(), 0.9, 'reads clearcoatFactor');
-	t.is(roundtripExt.getClearcoatRoughnessFactor(), 0.1, 'reads clearcoatFactor');
-});
+		strictEqual(roundtripExt.getClearcoatFactor(), 0.9, 'reads clearcoatFactor');
+		strictEqual(roundtripExt.getClearcoatRoughnessFactor(), 0.1, 'reads clearcoatFactor');
+	});
 
-test('textures', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
-	const clearcoat = clearcoatExtension
-		.createClearcoat()
-		.setClearcoatFactor(0.9)
-		.setClearcoatTexture(doc.createTexture().setImage(new Uint8Array(1)))
-		.setClearcoatRoughnessTexture(doc.createTexture().setImage(new Uint8Array(1)))
-		.setClearcoatNormalTexture(doc.createTexture().setImage(new Uint8Array(1)))
-		.setClearcoatNormalScale(2.0)
-		.setClearcoatRoughnessFactor(0.1);
+	test('textures', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
+		const clearcoat = clearcoatExtension
+			.createClearcoat()
+			.setClearcoatFactor(0.9)
+			.setClearcoatTexture(doc.createTexture().setImage(new Uint8Array(1)))
+			.setClearcoatRoughnessTexture(doc.createTexture().setImage(new Uint8Array(1)))
+			.setClearcoatNormalTexture(doc.createTexture().setImage(new Uint8Array(1)))
+			.setClearcoatNormalScale(2.0)
+			.setClearcoatRoughnessFactor(0.1);
 
-	const mat = doc
-		.createMaterial('MyClearcoatMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_clearcoat', clearcoat);
+		const mat = doc
+			.createMaterial('MyClearcoatMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_clearcoat', clearcoat);
 
-	t.is(mat.getExtension('KHR_materials_clearcoat'), clearcoat, 'clearcoat is attached');
+		strictEqual(mat.getExtension('KHR_materials_clearcoat'), clearcoat, 'clearcoat is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsClearcoat]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_clearcoat: {
-				clearcoatFactor: 0.9,
-				clearcoatRoughnessFactor: 0.1,
-				clearcoatTexture: { index: 0 },
-				clearcoatRoughnessTexture: { index: 1 },
-				clearcoatNormalTexture: { index: 2, scale: 2 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_clearcoat: {
+					clearcoatFactor: 0.9,
+					clearcoatRoughnessFactor: 0.1,
+					clearcoatTexture: { index: 0 },
+					clearcoatRoughnessTexture: { index: 1 },
+					clearcoatNormalTexture: { index: 2, scale: 2 },
+				},
 			},
-		},
-		'writes clearcoat extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsClearcoat.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes clearcoat extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsClearcoat.EXTENSION_NAME], 'writes extensionsUsed');
 
-	clearcoatExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_clearcoat'), null, 'clearcoat is detached');
+		clearcoatExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_clearcoat'), null, 'clearcoat is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsClearcoat]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsClearcoat]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Clearcoat>('KHR_materials_clearcoat');
 
-	t.is(roundtripExt.getClearcoatFactor(), 0.9, 'reads clearcoatFactor');
-	t.is(roundtripExt.getClearcoatRoughnessFactor(), 0.1, 'reads clearcoatFactor');
-	t.truthy(roundtripExt.getClearcoatTexture(), 'reads clearcoatTexture');
-	t.truthy(roundtripExt.getClearcoatRoughnessTexture(), 'reads clearcoatRoughnessTexture');
-	t.truthy(roundtripExt.getClearcoatNormalTexture(), 'reads clearcoatNormalTexture');
-	t.is(roundtripExt.getClearcoatNormalScale(), 2, 'reads clearcoatNormalScale');
-});
+		strictEqual(roundtripExt.getClearcoatFactor(), 0.9, 'reads clearcoatFactor');
+		strictEqual(roundtripExt.getClearcoatRoughnessFactor(), 0.1, 'reads clearcoatFactor');
+		ok(roundtripExt.getClearcoatTexture(), 'reads clearcoatTexture');
+		ok(roundtripExt.getClearcoatRoughnessTexture(), 'reads clearcoatRoughnessTexture');
+		ok(roundtripExt.getClearcoatNormalTexture(), 'reads clearcoatNormalTexture');
+		strictEqual(roundtripExt.getClearcoatNormalScale(), 2, 'reads clearcoatNormalScale');
+	});
 
-test('disabled', async (t) => {
-	const doc = new Document();
-	doc.createExtension(KHRMaterialsClearcoat);
-	doc.createMaterial();
+	test('disabled', async () => {
+		const doc = new Document();
+		doc.createExtension(KHRMaterialsClearcoat);
+		doc.createMaterial();
 
-	const io = new NodeIO().registerExtensions([KHRMaterialsClearcoat]);
-	const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	t.is(roundtripMat.getExtension('KHR_materials_clearcoat'), null, 'no effect when not attached');
-});
+		const io = new NodeIO().registerExtensions([KHRMaterialsClearcoat]);
+		const roundtripDoc = await io.readJSON(await io.writeJSON(doc));
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		strictEqual(roundtripMat.getExtension('KHR_materials_clearcoat'), null, 'no effect when not attached');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
-	const clearcoat = clearcoatExtension
-		.createClearcoat()
-		.setClearcoatFactor(0.9)
-		.setClearcoatRoughnessFactor(0.1)
-		.setClearcoatNormalScale(0.5)
-		.setClearcoatTexture(doc.createTexture('cc'))
-		.setClearcoatRoughnessTexture(doc.createTexture('ccrough'))
-		.setClearcoatNormalTexture(doc.createTexture('ccnormal'));
-	doc.createMaterial().setExtension('KHR_materials_clearcoat', clearcoat);
+	test('copy', () => {
+		const doc = new Document();
+		const clearcoatExtension = doc.createExtension(KHRMaterialsClearcoat);
+		const clearcoat = clearcoatExtension
+			.createClearcoat()
+			.setClearcoatFactor(0.9)
+			.setClearcoatRoughnessFactor(0.1)
+			.setClearcoatNormalScale(0.5)
+			.setClearcoatTexture(doc.createTexture('cc'))
+			.setClearcoatRoughnessTexture(doc.createTexture('ccrough'))
+			.setClearcoatNormalTexture(doc.createTexture('ccnormal'));
+		doc.createMaterial().setExtension('KHR_materials_clearcoat', clearcoat);
 
-	const doc2 = cloneDocument(doc);
-	const clearcoat2 = doc2.getRoot().listMaterials()[0].getExtension<Clearcoat>('KHR_materials_clearcoat');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsClearcoat');
-	t.truthy(clearcoat2, 'copy Clearcoat');
-	t.is(clearcoat2.getClearcoatFactor(), 0.9, 'copy clearcoatFactor');
-	t.is(clearcoat2.getClearcoatRoughnessFactor(), 0.1, 'copy clearcoatFactor');
-	t.is(clearcoat2.getClearcoatNormalScale(), 0.5, 'copy clearcoatFactor');
-	t.is(clearcoat2.getClearcoatTexture().getName(), 'cc', 'copy clearcoatTexture');
-	t.is(clearcoat2.getClearcoatRoughnessTexture().getName(), 'ccrough', 'copy clearcoatRoughnessTexture');
-	t.is(clearcoat2.getClearcoatNormalTexture().getName(), 'ccnormal', 'copy clearcoatNormalTexture');
-});
+		const doc2 = cloneDocument(doc);
+		const clearcoat2 = doc2.getRoot().listMaterials()[0].getExtension<Clearcoat>('KHR_materials_clearcoat');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsClearcoat');
+		ok(clearcoat2, 'copy Clearcoat');
+		strictEqual(clearcoat2.getClearcoatFactor(), 0.9, 'copy clearcoatFactor');
+		strictEqual(clearcoat2.getClearcoatRoughnessFactor(), 0.1, 'copy clearcoatFactor');
+		strictEqual(clearcoat2.getClearcoatNormalScale(), 0.5, 'copy clearcoatFactor');
+		strictEqual(clearcoat2.getClearcoatTexture().getName(), 'cc', 'copy clearcoatTexture');
+		strictEqual(clearcoat2.getClearcoatRoughnessTexture().getName(), 'ccrough', 'copy clearcoatRoughnessTexture');
+		strictEqual(clearcoat2.getClearcoatNormalTexture().getName(), 'ccnormal', 'copy clearcoatNormalTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsClearcoat]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsClearcoat]);
 
-	const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
-	const clearcoat = clearcoatExtension.createClearcoat().setExtras({ hello: 'world' });
+		const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
+		const clearcoat = clearcoatExtension.createClearcoat().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_clearcoat', clearcoat);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_clearcoat', clearcoat);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Clearcoat>('KHR_materials_clearcoat');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Clearcoat>('KHR_materials_clearcoat');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-diffuse-transmission.test.ts
+++ b/packages/extensions/test/materials-diffuse-transmission.test.ts
@@ -1,99 +1,108 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type DiffuseTransmission, KHRMaterialsDiffuseTransmission } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const document = new Document();
-	document.createBuffer();
-	const transmissionExtension = document.createExtension(KHRMaterialsDiffuseTransmission);
-	const transmission = transmissionExtension
-		.createDiffuseTransmission()
-		.setDiffuseTransmissionFactor(0.9)
-		.setDiffuseTransmissionTexture(document.createTexture().setImage(new Uint8Array(1)));
+describe('KHRMaterialsDiffuseTransmission', () => {
+	test('basic', async () => {
+		const document = new Document();
+		document.createBuffer();
+		const transmissionExtension = document.createExtension(KHRMaterialsDiffuseTransmission);
+		const transmission = transmissionExtension
+			.createDiffuseTransmission()
+			.setDiffuseTransmissionFactor(0.9)
+			.setDiffuseTransmissionTexture(document.createTexture().setImage(new Uint8Array(1)));
 
-	const mat = document
-		.createMaterial('MyDiffuseTransmissionMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_diffuse_transmission', transmission);
+		const mat = document
+			.createMaterial('MyDiffuseTransmissionMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_diffuse_transmission', transmission);
 
-	t.is(mat.getExtension('KHR_materials_diffuse_transmission'), transmission, 'diffuse transmission is attached');
+		strictEqual(
+			mat.getExtension('KHR_materials_diffuse_transmission'),
+			transmission,
+			'diffuse transmission is attached',
+		);
 
-	const jsonDocument = await new NodeIO()
-		.registerExtensions([KHRMaterialsDiffuseTransmission])
-		.writeJSON(document, WRITER_OPTIONS);
-	const materialDef = jsonDocument.json.materials[0];
+		const jsonDocument = await new NodeIO()
+			.registerExtensions([KHRMaterialsDiffuseTransmission])
+			.writeJSON(document, WRITER_OPTIONS);
+		const materialDef = jsonDocument.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_diffuse_transmission: {
-				diffuseTransmissionFactor: 0.9,
-				diffuseTransmissionColorFactor: [1, 1, 1],
-				diffuseTransmissionTexture: { index: 0 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_diffuse_transmission: {
+					diffuseTransmissionFactor: 0.9,
+					diffuseTransmissionColorFactor: [1, 1, 1],
+					diffuseTransmissionTexture: { index: 0 },
+				},
 			},
-		},
-		'writes transmission extension',
-	);
-	t.deepEqual(
-		jsonDocument.json.extensionsUsed,
-		[KHRMaterialsDiffuseTransmission.EXTENSION_NAME],
-		'writes extensionsUsed',
-	);
+			'writes transmission extension',
+		);
+		deepEqual(
+			jsonDocument.json.extensionsUsed,
+			[KHRMaterialsDiffuseTransmission.EXTENSION_NAME],
+			'writes extensionsUsed',
+		);
 
-	transmissionExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_diffuse_transmission'), null, 'diffuse transmission is detached');
+		transmissionExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_diffuse_transmission'), null, 'diffuse transmission is detached');
 
-	const roundtripDocument = await new NodeIO()
-		.registerExtensions([KHRMaterialsDiffuseTransmission])
-		.readJSON(jsonDocument);
-	const roundtripMat = roundtripDocument.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<DiffuseTransmission>('KHR_materials_diffuse_transmission');
+		const roundtripDocument = await new NodeIO()
+			.registerExtensions([KHRMaterialsDiffuseTransmission])
+			.readJSON(jsonDocument);
+		const roundtripMat = roundtripDocument.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<DiffuseTransmission>('KHR_materials_diffuse_transmission');
 
-	t.is(roundtripExt.getDiffuseTransmissionFactor(), 0.9, 'reads diffuseTransmissionFactor');
-	t.truthy(roundtripExt.getDiffuseTransmissionTexture(), 'reads diffuseTransmissionTexture');
-});
+		strictEqual(roundtripExt.getDiffuseTransmissionFactor(), 0.9, 'reads diffuseTransmissionFactor');
+		ok(roundtripExt.getDiffuseTransmissionTexture(), 'reads diffuseTransmissionTexture');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const diffuseTransmissionExtension = document.createExtension(KHRMaterialsDiffuseTransmission);
-	const diffuseTransmission = diffuseTransmissionExtension
-		.createDiffuseTransmission()
-		.setDiffuseTransmissionFactor(0.9)
-		.setDiffuseTransmissionTexture(document.createTexture('trns'));
-	document.createMaterial().setExtension('KHR_materials_diffuse_transmission', diffuseTransmission);
+	test('copy', () => {
+		const document = new Document();
+		const diffuseTransmissionExtension = document.createExtension(KHRMaterialsDiffuseTransmission);
+		const diffuseTransmission = diffuseTransmissionExtension
+			.createDiffuseTransmission()
+			.setDiffuseTransmissionFactor(0.9)
+			.setDiffuseTransmissionTexture(document.createTexture('trns'));
+		document.createMaterial().setExtension('KHR_materials_diffuse_transmission', diffuseTransmission);
 
-	const document2 = cloneDocument(document);
-	const diffuseTransmission2 = document2
-		.getRoot()
-		.listMaterials()[0]
-		.getExtension<DiffuseTransmission>('KHR_materials_diffuse_transmission');
-	t.is(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsDiffuseTransmission');
-	t.truthy(diffuseTransmission2, 'copy Transmission');
-	t.is(diffuseTransmission2.getDiffuseTransmissionFactor(), 0.9, 'copy transmissionFactor');
-	t.is(diffuseTransmission2.getDiffuseTransmissionTexture().getName(), 'trns', 'copy transmissionTexture');
-});
+		const document2 = cloneDocument(document);
+		const diffuseTransmission2 = document2
+			.getRoot()
+			.listMaterials()[0]
+			.getExtension<DiffuseTransmission>('KHR_materials_diffuse_transmission');
+		strictEqual(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsDiffuseTransmission');
+		ok(diffuseTransmission2, 'copy Transmission');
+		strictEqual(diffuseTransmission2.getDiffuseTransmissionFactor(), 0.9, 'copy transmissionFactor');
+		strictEqual(diffuseTransmission2.getDiffuseTransmissionTexture().getName(), 'trns', 'copy transmissionTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsDiffuseTransmission]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsDiffuseTransmission]);
 
-	const diffuseTransmissionExtension = document.createExtension(KHRMaterialsDiffuseTransmission);
-	const diffuseTransmission = diffuseTransmissionExtension.createDiffuseTransmission().setExtras({ hello: 'world' });
+		const diffuseTransmissionExtension = document.createExtension(KHRMaterialsDiffuseTransmission);
+		const diffuseTransmission = diffuseTransmissionExtension
+			.createDiffuseTransmission()
+			.setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_diffuse_transmission', diffuseTransmission);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_diffuse_transmission', diffuseTransmission);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<DiffuseTransmission>('KHR_materials_diffuse_transmission');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<DiffuseTransmission>('KHR_materials_diffuse_transmission');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-diffuse-transmission.test.ts
+++ b/packages/extensions/test/materials-diffuse-transmission.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsDiffuseTransmission', () => {
+describe('extensions::KHRMaterialsDiffuseTransmission', () => {
 	test('basic', async () => {
 		const document = new Document();
 		document.createBuffer();

--- a/packages/extensions/test/materials-dispersion.test.ts
+++ b/packages/extensions/test/materials-dispersion.test.ts
@@ -1,72 +1,79 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type Dispersion, KHRMaterialsDispersion } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const dispersionExtension = doc.createExtension(KHRMaterialsDispersion);
-	const dispersion = dispersionExtension.createDispersion().setDispersion(1.2);
+describe('KHRMaterialsDispersion', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const dispersionExtension = doc.createExtension(KHRMaterialsDispersion);
+		const dispersion = dispersionExtension.createDispersion().setDispersion(1.2);
 
-	const mat = doc
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_dispersion', dispersion);
+		const mat = doc
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_dispersion', dispersion);
 
-	t.is(mat.getExtension('KHR_materials_dispersion'), dispersion, 'dispersion is attached');
+		strictEqual(mat.getExtension('KHR_materials_dispersion'), dispersion, 'dispersion is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsDispersion]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsDispersion]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{ KHR_materials_dispersion: { dispersion: 1.2 } },
-		'writes dispersion extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsDispersion.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{ KHR_materials_dispersion: { dispersion: 1.2 } },
+			'writes dispersion extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsDispersion.EXTENSION_NAME], 'writes extensionsUsed');
 
-	dispersionExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_dispersion'), null, 'dispersion is detached');
+		dispersionExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_dispersion'), null, 'dispersion is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsDispersion]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsDispersion]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
-	t.is(roundtripMat.getExtension<Dispersion>('KHR_materials_dispersion').getDispersion(), 1.2, 'reads dispersion');
-});
+		strictEqual(
+			roundtripMat.getExtension<Dispersion>('KHR_materials_dispersion').getDispersion(),
+			1.2,
+			'reads dispersion',
+		);
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const dispersionExtension = document.createExtension(KHRMaterialsDispersion);
-	const dispersion = dispersionExtension.createDispersion().setDispersion(1.2);
-	document.createMaterial().setExtension('KHR_materials_dispersion', dispersion);
+	test('copy', () => {
+		const document = new Document();
+		const dispersionExtension = document.createExtension(KHRMaterialsDispersion);
+		const dispersion = dispersionExtension.createDispersion().setDispersion(1.2);
+		document.createMaterial().setExtension('KHR_materials_dispersion', dispersion);
 
-	const document2 = cloneDocument(document);
-	const dispersion2 = document2.getRoot().listMaterials()[0].getExtension<Dispersion>('KHR_materials_dispersion');
-	t.is(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsDispersion');
-	t.truthy(dispersion2, 'copy dispersion');
-	t.is(dispersion2.getDispersion(), 1.2, 'copy dispersion');
-});
+		const document2 = cloneDocument(document);
+		const dispersion2 = document2.getRoot().listMaterials()[0].getExtension<Dispersion>('KHR_materials_dispersion');
+		strictEqual(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsDispersion');
+		ok(dispersion2, 'copy dispersion');
+		strictEqual(dispersion2.getDispersion(), 1.2, 'copy dispersion');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsDispersion]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsDispersion]);
 
-	const dispersionExtension = document.createExtension(KHRMaterialsDispersion);
-	const dispersion = dispersionExtension.createDispersion().setExtras({ hello: 'world' });
+		const dispersionExtension = document.createExtension(KHRMaterialsDispersion);
+		const dispersion = dispersionExtension.createDispersion().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_dispersion', dispersion);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_dispersion', dispersion);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Dispersion>('KHR_materials_dispersion');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Dispersion>('KHR_materials_dispersion');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-dispersion.test.ts
+++ b/packages/extensions/test/materials-dispersion.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsDispersion', () => {
+describe('extensions::KHRMaterialsDispersion', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const dispersionExtension = doc.createExtension(KHRMaterialsDispersion);

--- a/packages/extensions/test/materials-emissive-strength.test.ts
+++ b/packages/extensions/test/materials-emissive-strength.test.ts
@@ -1,81 +1,88 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type EmissiveStrength, KHRMaterialsEmissiveStrength } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);
-	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
+describe('KHRMaterialsEmissiveStrength', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);
+		const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
 
-	const mat = doc
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_emissive_strength', emissiveStrength);
+		const mat = doc
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_emissive_strength', emissiveStrength);
 
-	t.is(mat.getExtension('KHR_materials_emissive_strength'), emissiveStrength, 'emissive strength is attached');
+		strictEqual(
+			mat.getExtension('KHR_materials_emissive_strength'),
+			emissiveStrength,
+			'emissive strength is attached',
+		);
 
-	const jsonDoc = await new NodeIO()
-		.registerExtensions([KHRMaterialsEmissiveStrength])
-		.writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO()
+			.registerExtensions([KHRMaterialsEmissiveStrength])
+			.writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{ KHR_materials_emissive_strength: { emissiveStrength: 5.0 } },
-		'writes emissive strength extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsEmissiveStrength.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{ KHR_materials_emissive_strength: { emissiveStrength: 5.0 } },
+			'writes emissive strength extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsEmissiveStrength.EXTENSION_NAME], 'writes extensionsUsed');
 
-	emissiveStrengthExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_emissive_strength'), null, 'emissive strength is detached');
+		emissiveStrengthExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_emissive_strength'), null, 'emissive strength is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsEmissiveStrength]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsEmissiveStrength]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
-	t.is(
-		roundtripMat.getExtension<EmissiveStrength>('KHR_materials_emissive_strength').getEmissiveStrength(),
-		5.0,
-		'reads emissive strength',
-	);
-});
+		strictEqual(
+			roundtripMat.getExtension<EmissiveStrength>('KHR_materials_emissive_strength').getEmissiveStrength(),
+			5.0,
+			'reads emissive strength',
+		);
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);
-	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
-	doc.createMaterial().setExtension('KHR_materials_emissive_strength', emissiveStrength);
+	test('copy', () => {
+		const doc = new Document();
+		const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);
+		const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setEmissiveStrength(5.0);
+		doc.createMaterial().setExtension('KHR_materials_emissive_strength', emissiveStrength);
 
-	const doc2 = cloneDocument(doc);
-	const emissiveStrength2 = doc2
-		.getRoot()
-		.listMaterials()[0]
-		.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsEmissiveStrength');
-	t.truthy(emissiveStrength2, 'copy EmissiveStrength');
-	t.is(emissiveStrength2.getEmissiveStrength(), 5.0, 'copy emissive strength');
-});
+		const doc2 = cloneDocument(doc);
+		const emissiveStrength2 = doc2
+			.getRoot()
+			.listMaterials()[0]
+			.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsEmissiveStrength');
+		ok(emissiveStrength2, 'copy EmissiveStrength');
+		strictEqual(emissiveStrength2.getEmissiveStrength(), 5.0, 'copy emissive strength');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsEmissiveStrength]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsEmissiveStrength]);
 
-	const emissiveStrengthExtension = document.createExtension(KHRMaterialsEmissiveStrength);
-	const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setExtras({ hello: 'world' });
+		const emissiveStrengthExtension = document.createExtension(KHRMaterialsEmissiveStrength);
+		const emissiveStrength = emissiveStrengthExtension.createEmissiveStrength().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_emissive_strength', emissiveStrength);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_emissive_strength', emissiveStrength);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<EmissiveStrength>('KHR_materials_emissive_strength');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-emissive-strength.test.ts
+++ b/packages/extensions/test/materials-emissive-strength.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsEmissiveStrength', () => {
+describe('extensions::KHRMaterialsEmissiveStrength', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const emissiveStrengthExtension = doc.createExtension(KHRMaterialsEmissiveStrength);

--- a/packages/extensions/test/materials-ior.test.ts
+++ b/packages/extensions/test/materials-ior.test.ts
@@ -1,68 +1,71 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type IOR, KHRMaterialsIOR } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const iorExtension = doc.createExtension(KHRMaterialsIOR);
-	const ior = iorExtension.createIOR().setIOR(1.2);
+describe('KHRMaterialsIOR', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const iorExtension = doc.createExtension(KHRMaterialsIOR);
+		const ior = iorExtension.createIOR().setIOR(1.2);
 
-	const mat = doc
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_ior', ior);
+		const mat = doc
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_ior', ior);
 
-	t.is(mat.getExtension('KHR_materials_ior'), ior, 'ior is attached');
+		strictEqual(mat.getExtension('KHR_materials_ior'), ior, 'ior is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsIOR]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(materialDef.extensions, { KHR_materials_ior: { ior: 1.2 } }, 'writes ior extension');
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsIOR.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(materialDef.extensions, { KHR_materials_ior: { ior: 1.2 } }, 'writes ior extension');
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsIOR.EXTENSION_NAME], 'writes extensionsUsed');
 
-	iorExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_ior'), null, 'ior is detached');
+		iorExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_ior'), null, 'ior is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsIOR]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsIOR]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
 
-	t.is(roundtripMat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1.2, 'reads ior');
-});
+		strictEqual(roundtripMat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1.2, 'reads ior');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const iorExtension = doc.createExtension(KHRMaterialsIOR);
-	const ior = iorExtension.createIOR().setIOR(1.2);
-	doc.createMaterial().setExtension('KHR_materials_ior', ior);
+	test('copy', () => {
+		const doc = new Document();
+		const iorExtension = doc.createExtension(KHRMaterialsIOR);
+		const ior = iorExtension.createIOR().setIOR(1.2);
+		doc.createMaterial().setExtension('KHR_materials_ior', ior);
 
-	const doc2 = cloneDocument(doc);
-	const ior2 = doc2.getRoot().listMaterials()[0].getExtension<IOR>('KHR_materials_ior');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIOR');
-	t.truthy(ior2, 'copy IOR');
-	t.is(ior2.getIOR(), 1.2, 'copy ior');
-});
+		const doc2 = cloneDocument(doc);
+		const ior2 = doc2.getRoot().listMaterials()[0].getExtension<IOR>('KHR_materials_ior');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIOR');
+		ok(ior2, 'copy IOR');
+		strictEqual(ior2.getIOR(), 1.2, 'copy ior');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsIOR]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsIOR]);
 
-	const iorExtension = document.createExtension(KHRMaterialsIOR);
-	const ior = iorExtension.createIOR().setExtras({ hello: 'world' });
+		const iorExtension = document.createExtension(KHRMaterialsIOR);
+		const ior = iorExtension.createIOR().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_ior', ior);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_ior', ior);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<IOR>('KHR_materials_ior');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<IOR>('KHR_materials_ior');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-ior.test.ts
+++ b/packages/extensions/test/materials-ior.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsIOR', () => {
+describe('extensions::KHRMaterialsIOR', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const iorExtension = doc.createExtension(KHRMaterialsIOR);

--- a/packages/extensions/test/materials-iridescence.test.ts
+++ b/packages/extensions/test/materials-iridescence.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsIridescence', () => {
+describe('extensions::KHRMaterialsIridescence', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/materials-iridescence.test.ts
+++ b/packages/extensions/test/materials-iridescence.test.ts
@@ -1,111 +1,114 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type Iridescence, KHRMaterialsIridescence } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const iridescenceExtension = doc.createExtension(KHRMaterialsIridescence);
-	const iridescence = iridescenceExtension
-		.createIridescence()
-		.setIridescenceFactor(0.9)
-		.setIridescenceIOR(1.5)
-		.setIridescenceThicknessMinimum(50)
-		.setIridescenceThicknessMaximum(500)
-		.setIridescenceTexture(doc.createTexture().setImage(new Uint8Array(1)))
-		.setIridescenceThicknessTexture(doc.createTexture().setImage(new Uint8Array(1)));
+describe('KHRMaterialsIridescence', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const iridescenceExtension = doc.createExtension(KHRMaterialsIridescence);
+		const iridescence = iridescenceExtension
+			.createIridescence()
+			.setIridescenceFactor(0.9)
+			.setIridescenceIOR(1.5)
+			.setIridescenceThicknessMinimum(50)
+			.setIridescenceThicknessMaximum(500)
+			.setIridescenceTexture(doc.createTexture().setImage(new Uint8Array(1)))
+			.setIridescenceThicknessTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
-	const mat = doc
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_iridescence', iridescence);
+		const mat = doc
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_iridescence', iridescence);
 
-	t.is(mat.getExtension('KHR_materials_iridescence'), iridescence, 'iridescence is attached');
+		strictEqual(mat.getExtension('KHR_materials_iridescence'), iridescence, 'iridescence is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsIridescence]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsIridescence]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_iridescence: {
-				iridescenceFactor: 0.9,
-				iridescenceIor: 1.5,
-				iridescenceThicknessMinimum: 50,
-				iridescenceThicknessMaximum: 500,
-				iridescenceTexture: { index: 0 },
-				iridescenceThicknessTexture: { index: 1 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_iridescence: {
+					iridescenceFactor: 0.9,
+					iridescenceIor: 1.5,
+					iridescenceThicknessMinimum: 50,
+					iridescenceThicknessMaximum: 500,
+					iridescenceTexture: { index: 0 },
+					iridescenceThicknessTexture: { index: 1 },
+				},
 			},
-		},
-		'writes iridescence extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsIridescence.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes iridescence extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsIridescence.EXTENSION_NAME], 'writes extensionsUsed');
 
-	iridescenceExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_iridescence'), null, 'iridescence is detached');
+		iridescenceExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_iridescence'), null, 'iridescence is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsIridescence]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Iridescence>('KHR_materials_iridescence');
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsIridescence]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Iridescence>('KHR_materials_iridescence');
 
-	t.is(roundtripExt.getIridescenceFactor(), 0.9, 'reads iridescenceFactor');
-	t.is(roundtripExt.getIridescenceIOR(), 1.5, 'reads iridescenceIOR');
-	t.is(roundtripExt.getIridescenceThicknessMinimum(), 50, 'reads iridescenceThicknessMinimum');
-	t.is(roundtripExt.getIridescenceThicknessMaximum(), 500, 'reads iridescenceThicknessMaximum');
-	t.truthy(roundtripExt.getIridescenceTexture(), 'reads iridescenceTexture');
-	t.truthy(roundtripExt.getIridescenceThicknessTexture(), 'reads iridescenceThicknessTexture');
-});
+		strictEqual(roundtripExt.getIridescenceFactor(), 0.9, 'reads iridescenceFactor');
+		strictEqual(roundtripExt.getIridescenceIOR(), 1.5, 'reads iridescenceIOR');
+		strictEqual(roundtripExt.getIridescenceThicknessMinimum(), 50, 'reads iridescenceThicknessMinimum');
+		strictEqual(roundtripExt.getIridescenceThicknessMaximum(), 500, 'reads iridescenceThicknessMaximum');
+		ok(roundtripExt.getIridescenceTexture(), 'reads iridescenceTexture');
+		ok(roundtripExt.getIridescenceThicknessTexture(), 'reads iridescenceThicknessTexture');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const iridescenceExtension = doc.createExtension(KHRMaterialsIridescence);
-	const iridescence = iridescenceExtension
-		.createIridescence()
-		.setIridescenceFactor(0.9)
-		.setIridescenceIOR(1.5)
-		.setIridescenceThicknessMinimum(50)
-		.setIridescenceThicknessMaximum(500)
-		.setIridescenceTexture(doc.createTexture('iridescence'))
-		.setIridescenceThicknessTexture(doc.createTexture('iridescenceThickness'));
-	doc.createMaterial().setExtension('KHR_materials_iridescence', iridescence);
+	test('copy', () => {
+		const doc = new Document();
+		const iridescenceExtension = doc.createExtension(KHRMaterialsIridescence);
+		const iridescence = iridescenceExtension
+			.createIridescence()
+			.setIridescenceFactor(0.9)
+			.setIridescenceIOR(1.5)
+			.setIridescenceThicknessMinimum(50)
+			.setIridescenceThicknessMaximum(500)
+			.setIridescenceTexture(doc.createTexture('iridescence'))
+			.setIridescenceThicknessTexture(doc.createTexture('iridescenceThickness'));
+		doc.createMaterial().setExtension('KHR_materials_iridescence', iridescence);
 
-	const doc2 = cloneDocument(doc);
-	const iridescence2 = doc2.getRoot().listMaterials()[0].getExtension<Iridescence>('KHR_materials_iridescence');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIridescence');
-	t.truthy(iridescence2, 'copy Iridescence');
-	t.is(iridescence2.getIridescenceFactor(), 0.9, 'copy iridescenceFactor');
-	t.is(iridescence2.getIridescenceIOR(), 1.5, 'copy iridescenceIOR');
-	t.is(iridescence2.getIridescenceThicknessMinimum(), 50, 'copy iridescenceThicknessMinimum');
-	t.is(iridescence2.getIridescenceThicknessMaximum(), 500, 'copy iridescenceThicknessMaximum');
-	t.is(iridescence2.getIridescenceTexture().getName(), 'iridescence', 'copy iridescenceTexture');
-	t.is(
-		iridescence2.getIridescenceThicknessTexture().getName(),
-		'iridescenceThickness',
-		'copy iridescenceThicknessTexture',
-	);
-});
+		const doc2 = cloneDocument(doc);
+		const iridescence2 = doc2.getRoot().listMaterials()[0].getExtension<Iridescence>('KHR_materials_iridescence');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsIridescence');
+		ok(iridescence2, 'copy Iridescence');
+		strictEqual(iridescence2.getIridescenceFactor(), 0.9, 'copy iridescenceFactor');
+		strictEqual(iridescence2.getIridescenceIOR(), 1.5, 'copy iridescenceIOR');
+		strictEqual(iridescence2.getIridescenceThicknessMinimum(), 50, 'copy iridescenceThicknessMinimum');
+		strictEqual(iridescence2.getIridescenceThicknessMaximum(), 500, 'copy iridescenceThicknessMaximum');
+		strictEqual(iridescence2.getIridescenceTexture().getName(), 'iridescence', 'copy iridescenceTexture');
+		strictEqual(
+			iridescence2.getIridescenceThicknessTexture().getName(),
+			'iridescenceThickness',
+			'copy iridescenceThicknessTexture',
+		);
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsIridescence]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsIridescence]);
 
-	const iridescenceExtension = document.createExtension(KHRMaterialsIridescence);
-	const iridescence = iridescenceExtension.createIridescence().setExtras({ hello: 'world' });
+		const iridescenceExtension = document.createExtension(KHRMaterialsIridescence);
+		const iridescence = iridescenceExtension.createIridescence().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_iridescence', iridescence);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_iridescence', iridescence);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Iridescence>('KHR_materials_iridescence');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Iridescence>('KHR_materials_iridescence');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsPBRSpecularGlossiness', () => {
+describe('extensions::KHRMaterialsPBRSpecularGlossiness', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
+++ b/packages/extensions/test/materials-pbr-specular-glossiness.test.ts
@@ -1,102 +1,107 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsPBRSpecularGlossiness, type PBRSpecularGlossiness } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
-	const specGloss = specGlossExtension
-		.createPBRSpecularGlossiness()
-		.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
-		.setSpecularFactor([0.9, 0.5, 0.8])
-		.setGlossinessFactor(0.5)
-		.setSpecularGlossinessTexture(doc.createTexture().setImage(new Uint8Array(1)));
+describe('KHRMaterialsPBRSpecularGlossiness', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
+		const specGloss = specGlossExtension
+			.createPBRSpecularGlossiness()
+			.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
+			.setSpecularFactor([0.9, 0.5, 0.8])
+			.setGlossinessFactor(0.5)
+			.setSpecularGlossinessTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
-	const mat = doc.createMaterial('MyMaterial').setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
+		const mat = doc.createMaterial('MyMaterial').setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 
-	t.is(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), specGloss, 'specGloss is attached');
+		strictEqual(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), specGloss, 'specGloss is attached');
 
-	const jsonDoc = await new NodeIO()
-		.registerExtensions([KHRMaterialsPBRSpecularGlossiness])
-		.writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO()
+			.registerExtensions([KHRMaterialsPBRSpecularGlossiness])
+			.writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_pbrSpecularGlossiness: {
-				diffuseFactor: [0.5, 0.5, 0.5, 0.9],
-				specularFactor: [0.9, 0.5, 0.8],
-				glossinessFactor: 0.5,
-				specularGlossinessTexture: { index: 0 },
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_pbrSpecularGlossiness: {
+					diffuseFactor: [0.5, 0.5, 0.5, 0.9],
+					specularFactor: [0.9, 0.5, 0.8],
+					glossinessFactor: 0.5,
+					specularGlossinessTexture: { index: 0 },
+				},
 			},
-		},
-		'writes specGloss extension',
-	);
-	t.deepEqual(
-		jsonDoc.json.extensionsUsed,
-		[KHRMaterialsPBRSpecularGlossiness.EXTENSION_NAME],
-		'writes extensionsUsed',
-	);
+			'writes specGloss extension',
+		);
+		deepEqual(
+			jsonDoc.json.extensionsUsed,
+			[KHRMaterialsPBRSpecularGlossiness.EXTENSION_NAME],
+			'writes extensionsUsed',
+		);
 
-	specGlossExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), null, 'specGloss is detached');
+		specGlossExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_pbrSpecularGlossiness'), null, 'specGloss is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsPBRSpecularGlossiness]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
+		const roundtripDoc = await new NodeIO()
+			.registerExtensions([KHRMaterialsPBRSpecularGlossiness])
+			.readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
 
-	t.deepEqual(roundtripExt.getDiffuseFactor(), [0.5, 0.5, 0.5, 0.9], 'reads diffuseFactor');
-	t.deepEqual(roundtripExt.getSpecularFactor(), [0.9, 0.5, 0.8], 'reads specularFactor');
-	t.is(roundtripExt.getGlossinessFactor(), 0.5, 'reads glossinessFactor');
-	t.truthy(roundtripExt.getSpecularGlossinessTexture(), 'reads specularGlossinessTexture');
-});
+		deepEqual(roundtripExt.getDiffuseFactor(), [0.5, 0.5, 0.5, 0.9], 'reads diffuseFactor');
+		deepEqual(roundtripExt.getSpecularFactor(), [0.9, 0.5, 0.8], 'reads specularFactor');
+		strictEqual(roundtripExt.getGlossinessFactor(), 0.5, 'reads glossinessFactor');
+		ok(roundtripExt.getSpecularGlossinessTexture(), 'reads specularGlossinessTexture');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
-	const specGloss = specGlossExtension
-		.createPBRSpecularGlossiness()
-		.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
-		.setSpecularFactor([0.9, 0.5, 0.8])
-		.setGlossinessFactor(0.5)
-		.setSpecularGlossinessTexture(doc.createTexture('specGloss'));
-	doc.createMaterial().setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
+	test('copy', () => {
+		const doc = new Document();
+		const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
+		const specGloss = specGlossExtension
+			.createPBRSpecularGlossiness()
+			.setDiffuseFactor([0.5, 0.5, 0.5, 0.9])
+			.setSpecularFactor([0.9, 0.5, 0.8])
+			.setGlossinessFactor(0.5)
+			.setSpecularGlossinessTexture(doc.createTexture('specGloss'));
+		doc.createMaterial().setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 
-	const doc2 = cloneDocument(doc);
-	const specGloss2 = doc2
-		.getRoot()
-		.listMaterials()[0]
-		.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsPBRSpecularGlossiness');
-	t.truthy(specGloss2, 'copy PBRSpecularGlossiness');
-	t.deepEqual(specGloss2.getDiffuseFactor(), [0.5, 0.5, 0.5, 0.9], 'copy diffuseFactor');
-	t.deepEqual(specGloss2.getSpecularFactor(), [0.9, 0.5, 0.8], 'copy specularFactor');
-	t.is(specGloss2.getGlossinessFactor(), 0.5, 'copy glossinessFactor');
-	t.is(specGloss2.getSpecularGlossinessTexture().getName(), 'specGloss', 'copy specularGlossinessTexture');
-});
+		const doc2 = cloneDocument(doc);
+		const specGloss2 = doc2
+			.getRoot()
+			.listMaterials()[0]
+			.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsPBRSpecularGlossiness');
+		ok(specGloss2, 'copy PBRSpecularGlossiness');
+		deepEqual(specGloss2.getDiffuseFactor(), [0.5, 0.5, 0.5, 0.9], 'copy diffuseFactor');
+		deepEqual(specGloss2.getSpecularFactor(), [0.9, 0.5, 0.8], 'copy specularFactor');
+		strictEqual(specGloss2.getGlossinessFactor(), 0.5, 'copy glossinessFactor');
+		strictEqual(specGloss2.getSpecularGlossinessTexture().getName(), 'specGloss', 'copy specularGlossinessTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsPBRSpecularGlossiness]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsPBRSpecularGlossiness]);
 
-	const specGlossExtension = document.createExtension(KHRMaterialsPBRSpecularGlossiness);
-	const specGloss = specGlossExtension.createPBRSpecularGlossiness().setExtras({ hello: 'world' });
+		const specGlossExtension = document.createExtension(KHRMaterialsPBRSpecularGlossiness);
+		const specGloss = specGlossExtension.createPBRSpecularGlossiness().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<PBRSpecularGlossiness>('KHR_materials_pbrSpecularGlossiness');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -1,88 +1,91 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsSheen, type Sheen } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const sheenExtension = doc.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension
-		.createSheen()
-		.setSheenColorFactor([0.9, 0.5, 0.8])
-		.setSheenColorTexture(doc.createTexture().setImage(new Uint8Array(1)));
+describe('KHRMaterialsSheen', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const sheenExtension = doc.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension
+			.createSheen()
+			.setSheenColorFactor([0.9, 0.5, 0.8])
+			.setSheenColorTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
-	const mat = doc
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_sheen', sheen);
+		const mat = doc
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_sheen', sheen);
 
-	t.is(mat.getExtension('KHR_materials_sheen'), sheen, 'sheen is attached');
+		strictEqual(mat.getExtension('KHR_materials_sheen'), sheen, 'sheen is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsSheen]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_sheen: {
-				sheenColorFactor: [0.9, 0.5, 0.8],
-				sheenRoughnessFactor: 0,
-				sheenColorTexture: { index: 0 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_sheen: {
+					sheenColorFactor: [0.9, 0.5, 0.8],
+					sheenRoughnessFactor: 0,
+					sheenColorTexture: { index: 0 },
+				},
 			},
-		},
-		'writes sheen extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsSheen.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes sheen extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsSheen.EXTENSION_NAME], 'writes extensionsUsed');
 
-	sheenExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_sheen'), null, 'sheen is detached');
+		sheenExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_sheen'), null, 'sheen is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsSheen]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Sheen>('KHR_materials_sheen');
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsSheen]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Sheen>('KHR_materials_sheen');
 
-	t.deepEqual(roundtripExt.getSheenColorFactor(), [0.9, 0.5, 0.8], 'reads sheenColorFactor');
-	t.truthy(roundtripExt.getSheenColorTexture(), 'reads sheenColorTexture');
-});
+		deepEqual(roundtripExt.getSheenColorFactor(), [0.9, 0.5, 0.8], 'reads sheenColorFactor');
+		ok(roundtripExt.getSheenColorTexture(), 'reads sheenColorTexture');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const sheenExtension = doc.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension
-		.createSheen()
-		.setSheenColorFactor([0.9, 0.5, 0.8])
-		.setSheenColorTexture(doc.createTexture('sheen'));
-	doc.createMaterial().setExtension('KHR_materials_sheen', sheen);
+	test('copy', () => {
+		const doc = new Document();
+		const sheenExtension = doc.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension
+			.createSheen()
+			.setSheenColorFactor([0.9, 0.5, 0.8])
+			.setSheenColorTexture(doc.createTexture('sheen'));
+		doc.createMaterial().setExtension('KHR_materials_sheen', sheen);
 
-	const doc2 = cloneDocument(doc);
-	const sheen2 = doc2.getRoot().listMaterials()[0].getExtension<Sheen>('KHR_materials_sheen');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSheen');
-	t.truthy(sheen2, 'copy Sheen');
-	t.deepEqual(sheen2.getSheenColorFactor(), [0.9, 0.5, 0.8], 'copy sheenColorFactor');
-	t.is(sheen2.getSheenColorTexture().getName(), 'sheen', 'copy sheenColorTexture');
-});
+		const doc2 = cloneDocument(doc);
+		const sheen2 = doc2.getRoot().listMaterials()[0].getExtension<Sheen>('KHR_materials_sheen');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSheen');
+		ok(sheen2, 'copy Sheen');
+		deepEqual(sheen2.getSheenColorFactor(), [0.9, 0.5, 0.8], 'copy sheenColorFactor');
+		strictEqual(sheen2.getSheenColorTexture().getName(), 'sheen', 'copy sheenColorTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsSheen]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsSheen]);
 
-	const sheenExtension = document.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension.createSheen().setExtras({ hello: 'world' });
+		const sheenExtension = document.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension.createSheen().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_sheen', sheen);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_sheen', sheen);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Sheen>('KHR_materials_sheen');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Sheen>('KHR_materials_sheen');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-sheen.test.ts
+++ b/packages/extensions/test/materials-sheen.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsSheen', () => {
+describe('extensions::KHRMaterialsSheen', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsSpecular', () => {
+describe('extensions::KHRMaterialsSpecular', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/materials-specular.test.ts
+++ b/packages/extensions/test/materials-specular.test.ts
@@ -1,96 +1,99 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsSpecular, type Specular } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const specularExtension = doc.createExtension(KHRMaterialsSpecular);
-	const specular = specularExtension
-		.createSpecular()
-		.setSpecularFactor(0.9)
-		.setSpecularColorFactor([0.9, 0.5, 0.8])
-		.setSpecularTexture(doc.createTexture().setImage(new Uint8Array(1)))
-		.setSpecularColorTexture(doc.createTexture().setImage(new Uint8Array(1)));
+describe('KHRMaterialsSpecular', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const specularExtension = doc.createExtension(KHRMaterialsSpecular);
+		const specular = specularExtension
+			.createSpecular()
+			.setSpecularFactor(0.9)
+			.setSpecularColorFactor([0.9, 0.5, 0.8])
+			.setSpecularTexture(doc.createTexture().setImage(new Uint8Array(1)))
+			.setSpecularColorTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
-	const mat = doc
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_specular', specular);
+		const mat = doc
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_specular', specular);
 
-	t.is(mat.getExtension('KHR_materials_specular'), specular, 'specular is attached');
+		strictEqual(mat.getExtension('KHR_materials_specular'), specular, 'specular is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsSpecular]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_specular: {
-				specularFactor: 0.9,
-				specularColorFactor: [0.9, 0.5, 0.8],
-				specularTexture: { index: 0 },
-				specularColorTexture: { index: 1 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_specular: {
+					specularFactor: 0.9,
+					specularColorFactor: [0.9, 0.5, 0.8],
+					specularTexture: { index: 0 },
+					specularColorTexture: { index: 1 },
+				},
 			},
-		},
-		'writes specular extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsSpecular.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes specular extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsSpecular.EXTENSION_NAME], 'writes extensionsUsed');
 
-	specularExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_specular'), null, 'specular is detached');
+		specularExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_specular'), null, 'specular is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsSpecular]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Specular>('KHR_materials_specular');
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsSpecular]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Specular>('KHR_materials_specular');
 
-	t.is(roundtripExt.getSpecularFactor(), 0.9, 'reads specularFactor');
-	t.deepEqual(roundtripExt.getSpecularColorFactor(), [0.9, 0.5, 0.8], 'reads specularColorFactor');
-	t.truthy(roundtripExt.getSpecularTexture(), 'reads specularTexture');
-});
+		strictEqual(roundtripExt.getSpecularFactor(), 0.9, 'reads specularFactor');
+		deepEqual(roundtripExt.getSpecularColorFactor(), [0.9, 0.5, 0.8], 'reads specularColorFactor');
+		ok(roundtripExt.getSpecularTexture(), 'reads specularTexture');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const specularExtension = doc.createExtension(KHRMaterialsSpecular);
-	const specular = specularExtension
-		.createSpecular()
-		.setSpecularFactor(0.9)
-		.setSpecularColorFactor([0.9, 0.5, 0.8])
-		.setSpecularTexture(doc.createTexture('spec'))
-		.setSpecularColorTexture(doc.createTexture('specColor'));
-	doc.createMaterial().setExtension('KHR_materials_specular', specular);
+	test('copy', () => {
+		const doc = new Document();
+		const specularExtension = doc.createExtension(KHRMaterialsSpecular);
+		const specular = specularExtension
+			.createSpecular()
+			.setSpecularFactor(0.9)
+			.setSpecularColorFactor([0.9, 0.5, 0.8])
+			.setSpecularTexture(doc.createTexture('spec'))
+			.setSpecularColorTexture(doc.createTexture('specColor'));
+		doc.createMaterial().setExtension('KHR_materials_specular', specular);
 
-	const doc2 = cloneDocument(doc);
-	const specular2 = doc2.getRoot().listMaterials()[0].getExtension<Specular>('KHR_materials_specular');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSpecular');
-	t.truthy(specular2, 'copy Specular');
-	t.is(specular2.getSpecularFactor(), 0.9, 'copy specularFactor');
-	t.deepEqual(specular2.getSpecularColorFactor(), [0.9, 0.5, 0.8], 'copy specularColorFactor');
-	t.is(specular2.getSpecularTexture().getName(), 'spec', 'copy specularTexture');
-	t.is(specular2.getSpecularColorTexture().getName(), 'specColor', 'copy specularColorTexture');
-});
+		const doc2 = cloneDocument(doc);
+		const specular2 = doc2.getRoot().listMaterials()[0].getExtension<Specular>('KHR_materials_specular');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsSpecular');
+		ok(specular2, 'copy Specular');
+		strictEqual(specular2.getSpecularFactor(), 0.9, 'copy specularFactor');
+		deepEqual(specular2.getSpecularColorFactor(), [0.9, 0.5, 0.8], 'copy specularColorFactor');
+		strictEqual(specular2.getSpecularTexture().getName(), 'spec', 'copy specularTexture');
+		strictEqual(specular2.getSpecularColorTexture().getName(), 'specColor', 'copy specularColorTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsSpecular]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsSpecular]);
 
-	const specularExtension = document.createExtension(KHRMaterialsSpecular);
-	const specular = specularExtension.createSpecular().setExtras({ hello: 'world' });
+		const specularExtension = document.createExtension(KHRMaterialsSpecular);
+		const specular = specularExtension.createSpecular().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_specular', specular);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_specular', specular);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Specular>('KHR_materials_specular');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Specular>('KHR_materials_specular');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -1,87 +1,95 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsTransmission, type Transmission } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const transmissionExtension = doc.createExtension(KHRMaterialsTransmission);
-	const transmission = transmissionExtension
-		.createTransmission()
-		.setTransmissionFactor(0.9)
-		.setTransmissionTexture(doc.createTexture().setImage(new Uint8Array(1)));
+describe('KHRMaterialsTransmission', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const transmissionExtension = doc.createExtension(KHRMaterialsTransmission);
+		const transmission = transmissionExtension
+			.createTransmission()
+			.setTransmissionFactor(0.9)
+			.setTransmissionTexture(doc.createTexture().setImage(new Uint8Array(1)));
 
-	const mat = doc
-		.createMaterial('MyTransmissionMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_transmission', transmission);
+		const mat = doc
+			.createMaterial('MyTransmissionMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_transmission', transmission);
 
-	t.is(mat.getExtension('KHR_materials_transmission'), transmission, 'transmission is attached');
+		strictEqual(mat.getExtension('KHR_materials_transmission'), transmission, 'transmission is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsTransmission]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO()
+			.registerExtensions([KHRMaterialsTransmission])
+			.writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_transmission: {
-				transmissionFactor: 0.9,
-				transmissionTexture: { index: 0 },
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_transmission: {
+					transmissionFactor: 0.9,
+					transmissionTexture: { index: 0 },
+				},
 			},
-		},
-		'writes transmission extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsTransmission.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes transmission extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsTransmission.EXTENSION_NAME], 'writes extensionsUsed');
 
-	transmissionExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_transmission'), null, 'transmission is detached');
+		transmissionExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_transmission'), null, 'transmission is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsTransmission]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Transmission>('KHR_materials_transmission');
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsTransmission]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Transmission>('KHR_materials_transmission');
 
-	t.is(roundtripExt.getTransmissionFactor(), 0.9, 'reads transmissionFactor');
-	t.truthy(roundtripExt.getTransmissionTexture(), 'reads transmissionTexture');
-});
+		strictEqual(roundtripExt.getTransmissionFactor(), 0.9, 'reads transmissionFactor');
+		ok(roundtripExt.getTransmissionTexture(), 'reads transmissionTexture');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const transmissionExtension = doc.createExtension(KHRMaterialsTransmission);
-	const transmission = transmissionExtension
-		.createTransmission()
-		.setTransmissionFactor(0.9)
-		.setTransmissionTexture(doc.createTexture('trns'));
-	doc.createMaterial().setExtension('KHR_materials_transmission', transmission);
+	test('copy', () => {
+		const doc = new Document();
+		const transmissionExtension = doc.createExtension(KHRMaterialsTransmission);
+		const transmission = transmissionExtension
+			.createTransmission()
+			.setTransmissionFactor(0.9)
+			.setTransmissionTexture(doc.createTexture('trns'));
+		doc.createMaterial().setExtension('KHR_materials_transmission', transmission);
 
-	const doc2 = cloneDocument(doc);
-	const transmission2 = doc2.getRoot().listMaterials()[0].getExtension<Transmission>('KHR_materials_transmission');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsTransmission');
-	t.truthy(transmission2, 'copy Transmission');
-	t.is(transmission2.getTransmissionFactor(), 0.9, 'copy transmissionFactor');
-	t.is(transmission2.getTransmissionTexture().getName(), 'trns', 'copy transmissionTexture');
-});
+		const doc2 = cloneDocument(doc);
+		const transmission2 = doc2
+			.getRoot()
+			.listMaterials()[0]
+			.getExtension<Transmission>('KHR_materials_transmission');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsTransmission');
+		ok(transmission2, 'copy Transmission');
+		strictEqual(transmission2.getTransmissionFactor(), 0.9, 'copy transmissionFactor');
+		strictEqual(transmission2.getTransmissionTexture().getName(), 'trns', 'copy transmissionTexture');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsTransmission]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsTransmission]);
 
-	const transmissionExtension = document.createExtension(KHRMaterialsTransmission);
-	const transmission = transmissionExtension.createTransmission().setExtras({ hello: 'world' });
+		const transmissionExtension = document.createExtension(KHRMaterialsTransmission);
+		const transmission = transmissionExtension.createTransmission().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_transmission', transmission);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_transmission', transmission);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Transmission>('KHR_materials_transmission');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Transmission>('KHR_materials_transmission');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/materials-transmission.test.ts
+++ b/packages/extensions/test/materials-transmission.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsTransmission', () => {
+describe('extensions::KHRMaterialsTransmission', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/materials-unlit.test.ts
+++ b/packages/extensions/test/materials-unlit.test.ts
@@ -6,7 +6,7 @@ import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsUnlit', () => {
+describe('extensions::KHRMaterialsUnlit', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const unlitExtension = doc.createExtension(KHRMaterialsUnlit);

--- a/packages/extensions/test/materials-unlit.test.ts
+++ b/packages/extensions/test/materials-unlit.test.ts
@@ -1,46 +1,49 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
-	const unlit = unlitExtension.createUnlit();
+describe('KHRMaterialsUnlit', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
+		const unlit = unlitExtension.createUnlit();
 
-	const mat = doc
-		.createMaterial('MyUnlitMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setRoughnessFactor(1.0)
-		.setMetallicFactor(0.0)
-		.setExtension('KHR_materials_unlit', unlit);
+		const mat = doc
+			.createMaterial('MyUnlitMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setRoughnessFactor(1.0)
+			.setMetallicFactor(0.0)
+			.setExtension('KHR_materials_unlit', unlit);
 
-	t.is(mat.getExtension('KHR_materials_unlit'), unlit, 'unlit is attached');
+		strictEqual(mat.getExtension('KHR_materials_unlit'), unlit, 'unlit is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsUnlit]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(materialDef.extensions, { KHR_materials_unlit: {} }, 'writes unlit extension');
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsUnlit.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(materialDef.extensions, { KHR_materials_unlit: {} }, 'writes unlit extension');
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsUnlit.EXTENSION_NAME], 'writes extensionsUsed');
 
-	const rtDoc = await new NodeIO().registerExtensions([KHRMaterialsUnlit]).readJSON(jsonDoc);
-	const rtMat = rtDoc.getRoot().listMaterials()[0];
-	t.truthy(rtMat.getExtension('KHR_materials_unlit'), 'unlit is round tripped');
+		const rtDoc = await new NodeIO().registerExtensions([KHRMaterialsUnlit]).readJSON(jsonDoc);
+		const rtMat = rtDoc.getRoot().listMaterials()[0];
+		ok(rtMat.getExtension('KHR_materials_unlit'), 'unlit is round tripped');
 
-	unlitExtension.dispose();
+		unlitExtension.dispose();
 
-	t.is(mat.getExtension('KHR_materials_unlit'), null, 'unlit is detached');
-});
+		strictEqual(mat.getExtension('KHR_materials_unlit'), null, 'unlit is detached');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
-	doc.createMaterial().setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
+	test('copy', () => {
+		const doc = new Document();
+		const unlitExtension = doc.createExtension(KHRMaterialsUnlit);
+		doc.createMaterial().setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
 
-	const doc2 = cloneDocument(doc);
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsUnlit');
-	t.truthy(doc2.getRoot().listMaterials()[0].getExtension('KHR_materials_unlit'), 'copy Unlit');
+		const doc2 = cloneDocument(doc);
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsUnlit');
+		ok(doc2.getRoot().listMaterials()[0].getExtension('KHR_materials_unlit'), 'copy Unlit');
+	});
 });

--- a/packages/extensions/test/materials-variants.test.ts
+++ b/packages/extensions/test/materials-variants.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsVariants, type MappingList } from '@gltf-transform/extensions';
 
-describe('KHRMaterialsVariants', () => {
+describe('extensions::KHRMaterialsVariants', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const variantsExtension = doc.createExtension(KHRMaterialsVariants);

--- a/packages/extensions/test/materials-variants.test.ts
+++ b/packages/extensions/test/materials-variants.test.ts
@@ -1,88 +1,91 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsVariants, type MappingList } from '@gltf-transform/extensions';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const variantsExtension = doc.createExtension(KHRMaterialsVariants);
-	const var2 = variantsExtension.createVariant('Damaged1');
-	const var3 = variantsExtension.createVariant('Damaged2');
+describe('KHRMaterialsVariants', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const variantsExtension = doc.createExtension(KHRMaterialsVariants);
+		const var2 = variantsExtension.createVariant('Damaged1');
+		const var3 = variantsExtension.createVariant('Damaged2');
 
-	const mat1 = doc.createMaterial('Default').setRoughnessFactor(0.0);
-	const mat2 = doc.createMaterial('Damaged1').setRoughnessFactor(0.5);
-	const mat3 = doc.createMaterial('Damaged2').setRoughnessFactor(1.0);
+		const mat1 = doc.createMaterial('Default').setRoughnessFactor(0.0);
+		const mat2 = doc.createMaterial('Damaged1').setRoughnessFactor(0.5);
+		const mat3 = doc.createMaterial('Damaged2').setRoughnessFactor(1.0);
 
-	const mappingList = variantsExtension
-		.createMappingList()
-		.addMapping(variantsExtension.createMapping().setMaterial(mat2).addVariant(var2))
-		.addMapping(variantsExtension.createMapping().setMaterial(mat3).addVariant(var3));
+		const mappingList = variantsExtension
+			.createMappingList()
+			.addMapping(variantsExtension.createMapping().setMaterial(mat2).addVariant(var2))
+			.addMapping(variantsExtension.createMapping().setMaterial(mat3).addVariant(var3));
 
-	doc.createMesh('Varies').addPrimitive(
-		doc.createPrimitive().setMaterial(mat1).setExtension('KHR_materials_variants', mappingList),
-	);
-	doc.createMesh('Static').addPrimitive(doc.createPrimitive().setMaterial(mat1));
+		doc.createMesh('Varies').addPrimitive(
+			doc.createPrimitive().setMaterial(mat1).setExtension('KHR_materials_variants', mappingList),
+		);
+		doc.createMesh('Static').addPrimitive(doc.createPrimitive().setMaterial(mat1));
 
-	//
+		//
 
-	const io = new NodeIO().registerExtensions([KHRMaterialsVariants]);
-	const rtDoc = await io.readJSON(await io.writeJSON(doc, {}));
-	const rtPrim1 = rtDoc.getRoot().listMeshes()[0].listPrimitives()[0];
-	const rtPrim2 = rtDoc.getRoot().listMeshes()[1].listPrimitives()[0];
-	const rtMappingList = rtPrim1.getExtension<MappingList>('KHR_materials_variants');
+		const io = new NodeIO().registerExtensions([KHRMaterialsVariants]);
+		const rtDoc = await io.readJSON(await io.writeJSON(doc, {}));
+		const rtPrim1 = rtDoc.getRoot().listMeshes()[0].listPrimitives()[0];
+		const rtPrim2 = rtDoc.getRoot().listMeshes()[1].listPrimitives()[0];
+		const rtMappingList = rtPrim1.getExtension<MappingList>('KHR_materials_variants');
 
-	//
+		//
 
-	t.deepEqual(
-		doc
-			.getRoot()
-			.listExtensionsUsed()
-			.map((e) => e.extensionName),
-		['KHR_materials_variants'],
-		'has extension',
-	);
-	t.truthy(rtPrim1.getExtension('KHR_materials_variants'));
-	t.falsy(rtPrim2.getExtension('KHR_materials_variants'));
-	t.is(rtPrim1.getMaterial().getRoughnessFactor(), 0.0, 'default material (1)');
-	t.is(rtPrim2.getMaterial().getRoughnessFactor(), 0.0, 'default material (2)');
-	t.deepEqual(
-		rtMappingList.listMappings().map((mapping) => mapping.getMaterial().getName()),
-		['Damaged1', 'Damaged2'],
-		'mapping materials',
-	);
-	t.deepEqual(
-		rtMappingList.listMappings().map((mapping) => mapping.listVariants().map((variant) => variant.getName())),
-		[['Damaged1'], ['Damaged2']],
-		'mapping variants',
-	);
+		deepEqual(
+			doc
+				.getRoot()
+				.listExtensionsUsed()
+				.map((e) => e.extensionName),
+			['KHR_materials_variants'],
+			'has extension',
+		);
+		ok(rtPrim1.getExtension('KHR_materials_variants'));
+		strictEqual(rtPrim2.getExtension('KHR_materials_variants'), null);
+		strictEqual(rtPrim1.getMaterial().getRoughnessFactor(), 0.0, 'default material (1)');
+		strictEqual(rtPrim2.getMaterial().getRoughnessFactor(), 0.0, 'default material (2)');
+		deepEqual(
+			rtMappingList.listMappings().map((mapping) => mapping.getMaterial().getName()),
+			['Damaged1', 'Damaged2'],
+			'mapping materials',
+		);
+		deepEqual(
+			rtMappingList.listMappings().map((mapping) => mapping.listVariants().map((variant) => variant.getName())),
+			[['Damaged1'], ['Damaged2']],
+			'mapping variants',
+		);
 
-	//
+		//
 
-	variantsExtension.dispose();
+		variantsExtension.dispose();
 
-	t.deepEqual(doc.getRoot().listExtensionsUsed(), [], 'all extensions detached');
-	t.is(mat1.getExtension('KHR_materials_variants'), null, 'unlit is detached');
-});
+		deepEqual(doc.getRoot().listExtensionsUsed(), [], 'all extensions detached');
+		strictEqual(mat1.getExtension('KHR_materials_variants'), null, 'unlit is detached');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const variantsExtension = doc.createExtension(KHRMaterialsVariants);
-	const var1 = variantsExtension.createVariant('Dry');
-	const var2 = variantsExtension.createVariant('Wet');
+	test('copy', () => {
+		const doc = new Document();
+		const variantsExtension = doc.createExtension(KHRMaterialsVariants);
+		const var1 = variantsExtension.createVariant('Dry');
+		const var2 = variantsExtension.createVariant('Wet');
 
-	const mat1 = doc.createMaterial('Dry').setRoughnessFactor(0.5);
-	const mat2 = doc.createMaterial('Wet').setRoughnessFactor(1.0);
+		const mat1 = doc.createMaterial('Dry').setRoughnessFactor(0.5);
+		const mat2 = doc.createMaterial('Wet').setRoughnessFactor(1.0);
 
-	const map1 = variantsExtension.createMapping().setMaterial(mat1).addVariant(var1);
-	const map2 = variantsExtension.createMapping().setMaterial(mat2).addVariant(var2);
+		const map1 = variantsExtension.createMapping().setMaterial(mat1).addVariant(var1);
+		const map2 = variantsExtension.createMapping().setMaterial(mat2).addVariant(var2);
 
-	const mappingList = variantsExtension.createMappingList().addMapping(map1).addMapping(map2);
+		const mappingList = variantsExtension.createMappingList().addMapping(map1).addMapping(map2);
 
-	const cpVariant = variantsExtension.createVariant().copy(var1);
-	const cpMapping = variantsExtension.createMapping().copy(mappingList.listMappings()[0]);
-	const cpMappingList = variantsExtension.createMappingList().copy(mappingList);
+		const cpVariant = variantsExtension.createVariant().copy(var1);
+		const cpMapping = variantsExtension.createMapping().copy(mappingList.listMappings()[0]);
+		const cpMappingList = variantsExtension.createMappingList().copy(mappingList);
 
-	t.is(cpVariant.getName(), 'Dry', 'copy variant');
-	t.is(cpMapping.getMaterial(), mat1, 'copy mapping - material');
-	t.deepEqual(cpMapping.listVariants(), [var1], 'copy mapping - variant');
-	t.deepEqual(cpMappingList.listMappings(), [map1, map2]);
+		strictEqual(cpVariant.getName(), 'Dry', 'copy variant');
+		strictEqual(cpMapping.getMaterial(), mat1, 'copy mapping - material');
+		deepEqual(cpMapping.listVariants(), [var1], 'copy mapping - variant');
+		deepEqual(cpMappingList.listMappings(), [map1, map2]);
+	});
 });

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -7,7 +7,7 @@ import { createPlatformIO } from '@gltf-transform/test-utils';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMaterialsVolume', () => {
+describe('extensions::KHRMaterialsVolume', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/materials-volume.test.ts
+++ b/packages/extensions/test/materials-volume.test.ts
@@ -1,97 +1,100 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRMaterialsVolume, type Volume } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const volumeExtension = doc.createExtension(KHRMaterialsVolume);
-	const volume = volumeExtension
-		.createVolume()
-		.setThicknessFactor(0.9)
-		.setThicknessTexture(doc.createTexture().setImage(new Uint8Array(1)))
-		.setAttenuationDistance(2)
-		.setAttenuationColor([0.1, 0.2, 0.3]);
+describe('KHRMaterialsVolume', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const volumeExtension = doc.createExtension(KHRMaterialsVolume);
+		const volume = volumeExtension
+			.createVolume()
+			.setThicknessFactor(0.9)
+			.setThicknessTexture(doc.createTexture().setImage(new Uint8Array(1)))
+			.setAttenuationDistance(2)
+			.setAttenuationColor([0.1, 0.2, 0.3]);
 
-	const mat = doc
-		.createMaterial('MyVolumeMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_volume', volume);
+		const mat = doc
+			.createMaterial('MyVolumeMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_volume', volume);
 
-	t.is(mat.getExtension('KHR_materials_volume'), volume, 'volume is attached');
+		strictEqual(mat.getExtension('KHR_materials_volume'), volume, 'volume is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRMaterialsVolume]).writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
 
-	t.deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
-	t.deepEqual(
-		materialDef.extensions,
-		{
-			KHR_materials_volume: {
-				thicknessFactor: 0.9,
-				thicknessTexture: { index: 0 },
-				attenuationDistance: 2,
-				attenuationColor: [0.1, 0.2, 0.3],
+		deepEqual(materialDef.pbrMetallicRoughness.baseColorFactor, [1.0, 0.5, 0.5, 1.0], 'writes base color');
+		deepEqual(
+			materialDef.extensions,
+			{
+				KHR_materials_volume: {
+					thicknessFactor: 0.9,
+					thicknessTexture: { index: 0 },
+					attenuationDistance: 2,
+					attenuationColor: [0.1, 0.2, 0.3],
+				},
 			},
-		},
-		'writes volume extension',
-	);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsVolume.EXTENSION_NAME], 'writes extensionsUsed');
+			'writes volume extension',
+		);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMaterialsVolume.EXTENSION_NAME], 'writes extensionsUsed');
 
-	volumeExtension.dispose();
-	t.is(mat.getExtension('KHR_materials_volume'), null, 'volume is detached');
+		volumeExtension.dispose();
+		strictEqual(mat.getExtension('KHR_materials_volume'), null, 'volume is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsVolume]).readJSON(jsonDoc);
-	const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
-	const roundtripExt = roundtripMat.getExtension<Volume>('KHR_materials_volume');
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRMaterialsVolume]).readJSON(jsonDoc);
+		const roundtripMat = roundtripDoc.getRoot().listMaterials().pop();
+		const roundtripExt = roundtripMat.getExtension<Volume>('KHR_materials_volume');
 
-	t.is(roundtripExt.getThicknessFactor(), 0.9, 'reads thicknessFactor');
-	t.truthy(roundtripExt.getThicknessTexture(), 'reads thicknessTexture');
-	t.is(roundtripExt.getAttenuationDistance(), 2, 'reads attenuationDistance');
-	t.deepEqual(roundtripExt.getAttenuationColor(), [0.1, 0.2, 0.3], 'reads attenuationColor');
-});
+		strictEqual(roundtripExt.getThicknessFactor(), 0.9, 'reads thicknessFactor');
+		ok(roundtripExt.getThicknessTexture(), 'reads thicknessTexture');
+		strictEqual(roundtripExt.getAttenuationDistance(), 2, 'reads attenuationDistance');
+		deepEqual(roundtripExt.getAttenuationColor(), [0.1, 0.2, 0.3], 'reads attenuationColor');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const volumeExtension = doc.createExtension(KHRMaterialsVolume);
-	const volume = volumeExtension
-		.createVolume()
-		.setThicknessFactor(0.9)
-		.setThicknessTexture(doc.createTexture('trns'))
-		.setAttenuationDistance(10)
-		.setAttenuationColor([1, 0, 0]);
-	doc.createMaterial().setExtension('KHR_materials_volume', volume);
+	test('copy', () => {
+		const doc = new Document();
+		const volumeExtension = doc.createExtension(KHRMaterialsVolume);
+		const volume = volumeExtension
+			.createVolume()
+			.setThicknessFactor(0.9)
+			.setThicknessTexture(doc.createTexture('trns'))
+			.setAttenuationDistance(10)
+			.setAttenuationColor([1, 0, 0]);
+		doc.createMaterial().setExtension('KHR_materials_volume', volume);
 
-	const doc2 = cloneDocument(doc);
-	const volume2 = doc2.getRoot().listMaterials()[0].getExtension<Volume>('KHR_materials_volume');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsVolume');
-	t.truthy(volume2, 'copy Volume');
-	t.is(volume2.getThicknessFactor(), 0.9, 'copy thicknessFactor');
-	t.is(volume2.getThicknessTexture().getName(), 'trns', 'copy thicknessTexture');
-	t.is(volume2.getAttenuationDistance(), 10, 'copy attenuationDistance');
-	t.deepEqual(volume2.getAttenuationColor(), [1, 0, 0], 'copy attenuationColor');
-});
+		const doc2 = cloneDocument(doc);
+		const volume2 = doc2.getRoot().listMaterials()[0].getExtension<Volume>('KHR_materials_volume');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy KHRMaterialsVolume');
+		ok(volume2, 'copy Volume');
+		strictEqual(volume2.getThicknessFactor(), 0.9, 'copy thicknessFactor');
+		strictEqual(volume2.getThicknessTexture().getName(), 'trns', 'copy thicknessTexture');
+		strictEqual(volume2.getAttenuationDistance(), 10, 'copy attenuationDistance');
+		deepEqual(volume2.getAttenuationColor(), [1, 0, 0], 'copy attenuationColor');
+	});
 
-test('extras', async (t) => {
-	const document = new Document();
-	const io = await createPlatformIO();
-	io.registerExtensions([KHRMaterialsVolume]);
+	test('extras', async () => {
+		const document = new Document();
+		const io = await createPlatformIO();
+		io.registerExtensions([KHRMaterialsVolume]);
 
-	const volumeExtension = document.createExtension(KHRMaterialsVolume);
-	const volume = volumeExtension.createVolume().setExtras({ hello: 'world' });
+		const volumeExtension = document.createExtension(KHRMaterialsVolume);
+		const volume = volumeExtension.createVolume().setExtras({ hello: 'world' });
 
-	document
-		.createMaterial('MyMaterial')
-		.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
-		.setExtension('KHR_materials_volume', volume);
+		document
+			.createMaterial('MyMaterial')
+			.setBaseColorFactor([1.0, 0.5, 0.5, 1.0])
+			.setExtension('KHR_materials_volume', volume);
 
-	const rtDocument = await io.readJSON(await io.writeJSON(document));
-	const rtMaterial = rtDocument.getRoot().listMaterials().pop();
-	const rtExtension = rtMaterial.getExtension<Volume>('KHR_materials_volume');
+		const rtDocument = await io.readJSON(await io.writeJSON(document));
+		const rtMaterial = rtDocument.getRoot().listMaterials().pop();
+		const rtExtension = rtMaterial.getExtension<Volume>('KHR_materials_volume');
 
-	t.deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+		deepEqual(rtExtension.getExtras(), { hello: 'world' }, 'reads/writes extras');
+	});
 });

--- a/packages/extensions/test/mesh-features.test.ts
+++ b/packages/extensions/test/mesh-features.test.ts
@@ -1,8 +1,9 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { EXTMeshFeatures, type Features } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -11,62 +12,64 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('id attribute', async (t) => {
-	const io = (await createPlatformIO()).registerExtensions([EXTMeshFeatures]);
-	const srcDocument = await io.read(join(__dirname, 'in', 'EXT_mesh_features', 'FeatureIdAttribute.gltf'));
+describe('EXTMeshFeatures', () => {
+	test('id attribute', async () => {
+		const io = (await createPlatformIO()).registerExtensions([EXTMeshFeatures]);
+		const srcDocument = await io.read(join(__dirname, 'in', 'EXT_mesh_features', 'FeatureIdAttribute.gltf'));
 
-	t.true(srcDocument.hasExtension('EXT_mesh_features'), 'reads EXT_mesh_features');
+		ok(srcDocument.hasExtension('EXT_mesh_features'), 'reads EXT_mesh_features');
 
-	const prim = srcDocument
-		.getRoot()
-		.listMeshes()
-		.flatMap((mesh) => mesh.listPrimitives())[0];
+		const prim = srcDocument
+			.getRoot()
+			.listMeshes()
+			.flatMap((mesh) => mesh.listPrimitives())[0];
 
-	const features = prim.getExtension<Features>('EXT_mesh_features');
-	t.is(features.listFeatureIDs().length, 1, 'reads 1 FeatureID');
+		const features = prim.getExtension<Features>('EXT_mesh_features');
+		strictEqual(features.listFeatureIDs().length, 1, 'reads 1 FeatureID');
 
-	const featureID = features.listFeatureIDs()[0];
-	t.is(featureID.getFeatureCount(), 4, 'reads 4 features');
-	t.is(featureID.getAttribute(), 0, 'reads attribute');
+		const featureID = features.listFeatureIDs()[0];
+		strictEqual(featureID.getFeatureCount(), 4, 'reads 4 features');
+		strictEqual(featureID.getAttribute(), 0, 'reads attribute');
 
-	const jsonDocument = await io.writeJSON(srcDocument, WRITER_OPTIONS);
+		const jsonDocument = await io.writeJSON(srcDocument, WRITER_OPTIONS);
 
-	const dstPrimDef = jsonDocument.json.meshes[0].primitives[0];
-	const dstExtensionDef = dstPrimDef.extensions.EXT_mesh_features;
-	t.deepEqual(dstExtensionDef, { featureIds: [{ featureCount: 4, attribute: 0 }] }, 'writes FeatureID');
-});
+		const dstPrimDef = jsonDocument.json.meshes[0].primitives[0];
+		const dstExtensionDef = dstPrimDef.extensions.EXT_mesh_features;
+		deepEqual(dstExtensionDef, { featureIds: [{ featureCount: 4, attribute: 0 }] }, 'writes FeatureID');
+	});
 
-test('id texture', async (t) => {
-	const io = (await createPlatformIO()).registerExtensions([EXTMeshFeatures]);
-	const srcDocument = await io.read(join(__dirname, 'in', 'EXT_mesh_features', 'FeatureIdTexture.gltf'));
+	test('id texture', async () => {
+		const io = (await createPlatformIO()).registerExtensions([EXTMeshFeatures]);
+		const srcDocument = await io.read(join(__dirname, 'in', 'EXT_mesh_features', 'FeatureIdTexture.gltf'));
 
-	t.true(srcDocument.hasExtension('EXT_mesh_features'), 'reads EXT_mesh_features');
+		ok(srcDocument.hasExtension('EXT_mesh_features'), 'reads EXT_mesh_features');
 
-	const prim = srcDocument
-		.getRoot()
-		.listMeshes()
-		.flatMap((mesh) => mesh.listPrimitives())[0];
+		const prim = srcDocument
+			.getRoot()
+			.listMeshes()
+			.flatMap((mesh) => mesh.listPrimitives())[0];
 
-	const features = prim.getExtension<Features>('EXT_mesh_features');
-	t.is(features.listFeatureIDs().length, 1, 'reads 1 FeatureID');
+		const features = prim.getExtension<Features>('EXT_mesh_features');
+		strictEqual(features.listFeatureIDs().length, 1, 'reads 1 FeatureID');
 
-	const featureID = features.listFeatureIDs()[0];
-	const featureIDTexture = featureID.getTexture();
-	const texture = featureIDTexture.getTexture();
+		const featureID = features.listFeatureIDs()[0];
+		const featureIDTexture = featureID.getTexture();
+		const texture = featureIDTexture.getTexture();
 
-	t.deepEqual(featureIDTexture.getChannels(), [0], 'reads channels');
-	t.truthy(texture, 'reads texture');
+		deepEqual(featureIDTexture.getChannels(), [0], 'reads channels');
+		ok(texture, 'reads texture');
 
-	const jsonDocument = await io.writeJSON(srcDocument, WRITER_OPTIONS);
+		const jsonDocument = await io.writeJSON(srcDocument, WRITER_OPTIONS);
 
-	const dstPrimDef = jsonDocument.json.meshes[0].primitives[0];
-	const dstExtensionDef = dstPrimDef.extensions.EXT_mesh_features;
-	t.deepEqual(dstExtensionDef, { featureIds: [{ featureCount: 4, texture: { index: 1 } }] }, 'writes FeatureID');
-});
+		const dstPrimDef = jsonDocument.json.meshes[0].primitives[0];
+		const dstExtensionDef = dstPrimDef.extensions.EXT_mesh_features;
+		deepEqual(dstExtensionDef, { featureIds: [{ featureCount: 4, texture: { index: 1 } }] }, 'writes FeatureID');
+	});
 
-test('clone', (t) => {
-	const doc = new Document();
-	doc.createExtension(EXTMeshFeatures);
+	test('clone', () => {
+		const doc = new Document();
+		doc.createExtension(EXTMeshFeatures);
 
-	t.true(cloneDocument(doc).hasExtension('EXT_mesh_features'), 'copy EXTMeshFeatures');
+		ok(cloneDocument(doc).hasExtension('EXT_mesh_features'), 'copy EXTMeshFeatures');
+	});
 });

--- a/packages/extensions/test/mesh-features.test.ts
+++ b/packages/extensions/test/mesh-features.test.ts
@@ -12,7 +12,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('EXTMeshFeatures', () => {
+describe('extensions::EXTMeshFeatures', () => {
 	test('id attribute', async () => {
 		const io = (await createPlatformIO()).registerExtensions([EXTMeshFeatures]);
 		const srcDocument = await io.read(join(__dirname, 'in', 'EXT_mesh_features', 'FeatureIdAttribute.gltf'));

--- a/packages/extensions/test/mesh-gpu-instancing.test.ts
+++ b/packages/extensions/test/mesh-gpu-instancing.test.ts
@@ -8,7 +8,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([EXTMeshGPUInstancing]);
 
-describe('EXTMeshGPUInstancing', () => {
+describe('extensions::EXTMeshGPUInstancing', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const data = doc

--- a/packages/extensions/test/mesh-gpu-instancing.test.ts
+++ b/packages/extensions/test/mesh-gpu-instancing.test.ts
@@ -1,79 +1,82 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, NodeIO } from '@gltf-transform/core';
 import { EXTMeshGPUInstancing, type InstancedMesh } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([EXTMeshGPUInstancing]);
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const data = doc
-		.createAccessor('unused')
-		.setArray(new Float32Array(12))
-		.setType(Accessor.Type.VEC3)
-		.setBuffer(doc.createBuffer());
+describe('EXTMeshGPUInstancing', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const data = doc
+			.createAccessor('unused')
+			.setArray(new Float32Array(12))
+			.setType(Accessor.Type.VEC3)
+			.setBuffer(doc.createBuffer());
 
-	// Create a non-instanced mesh primitive, and ensure its attributes are written into separate
-	// buffer views from instance attributes.
-	const prim = doc.createPrimitive().setAttribute('POSITION', data.clone().setName('prim_pos'));
-	const mesh = doc.createMesh().addPrimitive(prim);
+		// Create a non-instanced mesh primitive, and ensure its attributes are written into separate
+		// buffer views from instance attributes.
+		const prim = doc.createPrimitive().setAttribute('POSITION', data.clone().setName('prim_pos'));
+		const mesh = doc.createMesh().addPrimitive(prim);
 
-	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
-	const batch = batchExtension
-		.createInstancedMesh()
-		.setAttribute('TRANSLATION', data.clone().setName('inst_pos'))
-		.setAttribute('_CUSTOM', data.clone().setName('inst_cust'));
+		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
+		const batch = batchExtension
+			.createInstancedMesh()
+			.setAttribute('TRANSLATION', data.clone().setName('inst_pos'))
+			.setAttribute('_CUSTOM', data.clone().setName('inst_cust'));
 
-	const node = doc.createNode().setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch);
+		const node = doc.createNode().setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch);
 
-	t.is(node.getExtension('EXT_mesh_gpu_instancing'), batch, 'batch is attached');
+		strictEqual(node.getExtension('EXT_mesh_gpu_instancing'), batch, 'batch is attached');
 
-	const jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
-	const nodeDef = jsonDoc.json.nodes[0];
+		const jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		const nodeDef = jsonDoc.json.nodes[0];
 
-	t.is(jsonDoc.json.bufferViews.length, 3, 'creates three buffer views');
-	t.deepEqual(
-		nodeDef.extensions,
-		{
-			EXT_mesh_gpu_instancing: {
-				attributes: { TRANSLATION: 2, _CUSTOM: 3 },
+		strictEqual(jsonDoc.json.bufferViews.length, 3, 'creates three buffer views');
+		deepEqual(
+			nodeDef.extensions,
+			{
+				EXT_mesh_gpu_instancing: {
+					attributes: { TRANSLATION: 2, _CUSTOM: 3 },
+				},
 			},
-		},
-		'attaches batch',
-	);
-	t.is(jsonDoc.json.accessors[0].bufferView, 0, 'buffer view assignment (1/4)');
-	t.is(jsonDoc.json.accessors[1].bufferView, 1, 'buffer view assignment (2/4)');
-	t.is(jsonDoc.json.accessors[2].bufferView, 2, 'buffer view assignment (3/4)');
-	t.is(jsonDoc.json.accessors[3].bufferView, 2, 'buffer view assignment (4/4)');
+			'attaches batch',
+		);
+		strictEqual(jsonDoc.json.accessors[0].bufferView, 0, 'buffer view assignment (1/4)');
+		strictEqual(jsonDoc.json.accessors[1].bufferView, 1, 'buffer view assignment (2/4)');
+		strictEqual(jsonDoc.json.accessors[2].bufferView, 2, 'buffer view assignment (3/4)');
+		strictEqual(jsonDoc.json.accessors[3].bufferView, 2, 'buffer view assignment (4/4)');
 
-	const rtDoc = await io.readJSON(jsonDoc);
-	const rtNode = rtDoc.getRoot().listNodes().pop();
-	const batch2 = rtNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		const rtDoc = await io.readJSON(jsonDoc);
+		const rtNode = rtDoc.getRoot().listNodes().pop();
+		const batch2 = rtNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 
-	t.deepEqual(batch.listSemantics(), batch2.listSemantics(), 'batches have same semantics');
+		deepEqual(batch.listSemantics(), batch2.listSemantics(), 'batches have same semantics');
 
-	batchExtension.dispose();
-	t.is(node.getExtension('EXT_mesh_gpu_instancing'), null, 'batch is detached');
-});
+		batchExtension.dispose();
+		strictEqual(node.getExtension('EXT_mesh_gpu_instancing'), null, 'batch is detached');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	const data = doc
-		.createAccessor()
-		.setArray(new Float32Array(12))
-		.setType(Accessor.Type.VEC3)
-		.setBuffer(doc.createBuffer());
-	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
-	const batch = batchExtension.createInstancedMesh().setAttribute('TRANSLATION', data).setAttribute('_ID', data);
+	test('copy', () => {
+		const doc = new Document();
+		const data = doc
+			.createAccessor()
+			.setArray(new Float32Array(12))
+			.setType(Accessor.Type.VEC3)
+			.setBuffer(doc.createBuffer());
+		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
+		const batch = batchExtension.createInstancedMesh().setAttribute('TRANSLATION', data).setAttribute('_ID', data);
 
-	doc.createNode().setExtension('EXT_mesh_gpu_instancing', batch);
+		doc.createNode().setExtension('EXT_mesh_gpu_instancing', batch);
 
-	const doc2 = cloneDocument(doc);
-	const batch2 = doc2.getRoot().listNodes()[0].getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
-	t.is(doc2.getRoot().listExtensionsUsed().length, 1, 'copy EXTMeshGPUInstancing');
-	t.truthy(batch2, 'copy batch');
-	t.deepEqual(batch.listSemantics(), batch2.listSemantics(), 'matching semantics');
-	t.deepEqual(batch.getAttribute('_ID').getArray(), new Float32Array(12), 'matching data');
+		const doc2 = cloneDocument(doc);
+		const batch2 = doc2.getRoot().listNodes()[0].getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		strictEqual(doc2.getRoot().listExtensionsUsed().length, 1, 'copy EXTMeshGPUInstancing');
+		ok(batch2, 'copy batch');
+		deepEqual(batch.listSemantics(), batch2.listSemantics(), 'matching semantics');
+		deepEqual(batch.getAttribute('_ID').getArray(), new Float32Array(12), 'matching data');
+	});
 });

--- a/packages/extensions/test/mesh-primitive-restart.test.ts
+++ b/packages/extensions/test/mesh-primitive-restart.test.ts
@@ -6,7 +6,7 @@ import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMeshPrimitiveRestart', () => {
+describe('extensions::KHRMeshPrimitiveRestart', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const primRestartExtension = document.createExtension(KHRMeshPrimitiveRestart);

--- a/packages/extensions/test/mesh-primitive-restart.test.ts
+++ b/packages/extensions/test/mesh-primitive-restart.test.ts
@@ -1,28 +1,31 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type JSONDocument, NodeIO } from '@gltf-transform/core';
 import { KHRMeshPrimitiveRestart } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const document = new Document();
-	const primRestartExtension = document.createExtension(KHRMeshPrimitiveRestart);
+describe('KHRMeshPrimitiveRestart', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const primRestartExtension = document.createExtension(KHRMeshPrimitiveRestart);
 
-	let jsonDoc: JSONDocument;
+		let jsonDoc: JSONDocument;
 
-	jsonDoc = await new NodeIO().registerExtensions([KHRMeshPrimitiveRestart]).writeJSON(document, WRITER_OPTIONS);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMeshPrimitiveRestart.EXTENSION_NAME], 'writes extensionsUsed');
+		jsonDoc = await new NodeIO().registerExtensions([KHRMeshPrimitiveRestart]).writeJSON(document, WRITER_OPTIONS);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMeshPrimitiveRestart.EXTENSION_NAME], 'writes extensionsUsed');
 
-	primRestartExtension.dispose();
+		primRestartExtension.dispose();
 
-	jsonDoc = await new NodeIO().writeJSON(document, WRITER_OPTIONS);
-	t.is(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
-});
+		jsonDoc = await new NodeIO().writeJSON(document, WRITER_OPTIONS);
+		strictEqual(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	document.createExtension(KHRMeshPrimitiveRestart);
+	test('copy', () => {
+		const document = new Document();
+		document.createExtension(KHRMeshPrimitiveRestart);
 
-	t.true(cloneDocument(document).hasExtension('KHR_mesh_primitive_restart'), 'copy KHRMeshPrimitiveRestart');
+		ok(cloneDocument(document).hasExtension('KHR_mesh_primitive_restart'), 'copy KHRMeshPrimitiveRestart');
+	});
 });

--- a/packages/extensions/test/mesh-quantization.test.ts
+++ b/packages/extensions/test/mesh-quantization.test.ts
@@ -1,27 +1,30 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type JSONDocument, NodeIO } from '@gltf-transform/core';
 import { KHRMeshQuantization } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const quantizationExtension = doc.createExtension(KHRMeshQuantization);
-	let jsonDoc: JSONDocument;
+describe('KHRMeshQuantization', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const quantizationExtension = doc.createExtension(KHRMeshQuantization);
+		let jsonDoc: JSONDocument;
 
-	jsonDoc = await new NodeIO().registerExtensions([KHRMeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRMeshQuantization.EXTENSION_NAME], 'writes extensionsUsed');
+		jsonDoc = await new NodeIO().registerExtensions([KHRMeshQuantization]).writeJSON(doc, WRITER_OPTIONS);
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRMeshQuantization.EXTENSION_NAME], 'writes extensionsUsed');
 
-	quantizationExtension.dispose();
+		quantizationExtension.dispose();
 
-	jsonDoc = await new NodeIO().writeJSON(doc, WRITER_OPTIONS);
-	t.is(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
-});
+		jsonDoc = await new NodeIO().writeJSON(doc, WRITER_OPTIONS);
+		strictEqual(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
+	});
 
-test('copy', (t) => {
-	const doc = new Document();
-	doc.createExtension(KHRMeshQuantization);
+	test('copy', () => {
+		const doc = new Document();
+		doc.createExtension(KHRMeshQuantization);
 
-	t.is(cloneDocument(doc).getRoot().listExtensionsUsed().length, 1, 'copy KHRMeshQuantization');
+		strictEqual(cloneDocument(doc).getRoot().listExtensionsUsed().length, 1, 'copy KHRMeshQuantization');
+	});
 });

--- a/packages/extensions/test/mesh-quantization.test.ts
+++ b/packages/extensions/test/mesh-quantization.test.ts
@@ -6,7 +6,7 @@ import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRMeshQuantization', () => {
+describe('extensions::KHRMeshQuantization', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const quantizationExtension = doc.createExtension(KHRMeshQuantization);

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -1,6 +1,7 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, Format, getBounds, NodeIO, Primitive } from '@gltf-transform/core';
 import { EXTMeshoptCompression, KHRMeshQuantization } from '@gltf-transform/extensions';
-import test from 'ava';
 import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -9,59 +10,60 @@ const INPUTS = ['BoxMeshopt.glb', 'BoxMeshopt.gltf'];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('decoding', async (t) => {
-	const io = await createEncoderIO();
+describe('EXTMeshoptCompression', () => {
+	test('decoding', async () => {
+		const io = await createEncoderIO();
 
-	for (const input of INPUTS) {
-		const doc = await io.read(path.join(__dirname, 'in', input));
+		for (const input of INPUTS) {
+			const doc = await io.read(path.join(__dirname, 'in', input));
+			const bbox = getBounds(doc.getRoot().listScenes()[0]);
+			deepEqual(
+				bbox.min.map((v) => +v.toFixed(3)),
+				[-0.5, -0.5, -0.5],
+				`decompress (min) - "${input}"`,
+			);
+			deepEqual(
+				bbox.max.map((v) => +v.toFixed(3)),
+				[0.5, 0.5, 0.5],
+				`decompress (max) - "${input}"`,
+			);
+		}
+	});
+
+	test('encoding', async () => {
+		const io = await createEncoderIO();
+
+		const doc = await io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
+		const glb = await io.writeBinary(doc);
+		const rtDoc = await io.readBinary(glb);
+
+		const extensionsRequired = rtDoc
+			.getRoot()
+			.listExtensionsRequired()
+			.map((ext) => ext.extensionName);
 		const bbox = getBounds(doc.getRoot().listScenes()[0]);
-		t.deepEqual(
+
+		ok(extensionsRequired.includes('EXT_meshopt_compression'), 'retains EXT_meshopt_compression');
+		deepEqual(
 			bbox.min.map((v) => +v.toFixed(3)),
 			[-0.5, -0.5, -0.5],
-			`decompress (min) - "${input}"`,
+			'round trip (min)',
 		);
-		t.deepEqual(
+		deepEqual(
 			bbox.max.map((v) => +v.toFixed(3)),
 			[0.5, 0.5, 0.5],
-			`decompress (max) - "${input}"`,
+			'round trip (max)',
 		);
-	}
-});
+	});
 
-test('encoding', async (t) => {
-	const io = await createEncoderIO();
+	test('encoding sparse', async () => {
+		const io = await createEncoderIO();
 
-	const doc = await io.read(path.join(__dirname, 'in', 'BoxMeshopt.glb'));
-	const glb = await io.writeBinary(doc);
-	const rtDoc = await io.readBinary(glb);
+		const doc = new Document();
+		doc.createExtension(EXTMeshoptCompression).setRequired(true);
 
-	const extensionsRequired = rtDoc
-		.getRoot()
-		.listExtensionsRequired()
-		.map((ext) => ext.extensionName);
-	const bbox = getBounds(doc.getRoot().listScenes()[0]);
-
-	t.truthy(extensionsRequired.includes('EXT_meshopt_compression'), 'retains EXT_meshopt_compression');
-	t.deepEqual(
-		bbox.min.map((v) => +v.toFixed(3)),
-		[-0.5, -0.5, -0.5],
-		'round trip (min)',
-	);
-	t.deepEqual(
-		bbox.max.map((v) => +v.toFixed(3)),
-		[0.5, 0.5, 0.5],
-		'round trip (max)',
-	);
-});
-
-test('encoding sparse', async (t) => {
-	const io = await createEncoderIO();
-
-	const doc = new Document();
-	doc.createExtension(EXTMeshoptCompression).setRequired(true);
-
-	// biome-ignore format: Readability.
-	const positionArray = [
+		// biome-ignore format: Readability.
+		const positionArray = [
 		0, 0, 1,
 		0, 1, 0,
 		0, 1, 1,
@@ -69,133 +71,138 @@ test('encoding sparse', async (t) => {
 		0, 0, 1,
 		0, 0, 0,
 	];
-	const sparseArray = [0, 0, 0, 0, 25, 0];
+		const sparseArray = [0, 0, 0, 0, 25, 0];
 
-	const buffer = doc.createBuffer();
-	const position = doc.createAccessor().setType('VEC3').setBuffer(buffer).setArray(new Float32Array(positionArray));
-	const marker = doc.createAccessor().setBuffer(buffer).setArray(new Uint32Array(sparseArray)).setSparse(true);
-	const prim = doc.createPrimitive().setAttribute('POSITION', position).setAttribute('_SPARSE', marker);
-	const mesh = doc.createMesh().addPrimitive(prim);
+		const buffer = doc.createBuffer();
+		const position = doc
+			.createAccessor()
+			.setType('VEC3')
+			.setBuffer(buffer)
+			.setArray(new Float32Array(positionArray));
+		const marker = doc.createAccessor().setBuffer(buffer).setArray(new Uint32Array(sparseArray)).setSparse(true);
+		const prim = doc.createPrimitive().setAttribute('POSITION', position).setAttribute('_SPARSE', marker);
+		const mesh = doc.createMesh().addPrimitive(prim);
 
-	const { json, resources } = await io.writeJSON(doc, { format: Format.GLB });
-	const primitiveDefs = json.meshes[0].primitives;
-	const accessorDefs = json.accessors;
+		const { json, resources } = await io.writeJSON(doc, { format: Format.GLB });
+		const primitiveDefs = json.meshes[0].primitives;
+		const accessorDefs = json.accessors;
 
-	t.is(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
-	t.deepEqual(
-		primitiveDefs[0],
-		{
-			mode: Primitive.Mode.TRIANGLES,
-			attributes: { POSITION: 0, _SPARSE: 1 },
-		},
-		'primitiveDef',
-	);
-	t.is(accessorDefs[0].count, 6, 'POSITION count');
-	t.is(accessorDefs[1].count, 6, '_SPARSE count');
-	t.is(accessorDefs[0].sparse, undefined, 'POSITION not sparse');
-	t.is(accessorDefs[1].sparse.count, 1, '_SPARSE sparse');
-
-	const rtDocument = await io.readJSON({ json, resources });
-	const rtPosition = rtDocument.getRoot().listAccessors()[0];
-	const rtMarker = rtDocument.getRoot().listAccessors()[1];
-
-	t.is(rtPosition.getSparse(), false, 'POSITION not sparse (round trip)');
-	t.is(rtMarker.getSparse(), true, '_SPARSE sparse (round trip)');
-	t.deepEqual(Array.from(rtPosition.getArray()), positionArray, 'POSITION array');
-	t.deepEqual(Array.from(rtMarker.getArray()), sparseArray, '_SPARSE array');
-});
-
-test('encoding grouped buffer views', async (t) => {
-	const io = await createEncoderIO();
-
-	const document = new Document();
-	const buffer = document.createBuffer();
-	const positionA = document.createAccessor().setType('VEC3').setArray(new Uint16Array(12)).setBuffer(buffer);
-	const positionB = document.createAccessor().setType('VEC3').setArray(new Uint16Array(12)).setBuffer(buffer);
-	const primA = document.createPrimitive().setAttribute('POSITION', positionA);
-	const primB = document.createPrimitive().setAttribute('POSITION', positionB);
-	const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
-	const node = document.createNode().setMesh(mesh);
-	const scene = document.createScene().addChild(node);
-	document.getRoot().setDefaultScene(scene);
-	document.createExtension(EXTMeshoptCompression).setRequired(true);
-
-	const { json } = await io.writeJSON(document);
-
-	t.deepEqual(
-		json.meshes,
-		[
+		strictEqual(primitiveDefs.length, mesh.listPrimitives().length, 'writes all primitives');
+		deepEqual(
+			primitiveDefs[0],
 			{
-				primitives: [
-					{ attributes: { POSITION: 0 }, mode: 4 },
-					{ attributes: { POSITION: 1 }, mode: 4 },
-				],
+				mode: Primitive.Mode.TRIANGLES,
+				attributes: { POSITION: 0, _SPARSE: 1 },
 			},
-		],
-		'primitives',
-	);
+			'primitiveDef',
+		);
+		strictEqual(accessorDefs[0].count, 6, 'POSITION count');
+		strictEqual(accessorDefs[1].count, 6, '_SPARSE count');
+		strictEqual(accessorDefs[0].sparse, undefined, 'POSITION not sparse');
+		strictEqual(accessorDefs[1].sparse.count, 1, '_SPARSE sparse');
 
-	t.deepEqual(
-		json.buffers,
-		[
-			{
-				uri: 'buffer.bin',
-				byteLength: 88,
-			},
-			{
-				byteLength: 64,
-				extensions: {
-					EXT_meshopt_compression: {
-						fallback: true,
+		const rtDocument = await io.readJSON({ json, resources });
+		const rtPosition = rtDocument.getRoot().listAccessors()[0];
+		const rtMarker = rtDocument.getRoot().listAccessors()[1];
+
+		strictEqual(rtPosition.getSparse(), false, 'POSITION not sparse (round trip)');
+		strictEqual(rtMarker.getSparse(), true, '_SPARSE sparse (round trip)');
+		deepEqual(Array.from(rtPosition.getArray()), positionArray, 'POSITION array');
+		deepEqual(Array.from(rtMarker.getArray()), sparseArray, '_SPARSE array');
+	});
+
+	test('encoding grouped buffer views', async () => {
+		const io = await createEncoderIO();
+
+		const document = new Document();
+		const buffer = document.createBuffer();
+		const positionA = document.createAccessor().setType('VEC3').setArray(new Uint16Array(12)).setBuffer(buffer);
+		const positionB = document.createAccessor().setType('VEC3').setArray(new Uint16Array(12)).setBuffer(buffer);
+		const primA = document.createPrimitive().setAttribute('POSITION', positionA);
+		const primB = document.createPrimitive().setAttribute('POSITION', positionB);
+		const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
+		const node = document.createNode().setMesh(mesh);
+		const scene = document.createScene().addChild(node);
+		document.getRoot().setDefaultScene(scene);
+		document.createExtension(EXTMeshoptCompression).setRequired(true);
+
+		const { json } = await io.writeJSON(document);
+
+		deepEqual(
+			json.meshes,
+			[
+				{
+					primitives: [
+						{ attributes: { POSITION: 0 }, mode: 4 },
+						{ attributes: { POSITION: 1 }, mode: 4 },
+					],
+				},
+			],
+			'primitives',
+		);
+
+		deepEqual(
+			json.buffers,
+			[
+				{
+					uri: 'buffer.bin',
+					byteLength: 88,
+				},
+				{
+					byteLength: 64,
+					extensions: {
+						EXT_meshopt_compression: {
+							fallback: true,
+						},
 					},
 				},
-			},
-		],
-		'buffers',
-	);
+			],
+			'buffers',
+		);
 
-	t.deepEqual(
-		json.bufferViews,
-		[
-			{
-				buffer: 1,
-				byteLength: 32,
-				byteOffset: 0,
-				byteStride: 8,
-				extensions: {
-					EXT_meshopt_compression: {
-						buffer: 0,
-						byteLength: 41,
-						byteOffset: 0,
-						byteStride: 8,
-						count: 4,
-						filter: undefined,
-						mode: 'ATTRIBUTES',
+		deepEqual(
+			json.bufferViews,
+			[
+				{
+					buffer: 1,
+					byteLength: 32,
+					byteOffset: 0,
+					byteStride: 8,
+					extensions: {
+						EXT_meshopt_compression: {
+							buffer: 0,
+							byteLength: 41,
+							byteOffset: 0,
+							byteStride: 8,
+							count: 4,
+							filter: undefined,
+							mode: 'ATTRIBUTES',
+						},
 					},
+					target: 34962,
 				},
-				target: 34962,
-			},
-			{
-				buffer: 1,
-				byteLength: 32,
-				byteOffset: 32,
-				byteStride: 8,
-				extensions: {
-					EXT_meshopt_compression: {
-						buffer: 0,
-						byteLength: 41,
-						byteOffset: 44,
-						byteStride: 8,
-						count: 4,
-						filter: undefined,
-						mode: 'ATTRIBUTES',
+				{
+					buffer: 1,
+					byteLength: 32,
+					byteOffset: 32,
+					byteStride: 8,
+					extensions: {
+						EXT_meshopt_compression: {
+							buffer: 0,
+							byteLength: 41,
+							byteOffset: 44,
+							byteStride: 8,
+							count: 4,
+							filter: undefined,
+							mode: 'ATTRIBUTES',
+						},
 					},
+					target: 34962,
 				},
-				target: 34962,
-			},
-		],
-		'buffer views',
-	);
+			],
+			'buffer views',
+		);
+	});
 });
 
 async function createEncoderIO(): Promise<NodeIO> {

--- a/packages/extensions/test/meshopt-compression.test.ts
+++ b/packages/extensions/test/meshopt-compression.test.ts
@@ -10,7 +10,7 @@ const INPUTS = ['BoxMeshopt.glb', 'BoxMeshopt.gltf'];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('EXTMeshoptCompression', () => {
+describe('extensions::EXTMeshoptCompression', () => {
 	test('decoding', async () => {
 		const io = await createEncoderIO();
 

--- a/packages/extensions/test/node-visibility.test.ts
+++ b/packages/extensions/test/node-visibility.test.ts
@@ -1,43 +1,50 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRNodeVisibility, type Visibility } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-test('basic', async (t) => {
-	const document = new Document();
-	const visibilityExtension = document.createExtension(KHRNodeVisibility);
-	const visibility = visibilityExtension.createVisibility().setVisible(false);
+describe('KHRNodeVisibility', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const visibilityExtension = document.createExtension(KHRNodeVisibility);
+		const visibility = visibilityExtension.createVisibility().setVisible(false);
 
-	const node = document.createNode('MyNode').setExtension('KHR_node_visibility', visibility);
+		const node = document.createNode('MyNode').setExtension('KHR_node_visibility', visibility);
 
-	t.is(node.getExtension('KHR_node_visibility'), visibility, 'visibility is attached');
+		strictEqual(node.getExtension('KHR_node_visibility'), visibility, 'visibility is attached');
 
-	const jsonDoc = await new NodeIO().registerExtensions([KHRNodeVisibility]).writeJSON(document, WRITER_OPTIONS);
-	const nodeDef = jsonDoc.json.nodes[0];
+		const jsonDoc = await new NodeIO().registerExtensions([KHRNodeVisibility]).writeJSON(document, WRITER_OPTIONS);
+		const nodeDef = jsonDoc.json.nodes[0];
 
-	t.deepEqual(nodeDef.extensions, { KHR_node_visibility: { visible: false } }, 'writes visibility extension');
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRNodeVisibility.EXTENSION_NAME], 'writes extensionsUsed');
+		deepEqual(nodeDef.extensions, { KHR_node_visibility: { visible: false } }, 'writes visibility extension');
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRNodeVisibility.EXTENSION_NAME], 'writes extensionsUsed');
 
-	visibilityExtension.dispose();
-	t.is(node.getExtension('KHR_node_visibility'), null, 'visibility is detached');
+		visibilityExtension.dispose();
+		strictEqual(node.getExtension('KHR_node_visibility'), null, 'visibility is detached');
 
-	const roundtripDoc = await new NodeIO().registerExtensions([KHRNodeVisibility]).readJSON(jsonDoc);
-	const roundtripNode = roundtripDoc.getRoot().listNodes().pop();
+		const roundtripDoc = await new NodeIO().registerExtensions([KHRNodeVisibility]).readJSON(jsonDoc);
+		const roundtripNode = roundtripDoc.getRoot().listNodes().pop();
 
-	t.is(roundtripNode.getExtension<Visibility>('KHR_node_visibility').getVisible(), false, 'reads visibility');
-});
+		strictEqual(
+			roundtripNode.getExtension<Visibility>('KHR_node_visibility').getVisible(),
+			false,
+			'reads visibility',
+		);
+	});
 
-test('copy', (t) => {
-	const document = new Document();
-	const visibilityExtension = document.createExtension(KHRNodeVisibility);
-	const visibility = visibilityExtension.createVisibility().setVisible(false);
-	document.createNode().setExtension('KHR_node_visibility', visibility);
+	test('copy', () => {
+		const document = new Document();
+		const visibilityExtension = document.createExtension(KHRNodeVisibility);
+		const visibility = visibilityExtension.createVisibility().setVisible(false);
+		document.createNode().setExtension('KHR_node_visibility', visibility);
 
-	const document2 = cloneDocument(document);
-	const visibility2 = document2.getRoot().listNodes()[0].getExtension<Visibility>('KHR_node_visibility');
-	t.is(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRNodeVisibility');
-	t.truthy(visibility2, 'copy Visibility');
-	t.is(visibility2.getVisible(), false, 'copy visibility');
+		const document2 = cloneDocument(document);
+		const visibility2 = document2.getRoot().listNodes()[0].getExtension<Visibility>('KHR_node_visibility');
+		strictEqual(document2.getRoot().listExtensionsUsed().length, 1, 'copy KHRNodeVisibility');
+		ok(visibility2, 'copy Visibility');
+		strictEqual(visibility2.getVisible(), false, 'copy visibility');
+	});
 });

--- a/packages/extensions/test/node-visibility.test.ts
+++ b/packages/extensions/test/node-visibility.test.ts
@@ -6,7 +6,7 @@ import { cloneDocument } from '@gltf-transform/functions';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
-describe('KHRNodeVisibility', () => {
+describe('extensions::KHRNodeVisibility', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const visibilityExtension = document.createExtension(KHRNodeVisibility);

--- a/packages/extensions/test/structural-metadata.test.ts
+++ b/packages/extensions/test/structural-metadata.test.ts
@@ -1,36 +1,39 @@
+import { deepEqual, ok } from 'node:assert/strict';
 import { glob } from 'node:fs/promises';
+import { describe, test } from 'node:test';
 import { Document, type JSONDocument } from '@gltf-transform/core';
 import { EXTStructuralMetadata } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { createPlatformIO } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 import { basename, dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('round trip', async (t) => {
-	const io = (await createPlatformIO()).registerExtensions([EXTStructuralMetadata]);
+describe('EXTStructuralMetadata', () => {
+	test('round trip', async () => {
+		const io = (await createPlatformIO()).registerExtensions([EXTStructuralMetadata]);
 
-	for await (const inputPath of glob(resolve(__dirname, 'in', 'EXT_structural_metadata', '*.gltf'))) {
-		const inputBasename = basename(inputPath);
+		for await (const inputPath of glob(resolve(__dirname, 'in', 'EXT_structural_metadata', '*.gltf'))) {
+			const inputBasename = basename(inputPath);
 
-		const srcJSONDocument = await io.readAsJSON(inputPath);
-		const dstJSONDocument = await io.writeJSON(await io.readJSON(srcJSONDocument));
+			const srcJSONDocument = await io.readAsJSON(inputPath);
+			const dstJSONDocument = await io.writeJSON(await io.readJSON(srcJSONDocument));
 
-		const srcExtensionDef = snapshotExtensionDef(srcJSONDocument);
-		const dstExtensionDef = snapshotExtensionDef(dstJSONDocument);
+			const srcExtensionDef = snapshotExtensionDef(srcJSONDocument);
+			const dstExtensionDef = snapshotExtensionDef(dstJSONDocument);
 
-		t.deepEqual(dstExtensionDef, srcExtensionDef, inputBasename);
-	}
-});
+			deepEqual(dstExtensionDef, srcExtensionDef, inputBasename);
+		}
+	});
 
-test('clone', (t) => {
-	const doc = new Document();
-	doc.createExtension(EXTStructuralMetadata);
+	test('clone', () => {
+		const doc = new Document();
+		doc.createExtension(EXTStructuralMetadata);
 
-	t.true(cloneDocument(doc).hasExtension('EXT_structural_metadata'), 'copy EXTStructuralMetadata');
+		ok(cloneDocument(doc).hasExtension('EXT_structural_metadata'), 'copy EXTStructuralMetadata');
+	});
 });
 
 /**

--- a/packages/extensions/test/structural-metadata.test.ts
+++ b/packages/extensions/test/structural-metadata.test.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('EXTStructuralMetadata', () => {
+describe('extensions::EXTStructuralMetadata', () => {
 	test('round trip', async () => {
 		const io = (await createPlatformIO()).registerExtensions([EXTStructuralMetadata]);
 

--- a/packages/extensions/test/texture-avif.test.ts
+++ b/packages/extensions/test/texture-avif.test.ts
@@ -11,7 +11,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 const io = new NodeIO().registerExtensions([EXTTextureAVIF]);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('EXTTextureAVIF', () => {
+describe('extensions::EXTTextureAVIF', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/texture-avif.test.ts
+++ b/packages/extensions/test/texture-avif.test.ts
@@ -1,6 +1,7 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type GLTF, ImageUtils, type JSONDocument, NodeIO } from '@gltf-transform/core';
 import { EXTTextureAVIF } from '@gltf-transform/extensions';
-import test from 'ava';
 import fs from 'fs';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -10,52 +11,54 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 const io = new NodeIO().registerExtensions([EXTTextureAVIF]);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const avifExtension = doc.createExtension(EXTTextureAVIF);
-	const tex1 = doc.createTexture('AVIFTexture').setMimeType('image/avif').setImage(new Uint8Array(10));
-	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
-	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
+describe('EXTTextureAVIF', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const avifExtension = doc.createExtension(EXTTextureAVIF);
+		const tex1 = doc.createTexture('AVIFTexture').setMimeType('image/avif').setImage(new Uint8Array(10));
+		const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
+		doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
 
-	let jsonDoc: JSONDocument;
+		let jsonDoc: JSONDocument;
 
-	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 
-	// Writing to file.
-	t.deepEqual(jsonDoc.json.extensionsUsed, ['EXT_texture_avif'], 'writes extensionsUsed');
-	t.is(jsonDoc.json.textures[0].source, undefined, 'omits .source on AVIF texture');
-	t.is(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
-	t.is(
-		(jsonDoc.json.textures[0].extensions['EXT_texture_avif'] as GLTF.ITexture).source,
-		0,
-		'includes .source on AVIF extension',
-	);
+		// Writing to file.
+		deepEqual(jsonDoc.json.extensionsUsed, ['EXT_texture_avif'], 'writes extensionsUsed');
+		strictEqual(jsonDoc.json.textures[0].source, undefined, 'omits .source on AVIF texture');
+		strictEqual(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
+		strictEqual(
+			(jsonDoc.json.textures[0].extensions['EXT_texture_avif'] as GLTF.ITexture).source,
+			0,
+			'includes .source on AVIF extension',
+		);
 
-	// Read (roundtrip) from file.
-	const rtDoc = await io.readJSON(jsonDoc);
-	const rtRoot = rtDoc.getRoot();
-	t.is(rtRoot.listTextures()[0].getMimeType(), 'image/avif', 'reads AVIF mimetype');
-	t.is(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
-	t.is(rtRoot.listTextures()[0].getImage().byteLength, 10, 'reads AVIF payload');
-	t.is(rtRoot.listTextures()[1].getImage().byteLength, 15, 'reads PNG payload');
+		// Read (roundtrip) from file.
+		const rtDoc = await io.readJSON(jsonDoc);
+		const rtRoot = rtDoc.getRoot();
+		strictEqual(rtRoot.listTextures()[0].getMimeType(), 'image/avif', 'reads AVIF mimetype');
+		strictEqual(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
+		strictEqual(rtRoot.listTextures()[0].getImage().byteLength, 10, 'reads AVIF payload');
+		strictEqual(rtRoot.listTextures()[1].getImage().byteLength, 15, 'reads PNG payload');
 
-	// Clean up extension data, revert to core glTF.
-	avifExtension.dispose();
-	tex1.dispose();
-	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
-	t.is(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
-	t.is(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
-	t.is(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');
-});
+		// Clean up extension data, revert to core glTF.
+		avifExtension.dispose();
+		tex1.dispose();
+		jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		strictEqual(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
+		strictEqual(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
+		strictEqual(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');
+	});
 
-test('image-utils', (t) => {
-	const avif = fs.readFileSync(path.join(__dirname, 'in', 'test.avif'));
-	const buffer = new Uint8Array([0, 1, 2, 3]);
+	test('image-utils', () => {
+		const avif = fs.readFileSync(path.join(__dirname, 'in', 'test.avif'));
+		const buffer = new Uint8Array([0, 1, 2, 3]);
 
-	t.is(ImageUtils.getSize(new Uint8Array(8), 'image/avif'), null, 'invalid');
-	t.is(ImageUtils.getSize(buffer, 'image/avif'), null, 'no size');
-	t.deepEqual(ImageUtils.getSize(avif, 'image/avif'), [256, 256], 'size');
-	t.is(ImageUtils.getChannels(avif, 'image/avif'), 4, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(avif, 'image/avif'), 349524, 'vramSize');
+		strictEqual(ImageUtils.getSize(new Uint8Array(8), 'image/avif'), null, 'invalid');
+		strictEqual(ImageUtils.getSize(buffer, 'image/avif'), null, 'no size');
+		deepEqual(ImageUtils.getSize(avif, 'image/avif'), [256, 256], 'size');
+		strictEqual(ImageUtils.getChannels(avif, 'image/avif'), 4, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(avif, 'image/avif'), 349524, 'vramSize');
+	});
 });

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -1,6 +1,7 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type GLTF, ImageUtils, type JSONDocument, NodeIO } from '@gltf-transform/core';
 import { KHRTextureBasisu } from '@gltf-transform/extensions';
-import test from 'ava';
 import fs from 'fs';
 import path from 'path';
 
@@ -9,118 +10,120 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 const io = new NodeIO().registerExtensions([KHRTextureBasisu]);
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const basisuExtension = doc.createExtension(KHRTextureBasisu);
-	const tex1 = doc.createTexture('BasisTexture').setMimeType('image/ktx2').setImage(new Uint8Array(10));
-	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
-	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
+describe('KHRTextureBasisu', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const basisuExtension = doc.createExtension(KHRTextureBasisu);
+		const tex1 = doc.createTexture('BasisTexture').setMimeType('image/ktx2').setImage(new Uint8Array(10));
+		const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
+		doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
 
-	let jsonDoc: JSONDocument;
+		let jsonDoc: JSONDocument;
 
-	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 
-	// Writing to file.
-	t.deepEqual(jsonDoc.json.extensionsUsed, [KHRTextureBasisu.EXTENSION_NAME], 'writes extensionsUsed');
-	t.is(jsonDoc.json.textures[0].source, undefined, 'omits .source on KTX2 texture');
-	t.is(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
-	t.is(
-		(jsonDoc.json.textures[0].extensions['KHR_texture_basisu'] as GLTF.ITexture).source,
-		0,
-		'includes .source on KTX2 extension',
-	);
+		// Writing to file.
+		deepEqual(jsonDoc.json.extensionsUsed, [KHRTextureBasisu.EXTENSION_NAME], 'writes extensionsUsed');
+		strictEqual(jsonDoc.json.textures[0].source, undefined, 'omits .source on KTX2 texture');
+		strictEqual(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
+		strictEqual(
+			(jsonDoc.json.textures[0].extensions['KHR_texture_basisu'] as GLTF.ITexture).source,
+			0,
+			'includes .source on KTX2 extension',
+		);
 
-	// Read (roundtrip) from file.
-	const rtDoc = await io.readJSON(jsonDoc);
-	const rtRoot = rtDoc.getRoot();
-	t.is(rtRoot.listTextures()[0].getMimeType(), 'image/ktx2', 'reads KTX2 mimetype');
-	t.is(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
-	t.is(rtRoot.listTextures()[0].getImage().byteLength, 10, 'reads KTX2 payload');
-	t.is(rtRoot.listTextures()[1].getImage().byteLength, 15, 'reads PNG payload');
+		// Read (roundtrip) from file.
+		const rtDoc = await io.readJSON(jsonDoc);
+		const rtRoot = rtDoc.getRoot();
+		strictEqual(rtRoot.listTextures()[0].getMimeType(), 'image/ktx2', 'reads KTX2 mimetype');
+		strictEqual(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
+		strictEqual(rtRoot.listTextures()[0].getImage().byteLength, 10, 'reads KTX2 payload');
+		strictEqual(rtRoot.listTextures()[1].getImage().byteLength, 15, 'reads PNG payload');
 
-	// Clean up extension data, revert to core glTF.
-	basisuExtension.dispose();
-	tex1.dispose();
-	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
-	t.is(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
-	t.is(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
-	t.is(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');
-});
+		// Clean up extension data, revert to core glTF.
+		basisuExtension.dispose();
+		tex1.dispose();
+		jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		strictEqual(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
+		strictEqual(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
+		strictEqual(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');
+	});
 
-test('image-utils | basic', (t) => {
-	t.throws(() => ImageUtils.getSize(new Uint8Array(10), 'image/ktx2'), undefined, 'corrupt file');
-	t.is(ImageUtils.extensionToMimeType('ktx2'), 'image/ktx2', 'extensionToMimeType, inferred');
-});
+	test('image-utils | basic', () => {
+		throws(() => ImageUtils.getSize(new Uint8Array(10), 'image/ktx2'), undefined, 'corrupt file');
+		strictEqual(ImageUtils.extensionToMimeType('ktx2'), 'image/ktx2', 'extensionToMimeType, inferred');
+	});
 
-test('image-utils | etc1s', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_etc1s.ktx2'));
+	test('image-utils | etc1s', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_etc1s.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.is(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 1065, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		strictEqual(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 1065, 'gpuSize');
+	});
 
-test('image-utils | uastc', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_uastc.ktx2'));
+	test('image-utils | uastc', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_uastc.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.is(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 2240, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		strictEqual(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 2240, 'gpuSize');
+	});
 
-test('image-utils | rgb8', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgb8.ktx2'));
+	test('image-utils | rgb8', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgb8.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.is(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 6390, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		strictEqual(ImageUtils.getChannels(ktx2, 'image/ktx2'), 3, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 6390, 'gpuSize');
+	});
 
-test('image-utils | rgba8', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgba8.ktx2'));
+	test('image-utils | rgba8', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgba8.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.is(ImageUtils.getChannels(ktx2, 'image/ktx2'), 4, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 8520, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		strictEqual(ImageUtils.getChannels(ktx2, 'image/ktx2'), 4, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 8520, 'gpuSize');
+	});
 
-test('image-utils | rgba16', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgba16_linear.ktx2'));
+	test('image-utils | rgba16', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgba16_linear.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.is(ImageUtils.getChannels(ktx2, 'image/ktx2'), 4, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 17040, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		strictEqual(ImageUtils.getChannels(ktx2, 'image/ktx2'), 4, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 17040, 'gpuSize');
+	});
 
-test('image-utils | rgba32', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgba32_linear.ktx2'));
+	test('image-utils | rgba32', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_rgba32_linear.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.is(ImageUtils.getChannels(ktx2, 'image/ktx2'), 4, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 34080, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		strictEqual(ImageUtils.getChannels(ktx2, 'image/ktx2'), 4, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 34080, 'gpuSize');
+	});
 
-test('image-utils | astc4x4', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_astc4x4.ktx2'));
+	test('image-utils | astc4x4', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_astc4x4.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.throws(() => ImageUtils.getChannels(ktx2, 'image/ktx2'), { message: /vkFormat/ }, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 2240, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		throws(() => ImageUtils.getChannels(ktx2, 'image/ktx2'), { message: /vkFormat/ }, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 2240, 'gpuSize');
+	});
 
-test('image-utils | bc1', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_bc1.ktx2'));
+	test('image-utils | bc1', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_bc1.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.throws(() => ImageUtils.getChannels(ktx2, 'image/ktx2'), { message: /vkFormat/ }, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 1120, 'gpuSize');
-});
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		throws(() => ImageUtils.getChannels(ktx2, 'image/ktx2'), { message: /vkFormat/ }, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 1120, 'gpuSize');
+	});
 
-test('image-utils | bc7', (t) => {
-	const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_bc7.ktx2'));
+	test('image-utils | bc7', () => {
+		const ktx2 = fs.readFileSync(path.join(__dirname, 'in', '2d_bc7.ktx2'));
 
-	t.deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
-	t.throws(() => ImageUtils.getChannels(ktx2, 'image/ktx2'), { message: /vkFormat/ }, 'channels');
-	t.is(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 2240, 'gpuSize');
+		deepEqual(ImageUtils.getSize(ktx2, 'image/ktx2'), [40, 40], 'size');
+		throws(() => ImageUtils.getChannels(ktx2, 'image/ktx2'), { message: /vkFormat/ }, 'channels');
+		strictEqual(ImageUtils.getVRAMByteLength(ktx2, 'image/ktx2'), 2240, 'gpuSize');
+	});
 });

--- a/packages/extensions/test/texture-basisu.test.ts
+++ b/packages/extensions/test/texture-basisu.test.ts
@@ -10,7 +10,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 const io = new NodeIO().registerExtensions([KHRTextureBasisu]);
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-describe('KHRTextureBasisu', () => {
+describe('extensions::KHRTextureBasisu', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -1,221 +1,231 @@
+import { deepEqual, notStrictEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { type Clearcoat, KHRMaterialsClearcoat, KHRTextureTransform, type Transform } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([KHRTextureTransform]);
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const transformExtension = doc.createExtension(KHRTextureTransform);
-	const tex1 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(10));
-	const tex2 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(15));
-	const tex3 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(20));
-	const mat = doc.createMaterial();
-	mat.setBaseColorTexture(tex1)
-		.getBaseColorTextureInfo()
-		.setExtension(
-			'KHR_texture_transform',
-			transformExtension.createTransform().setTexCoord(2).setScale([100, 100]),
+describe('KHRTextureTransform', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const transformExtension = doc.createExtension(KHRTextureTransform);
+		const tex1 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(10));
+		const tex2 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(15));
+		const tex3 = doc.createTexture().setMimeType('image/png').setImage(new Uint8Array(20));
+		const mat = doc.createMaterial();
+		mat.setBaseColorTexture(tex1)
+			.getBaseColorTextureInfo()
+			.setExtension(
+				'KHR_texture_transform',
+				transformExtension.createTransform().setTexCoord(2).setScale([100, 100]),
+			);
+		mat.setEmissiveTexture(tex2)
+			.getEmissiveTextureInfo()
+			.setExtension(
+				'KHR_texture_transform',
+				transformExtension.createTransform().setTexCoord(1).setOffset([0.5, 0.5]).setRotation(Math.PI),
+			);
+		mat.setOcclusionTexture(tex3);
+
+		// Read (roundtrip) from file.
+		const rtDoc = await io.readJSON(await io.writeJSON(doc, WRITER_OPTIONS));
+		const rtMat = rtDoc.getRoot().listMaterials()[0];
+		const rtTransform1 = rtMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
+		const rtTransform2 = rtMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
+		const rtTransform3 = rtMat.getOcclusionTextureInfo().getExtension<Transform>('KHR_texture_transform');
+
+		ok(rtTransform1, 'baseColorTexture transform');
+		ok(rtTransform2, 'emissiveColorTexture transform');
+		strictEqual(rtTransform3, null, 'occlusionColorTexture transform');
+
+		strictEqual(rtTransform1.getTexCoord(), 2, 'baseColorTexture.texCoord');
+		deepEqual(rtTransform1.getScale(), [100, 100], 'baseColorTexture.scale');
+		deepEqual(rtTransform1.getOffset(), [0, 0], 'baseColorTexture.offset');
+		deepEqual(rtTransform1.getRotation(), 0, 'baseColorTexture.rotation');
+
+		strictEqual(rtTransform2.getTexCoord(), 1, 'emissiveColorTexture.texCoord');
+		deepEqual(rtTransform2.getScale(), [1, 1], 'emissiveColorTexture.scale');
+		deepEqual(rtTransform2.getOffset(), [0.5, 0.5], 'emissiveColorTexture.offset');
+		deepEqual(rtTransform2.getRotation(), Math.PI, 'emissiveColorTexture.rotation');
+
+		// Clean up extension data, revert to core glTF.
+		transformExtension.dispose();
+		strictEqual(
+			mat.getBaseColorTextureInfo().getExtension('KHR_texture_transform'),
+			null,
+			'clears baseColorTexture transform',
 		);
-	mat.setEmissiveTexture(tex2)
-		.getEmissiveTextureInfo()
-		.setExtension(
-			'KHR_texture_transform',
-			transformExtension.createTransform().setTexCoord(1).setOffset([0.5, 0.5]).setRotation(Math.PI),
+		strictEqual(
+			mat.getEmissiveTextureInfo().getExtension('KHR_texture_transform'),
+			null,
+			'clears emissiveColorTexture transform',
 		);
-	mat.setOcclusionTexture(tex3);
+	});
 
-	// Read (roundtrip) from file.
-	const rtDoc = await io.readJSON(await io.writeJSON(doc, WRITER_OPTIONS));
-	const rtMat = rtDoc.getRoot().listMaterials()[0];
-	const rtTransform1 = rtMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
-	const rtTransform2 = rtMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
-	const rtTransform3 = rtMat.getOcclusionTextureInfo().getExtension<Transform>('KHR_texture_transform');
+	test('clone', () => {
+		const srcDoc = new Document();
+		const transformExtension = srcDoc.createExtension(KHRTextureTransform);
+		const tex1 = srcDoc.createTexture();
+		const tex2 = srcDoc.createTexture();
+		const tex3 = srcDoc.createTexture();
 
-	t.truthy(rtTransform1, 'baseColorTexture transform');
-	t.truthy(rtTransform2, 'emissiveColorTexture transform');
-	t.falsy(rtTransform3, 'occlusionColorTexture transform');
+		const srcMat = srcDoc.createMaterial();
+		srcMat
+			.setBaseColorTexture(tex1)
+			.getBaseColorTextureInfo()
+			.setExtension(
+				'KHR_texture_transform',
+				transformExtension.createTransform().setTexCoord(2).setScale([100, 100]),
+			);
+		srcMat
+			.setEmissiveTexture(tex2)
+			.getEmissiveTextureInfo()
+			.setExtension(
+				'KHR_texture_transform',
+				transformExtension.createTransform().setTexCoord(1).setOffset([0.5, 0.5]).setRotation(Math.PI),
+			);
+		srcMat.setOcclusionTexture(tex3);
 
-	t.is(rtTransform1.getTexCoord(), 2, 'baseColorTexture.texCoord');
-	t.deepEqual(rtTransform1.getScale(), [100, 100], 'baseColorTexture.scale');
-	t.deepEqual(rtTransform1.getOffset(), [0, 0], 'baseColorTexture.offset');
-	t.deepEqual(rtTransform1.getRotation(), 0, 'baseColorTexture.rotation');
+		// Clone the Document.
+		const dstDoc = cloneDocument(srcDoc);
 
-	t.is(rtTransform2.getTexCoord(), 1, 'emissiveColorTexture.texCoord');
-	t.deepEqual(rtTransform2.getScale(), [1, 1], 'emissiveColorTexture.scale');
-	t.deepEqual(rtTransform2.getOffset(), [0.5, 0.5], 'emissiveColorTexture.offset');
-	t.deepEqual(rtTransform2.getRotation(), Math.PI, 'emissiveColorTexture.rotation');
+		// Ensure source Document is unchanged.
 
-	// Clean up extension data, revert to core glTF.
-	transformExtension.dispose();
-	t.falsy(mat.getBaseColorTextureInfo().getExtension('KHR_texture_transform'), 'clears baseColorTexture transform');
-	t.falsy(
-		mat.getEmissiveTextureInfo().getExtension('KHR_texture_transform'),
-		'clears emissiveColorTexture transform',
-	);
-});
+		const srcTransform1 = srcMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
+		const srcTransform2 = srcMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
 
-test('clone', (t) => {
-	const srcDoc = new Document();
-	const transformExtension = srcDoc.createExtension(KHRTextureTransform);
-	const tex1 = srcDoc.createTexture();
-	const tex2 = srcDoc.createTexture();
-	const tex3 = srcDoc.createTexture();
+		ok(srcTransform1, 'original baseColorTexture transform unchanged');
+		ok(srcTransform2, 'original emissiveColorTexture transform unchanged');
 
-	const srcMat = srcDoc.createMaterial();
-	srcMat
-		.setBaseColorTexture(tex1)
-		.getBaseColorTextureInfo()
-		.setExtension(
-			'KHR_texture_transform',
-			transformExtension.createTransform().setTexCoord(2).setScale([100, 100]),
+		// Ensure target Document matches.
+
+		const dstMat = dstDoc.getRoot().listMaterials()[0];
+		const dstTransform1 = dstMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
+		const dstTransform2 = dstMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
+
+		ok(dstTransform1, 'cloned baseColorTexture transform added');
+		ok(dstTransform2, 'cloned emissiveColorTexture transform added');
+
+		notStrictEqual(srcTransform1, dstTransform1, 'baseColorTexture transform cloned');
+		notStrictEqual(srcTransform2, dstTransform2, 'emissiveColorTexture transform cloned');
+
+		strictEqual(dstTransform1.getTexCoord(), 2, 'baseColorTexture.texCoord');
+		deepEqual(dstTransform1.getScale(), [100, 100], 'baseColorTexture.scale');
+		deepEqual(dstTransform1.getOffset(), [0, 0], 'baseColorTexture.offset');
+		deepEqual(dstTransform1.getRotation(), 0, 'baseColorTexture.rotation');
+
+		strictEqual(dstTransform2.getTexCoord(), 1, 'emissiveColorTexture.texCoord');
+		deepEqual(dstTransform2.getScale(), [1, 1], 'emissiveColorTexture.scale');
+		deepEqual(dstTransform2.getOffset(), [0.5, 0.5], 'emissiveColorTexture.offset');
+		deepEqual(dstTransform2.getRotation(), Math.PI, 'emissiveColorTexture.rotation');
+	});
+
+	test('i/o', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const transformExtension = doc.createExtension(KHRTextureTransform);
+		const tex1 = doc.createTexture();
+
+		const mat = doc.createMaterial();
+		mat.setBaseColorTexture(tex1)
+			.getBaseColorTextureInfo()
+			.setExtension('KHR_texture_transform', transformExtension.createTransform().setScale([100, 100]));
+		mat.setEmissiveTexture(tex1)
+			.getEmissiveTextureInfo()
+			.setExtension(
+				'KHR_texture_transform',
+				transformExtension.createTransform().setTexCoord(0).setOffset([0.5, 0.5]).setRotation(Math.PI),
+			);
+
+		const jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		const materialDef = jsonDoc.json.materials[0];
+		const baseColorTextureInfoDef = materialDef.pbrMetallicRoughness.baseColorTexture;
+		const emissiveTextureInfoDef = materialDef.emissiveTexture;
+
+		deepEqual(
+			baseColorTextureInfoDef.extensions,
+			{ KHR_texture_transform: { scale: [100, 100] } }, // omit texCoord!
+			'base color texture info',
 		);
-	srcMat
-		.setEmissiveTexture(tex2)
-		.getEmissiveTextureInfo()
-		.setExtension(
-			'KHR_texture_transform',
-			transformExtension.createTransform().setTexCoord(1).setOffset([0.5, 0.5]).setRotation(Math.PI),
+		deepEqual(
+			emissiveTextureInfoDef.extensions,
+			{ KHR_texture_transform: { texCoord: 0, offset: [0.5, 0.5], rotation: Math.PI } },
+			'emissive texture info',
 		);
-	srcMat.setOcclusionTexture(tex3);
+	});
 
-	// Clone the Document.
-	const dstDoc = cloneDocument(srcDoc);
+	// See https://github.com/donmccurdy/glTF-Transform/issues/1256.
+	test('order independence', async () => {
+		const documentA = new Document().setLogger(logger);
+		const documentB = new Document().setLogger(logger);
 
-	// Ensure source Document is unchanged.
+		documentA.createBuffer();
+		documentB.createBuffer();
 
-	const srcTransform1 = srcMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
-	const srcTransform2 = srcMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
+		// KHR_texture_transform before KHR_materials_clearcoat
+		const ioA = new NodeIO().setLogger(logger).registerExtensions([KHRTextureTransform, KHRMaterialsClearcoat]);
+		const transformExtensionA = documentA.createExtension(KHRTextureTransform);
+		const clearcoatExtensionA = documentA.createExtension(KHRMaterialsClearcoat);
 
-	t.truthy(srcTransform1, 'original baseColorTexture transform unchanged');
-	t.truthy(srcTransform2, 'original emissiveColorTexture transform unchanged');
+		// KHR_materials_clearcoat before KHR_texture_transform
+		const ioB = new NodeIO().setLogger(logger).registerExtensions([KHRMaterialsClearcoat, KHRTextureTransform]);
+		const clearcoatExtensionB = documentB.createExtension(KHRMaterialsClearcoat);
+		const transformExtensionB = documentB.createExtension(KHRTextureTransform);
 
-	// Ensure target Document matches.
+		const fixtures = [
+			['transform then clearcoat', ioA, documentA, transformExtensionA, clearcoatExtensionA],
+			['clearcoat then transform', ioB, documentB, transformExtensionB, clearcoatExtensionB],
+		] as [string, NodeIO, Document, KHRTextureTransform, KHRMaterialsClearcoat][];
 
-	const dstMat = dstDoc.getRoot().listMaterials()[0];
-	const dstTransform1 = dstMat.getBaseColorTextureInfo().getExtension<Transform>('KHR_texture_transform');
-	const dstTransform2 = dstMat.getEmissiveTextureInfo().getExtension<Transform>('KHR_texture_transform');
+		for (const [title, io, document, transformExtension, clearcoatExtension] of fixtures) {
+			const texture = document.createTexture().setMimeType('image/png').setImage(new Uint8Array(10));
+			const transform = transformExtension.createTransform().setScale([100, 100]);
+			const material = document.createMaterial().setBaseColorTexture(texture);
+			material.getBaseColorTextureInfo()!.setExtension('KHR_texture_transform', transform);
 
-	t.truthy(dstTransform1, 'cloned baseColorTexture transform added');
-	t.truthy(dstTransform2, 'cloned emissiveColorTexture transform added');
+			const clearcoat = clearcoatExtension.createClearcoat().setClearcoatTexture(texture);
+			clearcoat.getClearcoatTextureInfo()!.setExtension('KHR_texture_transform', transform);
+			material.setExtension('KHR_materials_clearcoat', clearcoat);
 
-	t.not(srcTransform1, dstTransform1, 'baseColorTexture transform cloned');
-	t.not(srcTransform2, dstTransform2, 'emissiveColorTexture transform cloned');
+			const { json, resources } = await io.writeJSON(document);
 
-	t.is(dstTransform1.getTexCoord(), 2, 'baseColorTexture.texCoord');
-	t.deepEqual(dstTransform1.getScale(), [100, 100], 'baseColorTexture.scale');
-	t.deepEqual(dstTransform1.getOffset(), [0, 0], 'baseColorTexture.offset');
-	t.deepEqual(dstTransform1.getRotation(), 0, 'baseColorTexture.rotation');
-
-	t.is(dstTransform2.getTexCoord(), 1, 'emissiveColorTexture.texCoord');
-	t.deepEqual(dstTransform2.getScale(), [1, 1], 'emissiveColorTexture.scale');
-	t.deepEqual(dstTransform2.getOffset(), [0.5, 0.5], 'emissiveColorTexture.offset');
-	t.deepEqual(dstTransform2.getRotation(), Math.PI, 'emissiveColorTexture.rotation');
-});
-
-test('i/o', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const transformExtension = doc.createExtension(KHRTextureTransform);
-	const tex1 = doc.createTexture();
-
-	const mat = doc.createMaterial();
-	mat.setBaseColorTexture(tex1)
-		.getBaseColorTextureInfo()
-		.setExtension('KHR_texture_transform', transformExtension.createTransform().setScale([100, 100]));
-	mat.setEmissiveTexture(tex1)
-		.getEmissiveTextureInfo()
-		.setExtension(
-			'KHR_texture_transform',
-			transformExtension.createTransform().setTexCoord(0).setOffset([0.5, 0.5]).setRotation(Math.PI),
-		);
-
-	const jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
-	const materialDef = jsonDoc.json.materials[0];
-	const baseColorTextureInfoDef = materialDef.pbrMetallicRoughness.baseColorTexture;
-	const emissiveTextureInfoDef = materialDef.emissiveTexture;
-
-	t.deepEqual(
-		baseColorTextureInfoDef.extensions,
-		{ KHR_texture_transform: { scale: [100, 100] } }, // omit texCoord!
-		'base color texture info',
-	);
-	t.deepEqual(
-		emissiveTextureInfoDef.extensions,
-		{ KHR_texture_transform: { texCoord: 0, offset: [0.5, 0.5], rotation: Math.PI } },
-		'emissive texture info',
-	);
-});
-
-// See https://github.com/donmccurdy/glTF-Transform/issues/1256.
-test('order independence', async (t) => {
-	const documentA = new Document().setLogger(logger);
-	const documentB = new Document().setLogger(logger);
-
-	documentA.createBuffer();
-	documentB.createBuffer();
-
-	// KHR_texture_transform before KHR_materials_clearcoat
-	const ioA = new NodeIO().setLogger(logger).registerExtensions([KHRTextureTransform, KHRMaterialsClearcoat]);
-	const transformExtensionA = documentA.createExtension(KHRTextureTransform);
-	const clearcoatExtensionA = documentA.createExtension(KHRMaterialsClearcoat);
-
-	// KHR_materials_clearcoat before KHR_texture_transform
-	const ioB = new NodeIO().setLogger(logger).registerExtensions([KHRMaterialsClearcoat, KHRTextureTransform]);
-	const clearcoatExtensionB = documentB.createExtension(KHRMaterialsClearcoat);
-	const transformExtensionB = documentB.createExtension(KHRTextureTransform);
-
-	const fixtures = [
-		['transform then clearcoat', ioA, documentA, transformExtensionA, clearcoatExtensionA],
-		['clearcoat then transform', ioB, documentB, transformExtensionB, clearcoatExtensionB],
-	] as [string, NodeIO, Document, KHRTextureTransform, KHRMaterialsClearcoat][];
-
-	for (const [title, io, document, transformExtension, clearcoatExtension] of fixtures) {
-		const texture = document.createTexture().setMimeType('image/png').setImage(new Uint8Array(10));
-		const transform = transformExtension.createTransform().setScale([100, 100]);
-		const material = document.createMaterial().setBaseColorTexture(texture);
-		material.getBaseColorTextureInfo()!.setExtension('KHR_texture_transform', transform);
-
-		const clearcoat = clearcoatExtension.createClearcoat().setClearcoatTexture(texture);
-		clearcoat.getClearcoatTextureInfo()!.setExtension('KHR_texture_transform', transform);
-		material.setExtension('KHR_materials_clearcoat', clearcoat);
-
-		const { json, resources } = await io.writeJSON(document);
-
-		t.deepEqual(
-			json.materials,
-			[
-				{
-					extensions: {
-						KHR_materials_clearcoat: {
-							clearcoatFactor: 0,
-							clearcoatRoughnessFactor: 0,
-							clearcoatTexture: {
+			deepEqual(
+				json.materials,
+				[
+					{
+						extensions: {
+							KHR_materials_clearcoat: {
+								clearcoatFactor: 0,
+								clearcoatRoughnessFactor: 0,
+								clearcoatTexture: {
+									extensions: { KHR_texture_transform: { scale: [100, 100] } },
+									index: 0,
+								},
+							},
+						},
+						pbrMetallicRoughness: {
+							baseColorTexture: {
 								extensions: { KHR_texture_transform: { scale: [100, 100] } },
 								index: 0,
 							},
 						},
 					},
-					pbrMetallicRoughness: {
-						baseColorTexture: {
-							extensions: { KHR_texture_transform: { scale: [100, 100] } },
-							index: 0,
-						},
-					},
-				},
-			],
-			`writes material (${title})`,
-		);
+				],
+				`writes material (${title})`,
+			);
 
-		const dstDocument = await io.readJSON({ json, resources });
-		const dstMaterial = dstDocument.getRoot().listMaterials()[0];
-		const dstClearcoat = dstMaterial.getExtension<Clearcoat>('KHR_materials_clearcoat');
-		const dstTransform = dstClearcoat.getClearcoatTextureInfo()!.getExtension<Transform>('KHR_texture_transform');
-		t.deepEqual(dstTransform.getScale(), [100, 100], `reads transform.scale (${title})`);
-	}
+			const dstDocument = await io.readJSON({ json, resources });
+			const dstMaterial = dstDocument.getRoot().listMaterials()[0];
+			const dstClearcoat = dstMaterial.getExtension<Clearcoat>('KHR_materials_clearcoat');
+			const dstTransform = dstClearcoat
+				.getClearcoatTextureInfo()!
+				.getExtension<Transform>('KHR_texture_transform');
+			deepEqual(dstTransform.getScale(), [100, 100], `reads transform.scale (${title})`);
+		}
+	});
 });

--- a/packages/extensions/test/texture-transform.test.ts
+++ b/packages/extensions/test/texture-transform.test.ts
@@ -9,7 +9,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 
 const io = new NodeIO().registerExtensions([KHRTextureTransform]);
 
-describe('KHRTextureTransform', () => {
+describe('extensions::KHRTextureTransform', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/texture-webp.test.ts
+++ b/packages/extensions/test/texture-webp.test.ts
@@ -1,6 +1,7 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { BufferUtils, Document, type GLTF, ImageUtils, type JSONDocument, NodeIO } from '@gltf-transform/core';
 import { EXTTextureWebP } from '@gltf-transform/extensions';
-import test from 'ava';
 import fs from 'fs';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -10,61 +11,63 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 const io = new NodeIO().registerExtensions([EXTTextureWebP]);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('basic', async (t) => {
-	const doc = new Document();
-	doc.createBuffer();
-	const webpExtension = doc.createExtension(EXTTextureWebP);
-	const tex1 = doc.createTexture('WebPTexture').setMimeType('image/webp').setImage(new Uint8Array(10));
-	const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
-	doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
+describe('EXTTextureWebP', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		doc.createBuffer();
+		const webpExtension = doc.createExtension(EXTTextureWebP);
+		const tex1 = doc.createTexture('WebPTexture').setMimeType('image/webp').setImage(new Uint8Array(10));
+		const tex2 = doc.createTexture('PNGTexture').setMimeType('image/png').setImage(new Uint8Array(15));
+		doc.createMaterial().setBaseColorTexture(tex1).setEmissiveTexture(tex2);
 
-	let jsonDoc: JSONDocument;
+		let jsonDoc: JSONDocument;
 
-	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
 
-	// Writing to file.
-	t.deepEqual(jsonDoc.json.extensionsUsed, ['EXT_texture_webp'], 'writes extensionsUsed');
-	t.is(jsonDoc.json.textures[0].source, undefined, 'omits .source on WebP texture');
-	t.is(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
-	t.is(
-		(jsonDoc.json.textures[0].extensions['EXT_texture_webp'] as GLTF.ITexture).source,
-		0,
-		'includes .source on WebP extension',
-	);
+		// Writing to file.
+		deepEqual(jsonDoc.json.extensionsUsed, ['EXT_texture_webp'], 'writes extensionsUsed');
+		strictEqual(jsonDoc.json.textures[0].source, undefined, 'omits .source on WebP texture');
+		strictEqual(jsonDoc.json.textures[1].source, 1, 'includes .source on PNG texture');
+		strictEqual(
+			(jsonDoc.json.textures[0].extensions['EXT_texture_webp'] as GLTF.ITexture).source,
+			0,
+			'includes .source on WebP extension',
+		);
 
-	// Read (roundtrip) from file.
-	const rtDoc = await io.readJSON(jsonDoc);
-	const rtRoot = rtDoc.getRoot();
-	t.is(rtRoot.listTextures()[0].getMimeType(), 'image/webp', 'reads WebP mimetype');
-	t.is(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
-	t.is(rtRoot.listTextures()[0].getImage().byteLength, 10, 'reads WebP payload');
-	t.is(rtRoot.listTextures()[1].getImage().byteLength, 15, 'reads PNG payload');
+		// Read (roundtrip) from file.
+		const rtDoc = await io.readJSON(jsonDoc);
+		const rtRoot = rtDoc.getRoot();
+		strictEqual(rtRoot.listTextures()[0].getMimeType(), 'image/webp', 'reads WebP mimetype');
+		strictEqual(rtRoot.listTextures()[1].getMimeType(), 'image/png', 'reads PNG mimetype');
+		strictEqual(rtRoot.listTextures()[0].getImage().byteLength, 10, 'reads WebP payload');
+		strictEqual(rtRoot.listTextures()[1].getImage().byteLength, 15, 'reads PNG payload');
 
-	// Clean up extension data, revert to core glTF.
-	webpExtension.dispose();
-	tex1.dispose();
-	jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
-	t.is(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
-	t.is(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
-	t.is(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');
-});
+		// Clean up extension data, revert to core glTF.
+		webpExtension.dispose();
+		tex1.dispose();
+		jsonDoc = await io.writeJSON(doc, WRITER_OPTIONS);
+		strictEqual(jsonDoc.json.extensionsUsed, undefined, 'clears extensionsUsed');
+		strictEqual(jsonDoc.json.textures.length, 1, 'writes only 1 texture');
+		strictEqual(jsonDoc.json.textures[0].source, 0, 'includes .source on PNG texture');
+	});
 
-test('image-utils', (t) => {
-	const webpLossy = fs.readFileSync(path.join(__dirname, 'in', 'test-lossy.webp'));
-	const webpLossless = fs.readFileSync(path.join(__dirname, 'in', 'test-lossless.webp'));
-	const buffer = BufferUtils.concat([
-		BufferUtils.encodeText('RIFF'),
-		new Uint8Array(4),
-		BufferUtils.encodeText('WEBP'),
-		BufferUtils.encodeText('OTHR'),
-		new Uint8Array([999, 0, 0, 0]),
-	]);
+	test('image-utils', () => {
+		const webpLossy = fs.readFileSync(path.join(__dirname, 'in', 'test-lossy.webp'));
+		const webpLossless = fs.readFileSync(path.join(__dirname, 'in', 'test-lossless.webp'));
+		const buffer = BufferUtils.concat([
+			BufferUtils.encodeText('RIFF'),
+			new Uint8Array(4),
+			BufferUtils.encodeText('WEBP'),
+			BufferUtils.encodeText('OTHR'),
+			new Uint8Array([999, 0, 0, 0]),
+		]);
 
-	t.is(ImageUtils.getSize(new Uint8Array(8), 'image/webp'), null, 'invalid');
-	t.is(ImageUtils.getSize(buffer, 'image/webp'), null, 'no size');
-	t.deepEqual(ImageUtils.getSize(webpLossy, 'image/webp'), [256, 256], 'size (lossy)');
-	t.deepEqual(ImageUtils.getSize(webpLossless, 'image/webp'), [256, 256], 'size (lossless)');
-	t.is(ImageUtils.getChannels(webpLossy, 'image/webp'), 4, 'channels');
-	t.is(ImageUtils.getChannels(webpLossless, 'image/fake'), null, 'channels (other)');
-	t.is(ImageUtils.getVRAMByteLength(webpLossy, 'image/webp'), 349524, 'vramSize');
+		strictEqual(ImageUtils.getSize(new Uint8Array(8), 'image/webp'), null, 'invalid');
+		strictEqual(ImageUtils.getSize(buffer, 'image/webp'), null, 'no size');
+		deepEqual(ImageUtils.getSize(webpLossy, 'image/webp'), [256, 256], 'size (lossy)');
+		deepEqual(ImageUtils.getSize(webpLossless, 'image/webp'), [256, 256], 'size (lossless)');
+		strictEqual(ImageUtils.getChannels(webpLossy, 'image/webp'), 4, 'channels');
+		strictEqual(ImageUtils.getChannels(webpLossless, 'image/fake'), null, 'channels (other)');
+		strictEqual(ImageUtils.getVRAMByteLength(webpLossy, 'image/webp'), 349524, 'vramSize');
+	});
 });

--- a/packages/extensions/test/texture-webp.test.ts
+++ b/packages/extensions/test/texture-webp.test.ts
@@ -11,7 +11,7 @@ const WRITER_OPTIONS = { basename: 'extensionTest' };
 const io = new NodeIO().registerExtensions([EXTTextureWebP]);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('EXTTextureWebP', () => {
+describe('extensions::EXTTextureWebP', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		doc.createBuffer();

--- a/packages/extensions/test/xmp.test.ts
+++ b/packages/extensions/test/xmp.test.ts
@@ -22,7 +22,7 @@ const MOCK_JSONLD_PACKET = {
 	'xmpRights:Marked': true,
 };
 
-describe('KHRXMP', () => {
+describe('extensions::KHRXMP', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const xmpExtension = document.createExtension(KHRXMP);

--- a/packages/extensions/test/xmp.test.ts
+++ b/packages/extensions/test/xmp.test.ts
@@ -1,7 +1,8 @@
+import { deepEqual, doesNotThrow, ok, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { KHRXMP, type Packet } from '@gltf-transform/extensions';
 import { cloneDocument } from '@gltf-transform/functions';
-import test from 'ava';
 
 const MOCK_CONTEXT_URL = 'https://test.example/1.0/';
 
@@ -21,202 +22,204 @@ const MOCK_JSONLD_PACKET = {
 	'xmpRights:Marked': true,
 };
 
-test('basic', async (t) => {
-	const document = new Document();
-	const xmpExtension = document.createExtension(KHRXMP);
-	const packet = xmpExtension.createPacket();
+describe('KHRXMP', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const xmpExtension = document.createExtension(KHRXMP);
+		const packet = xmpExtension.createPacket();
 
-	// Context.
-	t.throws(() => packet.setProperty('test:Foo', true), { message: /context/i }, 'throws on unknown context');
-	packet.setContext({ test: MOCK_CONTEXT_URL });
-	t.deepEqual(packet.getContext(), { test: MOCK_CONTEXT_URL }, 'sets context');
-	packet.setContext({});
-	t.deepEqual(packet.getContext(), {}, 'removes context');
-	packet.setContext({
-		test: MOCK_CONTEXT_URL,
-		dc: 'http://purl.org/dc/elements/1.1/',
-	});
-	t.notThrows(() => packet.setProperty('test:Foo', true), 'accepts known context');
+		// Context.
+		throws(() => packet.setProperty('test:Foo', true), { message: /context/i }, 'throws on unknown context');
+		packet.setContext({ test: MOCK_CONTEXT_URL });
+		deepEqual(packet.getContext(), { test: MOCK_CONTEXT_URL }, 'sets context');
+		packet.setContext({});
+		deepEqual(packet.getContext(), {}, 'removes context');
+		packet.setContext({
+			test: MOCK_CONTEXT_URL,
+			dc: 'http://purl.org/dc/elements/1.1/',
+		});
+		doesNotThrow(() => packet.setProperty('test:Foo', true), 'accepts known context');
 
-	// Properties.
-	t.is(packet.getProperty('test:Foo'), true, 'sets literal property');
-	packet.setProperty('dc:Creator', { '@list': ['Acme, Inc.'] });
-	t.deepEqual(packet.getProperty('dc:Creator'), { '@list': ['Acme, Inc.'] }, 'sets RDF property');
-	t.deepEqual(packet.listProperties(), ['test:Foo', 'dc:Creator'], 'lists properties');
-	packet.setProperty('dc:Creator', null);
-	t.is(packet.getProperty('dc:Creator'), null, 'removes property');
-	packet.setProperty('dc:Creator', { '@list': ['Acme, Inc.'] });
+		// Properties.
+		strictEqual(packet.getProperty('test:Foo'), true, 'sets literal property');
+		packet.setProperty('dc:Creator', { '@list': ['Acme, Inc.'] });
+		deepEqual(packet.getProperty('dc:Creator'), { '@list': ['Acme, Inc.'] }, 'sets RDF property');
+		deepEqual(packet.listProperties(), ['test:Foo', 'dc:Creator'], 'lists properties');
+		packet.setProperty('dc:Creator', null);
+		strictEqual(packet.getProperty('dc:Creator'), null, 'removes property');
+		packet.setProperty('dc:Creator', { '@list': ['Acme, Inc.'] });
 
-	// Serialize.
-	t.deepEqual(
-		packet.toJSONLD(),
-		{
-			'@context': {
-				dc: 'http://purl.org/dc/elements/1.1/',
-				test: MOCK_CONTEXT_URL,
+		// Serialize.
+		deepEqual(
+			packet.toJSONLD(),
+			{
+				'@context': {
+					dc: 'http://purl.org/dc/elements/1.1/',
+					test: MOCK_CONTEXT_URL,
+				},
+				'test:Foo': true,
+				'dc:Creator': { '@list': ['Acme, Inc.'] },
 			},
-			'test:Foo': true,
-			'dc:Creator': { '@list': ['Acme, Inc.'] },
-		},
-		'serialize to JSON LD',
-	);
+			'serialize to JSON LD',
+		);
 
-	// Deserialize.
-	packet.fromJSONLD(MOCK_JSONLD_PACKET);
-	t.is(packet.getProperty('xmpRights:Marked'), true, 'parse JSON LD (1/2)');
-	t.deepEqual(packet.getProperty('dc:title'), MOCK_JSONLD_PACKET['dc:title'], 'parse JSON LD (2/2)');
+		// Deserialize.
+		packet.fromJSONLD(MOCK_JSONLD_PACKET);
+		strictEqual(packet.getProperty('xmpRights:Marked'), true, 'parse JSON LD (1/2)');
+		deepEqual(packet.getProperty('dc:title'), MOCK_JSONLD_PACKET['dc:title'], 'parse JSON LD (2/2)');
 
-	// Equals and Copy.
-	const packet2 = xmpExtension.createPacket();
-	t.falsy(packet.equals(packet2), 'not equal');
-	packet2.copy(packet);
-	t.truthy(packet.equals(packet2), 'not equal');
-	packet2.setContext({
-		...packet2.getContext(),
-		xmp: 'http://ns.adobe.com/xap/1.0/',
+		// Equals and Copy.
+		const packet2 = xmpExtension.createPacket();
+		strictEqual(packet.equals(packet2), false, 'not equal');
+		packet2.copy(packet);
+		ok(packet.equals(packet2), 'not equal');
+		packet2.setContext({
+			...packet2.getContext(),
+			xmp: 'http://ns.adobe.com/xap/1.0/',
+		});
+		packet2.setProperty('xmp:CreateDate', '2022-01-05');
+		strictEqual(packet.equals(packet2), false, 'not equal');
+
+		// Assignment.
+		const root = document.getRoot();
+		const node = document.createNode();
+		const scene = document.createScene();
+		const mesh = document.createMesh();
+		const material = document.createMaterial();
+		const texture = document.createTexture();
+		const animation = document.createAnimation();
+		const sampler = document.createAnimationSampler(); // invalid
+		doesNotThrow(() => root.setExtension('KHR_xmp_json_ld', packet), 'attach to root');
+		doesNotThrow(() => node.setExtension('KHR_xmp_json_ld', packet), 'attach to node');
+		doesNotThrow(() => scene.setExtension('KHR_xmp_json_ld', packet), 'attach to scene');
+		doesNotThrow(() => mesh.setExtension('KHR_xmp_json_ld', packet), 'attach to mesh');
+		doesNotThrow(() => material.setExtension('KHR_xmp_json_ld', packet), 'attach to material');
+		doesNotThrow(() => texture.setExtension('KHR_xmp_json_ld', packet), 'attach to texture');
+		doesNotThrow(() => animation.setExtension('KHR_xmp_json_ld', packet), 'attach to animation');
+		throws(() => sampler.setExtension('KHR_xmp_json_ld', packet), undefined, 'attach to sampler (throws)');
+		ok(root.getExtension('KHR_xmp_json_ld'), 'read from root');
+		ok(node.getExtension('KHR_xmp_json_ld'), 'read from node');
+		ok(scene.getExtension('KHR_xmp_json_ld'), 'read from scene');
+		ok(mesh.getExtension('KHR_xmp_json_ld'), 'read from mesh');
+		ok(material.getExtension('KHR_xmp_json_ld'), 'read from material');
+		ok(texture.getExtension('KHR_xmp_json_ld'), 'read from texture');
+		ok(animation.getExtension('KHR_xmp_json_ld'), 'read from animation');
+		strictEqual(sampler.getExtension('KHR_xmp_json_ld'), null, 'read from sampler (null)');
+
+		// (5) dispose
+		packet.dispose();
+		strictEqual(root.getExtension('KHR_xmp_json_ld'), null, 'dispose from root');
+		strictEqual(node.getExtension('KHR_xmp_json_ld'), null, 'dispose from node');
 	});
-	packet2.setProperty('xmp:CreateDate', '2022-01-05');
-	t.falsy(packet.equals(packet2), 'not equal');
 
-	// Assignment.
-	const root = document.getRoot();
-	const node = document.createNode();
-	const scene = document.createScene();
-	const mesh = document.createMesh();
-	const material = document.createMaterial();
-	const texture = document.createTexture();
-	const animation = document.createAnimation();
-	const sampler = document.createAnimationSampler(); // invalid
-	t.notThrows(() => root.setExtension('KHR_xmp_json_ld', packet), 'attach to root');
-	t.notThrows(() => node.setExtension('KHR_xmp_json_ld', packet), 'attach to node');
-	t.notThrows(() => scene.setExtension('KHR_xmp_json_ld', packet), 'attach to scene');
-	t.notThrows(() => mesh.setExtension('KHR_xmp_json_ld', packet), 'attach to mesh');
-	t.notThrows(() => material.setExtension('KHR_xmp_json_ld', packet), 'attach to material');
-	t.notThrows(() => texture.setExtension('KHR_xmp_json_ld', packet), 'attach to texture');
-	t.notThrows(() => animation.setExtension('KHR_xmp_json_ld', packet), 'attach to animation');
-	t.throws(() => sampler.setExtension('KHR_xmp_json_ld', packet), undefined, 'attach to sampler (throws)');
-	t.truthy(root.getExtension('KHR_xmp_json_ld'), 'read from root');
-	t.truthy(node.getExtension('KHR_xmp_json_ld'), 'read from node');
-	t.truthy(scene.getExtension('KHR_xmp_json_ld'), 'read from scene');
-	t.truthy(mesh.getExtension('KHR_xmp_json_ld'), 'read from mesh');
-	t.truthy(material.getExtension('KHR_xmp_json_ld'), 'read from material');
-	t.truthy(texture.getExtension('KHR_xmp_json_ld'), 'read from texture');
-	t.truthy(animation.getExtension('KHR_xmp_json_ld'), 'read from animation');
-	t.falsy(sampler.getExtension('KHR_xmp_json_ld'), 'read from sampler (null)');
+	test('i/o', async () => {
+		const document = new Document();
+		const xmpExtension = document.createExtension(KHRXMP);
+		const packet = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
+		const packet2 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
 
-	// (5) dispose
-	packet.dispose();
-	t.falsy(root.getExtension('KHR_xmp_json_ld'), 'dispose from root');
-	t.falsy(node.getExtension('KHR_xmp_json_ld'), 'dispose from node');
-});
+		const root = document.getRoot();
+		root.setExtension('KHR_xmp_json_ld', packet);
+		document.createNode().setExtension('KHR_xmp_json_ld', packet2);
+		document.createScene().setExtension('KHR_xmp_json_ld', packet2);
+		document.createMesh().setExtension('KHR_xmp_json_ld', packet2);
+		document.createMaterial().setExtension('KHR_xmp_json_ld', packet2);
+		document
+			.createTexture()
+			.setImage(new Uint8Array(0))
+			.setMimeType('image/png')
+			.setExtension('KHR_xmp_json_ld', packet2);
+		document.createAnimation().setExtension('KHR_xmp_json_ld', packet2);
 
-test('i/o', async (t) => {
-	const document = new Document();
-	const xmpExtension = document.createExtension(KHRXMP);
-	const packet = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
-	const packet2 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
+		document.createBuffer();
 
-	const root = document.getRoot();
-	root.setExtension('KHR_xmp_json_ld', packet);
-	document.createNode().setExtension('KHR_xmp_json_ld', packet2);
-	document.createScene().setExtension('KHR_xmp_json_ld', packet2);
-	document.createMesh().setExtension('KHR_xmp_json_ld', packet2);
-	document.createMaterial().setExtension('KHR_xmp_json_ld', packet2);
-	document
-		.createTexture()
-		.setImage(new Uint8Array(0))
-		.setMimeType('image/png')
-		.setExtension('KHR_xmp_json_ld', packet2);
-	document.createAnimation().setExtension('KHR_xmp_json_ld', packet2);
+		const io = new NodeIO().registerExtensions([KHRXMP]);
+		const jsonDocument = await io.writeJSON(document);
 
-	document.createBuffer();
+		// Serialize.
 
-	const io = new NodeIO().registerExtensions([KHRXMP]);
-	const jsonDocument = await io.writeJSON(document);
+		deepEqual(
+			jsonDocument.json.extensions,
+			{
+				KHR_xmp_json_ld: { packets: [MOCK_JSONLD_PACKET, MOCK_JSONLD_PACKET] },
+			},
+			'writes packets',
+		);
+		deepEqual(
+			jsonDocument.json.asset.extensions,
+			{
+				KHR_xmp_json_ld: { packet: 0 },
+			},
+			'writes to asset',
+		);
+		deepEqual(
+			jsonDocument.json.nodes[0].extensions,
+			{
+				KHR_xmp_json_ld: { packet: 1 },
+			},
+			'writes to node',
+		);
+		deepEqual(
+			jsonDocument.json.scenes[0].extensions,
+			{
+				KHR_xmp_json_ld: { packet: 1 },
+			},
+			'writes to scene',
+		);
+		deepEqual(
+			jsonDocument.json.meshes[0].extensions,
+			{
+				KHR_xmp_json_ld: { packet: 1 },
+			},
+			'writes to mesh',
+		);
+		deepEqual(
+			jsonDocument.json.materials[0].extensions,
+			{
+				KHR_xmp_json_ld: { packet: 1 },
+			},
+			'writes to material',
+		);
+		deepEqual(
+			jsonDocument.json.images[0].extensions,
+			{
+				KHR_xmp_json_ld: { packet: 1 },
+			},
+			'writes to image',
+		);
+		deepEqual(
+			jsonDocument.json.animations[0].extensions,
+			{
+				KHR_xmp_json_ld: { packet: 1 },
+			},
+			'writes to animation',
+		);
 
-	// Serialize.
+		// Deserialize.
 
-	t.deepEqual(
-		jsonDocument.json.extensions,
-		{
-			KHR_xmp_json_ld: { packets: [MOCK_JSONLD_PACKET, MOCK_JSONLD_PACKET] },
-		},
-		'writes packets',
-	);
-	t.deepEqual(
-		jsonDocument.json.asset.extensions,
-		{
-			KHR_xmp_json_ld: { packet: 0 },
-		},
-		'writes to asset',
-	);
-	t.deepEqual(
-		jsonDocument.json.nodes[0].extensions,
-		{
-			KHR_xmp_json_ld: { packet: 1 },
-		},
-		'writes to node',
-	);
-	t.deepEqual(
-		jsonDocument.json.scenes[0].extensions,
-		{
-			KHR_xmp_json_ld: { packet: 1 },
-		},
-		'writes to scene',
-	);
-	t.deepEqual(
-		jsonDocument.json.meshes[0].extensions,
-		{
-			KHR_xmp_json_ld: { packet: 1 },
-		},
-		'writes to mesh',
-	);
-	t.deepEqual(
-		jsonDocument.json.materials[0].extensions,
-		{
-			KHR_xmp_json_ld: { packet: 1 },
-		},
-		'writes to material',
-	);
-	t.deepEqual(
-		jsonDocument.json.images[0].extensions,
-		{
-			KHR_xmp_json_ld: { packet: 1 },
-		},
-		'writes to image',
-	);
-	t.deepEqual(
-		jsonDocument.json.animations[0].extensions,
-		{
-			KHR_xmp_json_ld: { packet: 1 },
-		},
-		'writes to animation',
-	);
+		const rtDocument = await io.readJSON(jsonDocument);
+		const rtRoot = rtDocument.getRoot();
+		const rtPacket = rtDocument.getRoot().getExtension<Packet>('KHR_xmp_json_ld');
+		ok(rtPacket, 'reads packet assignment');
+		deepEqual(rtPacket.toJSONLD(), packet.toJSONLD(), 'reads packet data');
+		ok(rtRoot.getExtension('KHR_xmp_json_ld'), 'reads packet from asset');
+		ok(rtRoot.listNodes()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from node');
+		ok(rtRoot.listScenes()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from scene');
+		ok(rtRoot.listMeshes()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from mesh');
+		ok(rtRoot.listMaterials()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from material');
+		ok(rtRoot.listTextures()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from image');
+		ok(rtRoot.listAnimations()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from animation');
+	});
 
-	// Deserialize.
-
-	const rtDocument = await io.readJSON(jsonDocument);
-	const rtRoot = rtDocument.getRoot();
-	const rtPacket = rtDocument.getRoot().getExtension<Packet>('KHR_xmp_json_ld');
-	t.truthy(rtPacket, 'reads packet assignment');
-	t.deepEqual(rtPacket.toJSONLD(), packet.toJSONLD(), 'reads packet data');
-	t.truthy(rtRoot.getExtension('KHR_xmp_json_ld'), 'reads packet from asset');
-	t.truthy(rtRoot.listNodes()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from node');
-	t.truthy(rtRoot.listScenes()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from scene');
-	t.truthy(rtRoot.listMeshes()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from mesh');
-	t.truthy(rtRoot.listMaterials()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from material');
-	t.truthy(rtRoot.listTextures()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from image');
-	t.truthy(rtRoot.listAnimations()[0].getExtension('KHR_xmp_json_ld'), 'reads packet from animation');
-});
-
-test('clone', async (t) => {
-	const document1 = new Document();
-	const xmpExtension = document1.createExtension(KHRXMP);
-	const packet1 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
-	document1.getRoot().setExtension('KHR_xmp_json_ld', packet1);
-	t.is(document1.getRoot().getExtension('KHR_xmp_json_ld'), packet1, 'sets packet');
-	const document2 = cloneDocument(document1);
-	const packet2 = document2.getRoot().getExtension('KHR_xmp_json_ld') as Packet;
-	t.truthy(packet2, 'clones packet');
-	t.deepEqual(packet1.toJSONLD(), packet2.toJSONLD(), 'equal packet');
+	test('clone', async () => {
+		const document1 = new Document();
+		const xmpExtension = document1.createExtension(KHRXMP);
+		const packet1 = xmpExtension.createPacket().fromJSONLD(MOCK_JSONLD_PACKET);
+		document1.getRoot().setExtension('KHR_xmp_json_ld', packet1);
+		strictEqual(document1.getRoot().getExtension('KHR_xmp_json_ld'), packet1, 'sets packet');
+		const document2 = cloneDocument(document1);
+		const packet2 = document2.getRoot().getExtension('KHR_xmp_json_ld') as Packet;
+		ok(packet2, 'clones packet');
+		deepEqual(packet1.toJSONLD(), packet2.toJSONLD(), 'equal packet');
+	});
 });

--- a/packages/functions/test/center.test.ts
+++ b/packages/functions/test/center.test.ts
@@ -1,48 +1,51 @@
+import { deepEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, getBounds } from '@gltf-transform/core';
 import { center } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const position = doc
-		.createAccessor()
-		.setArray(new Float32Array([0, 0, 0, 1, 1, 1]))
-		.setType(Accessor.Type.VEC3);
-	const prim = doc.createPrimitive().setAttribute('POSITION', position);
-	const mesh = doc.createMesh().addPrimitive(prim);
-	const node = doc.createNode().setMesh(mesh).setTranslation([100, 100, 100]).setScale([5, 5, 5]);
-	const scene = doc.createScene().addChild(node);
+describe('center', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const position = doc
+			.createAccessor()
+			.setArray(new Float32Array([0, 0, 0, 1, 1, 1]))
+			.setType(Accessor.Type.VEC3);
+		const prim = doc.createPrimitive().setAttribute('POSITION', position);
+		const mesh = doc.createMesh().addPrimitive(prim);
+		const node = doc.createNode().setMesh(mesh).setTranslation([100, 100, 100]).setScale([5, 5, 5]);
+		const scene = doc.createScene().addChild(node);
 
-	await doc.transform(center({ pivot: 'center' }));
+		await doc.transform(center({ pivot: 'center' }));
 
-	t.deepEqual(
-		getBounds(scene),
-		{
-			min: [-2.5, -2.5, -2.5],
-			max: [2.5, 2.5, 2.5],
-		},
-		'center',
-	);
+		deepEqual(
+			getBounds(scene),
+			{
+				min: [-2.5, -2.5, -2.5],
+				max: [2.5, 2.5, 2.5],
+			},
+			'center',
+		);
 
-	await doc.transform(center({ pivot: 'above' }));
+		await doc.transform(center({ pivot: 'above' }));
 
-	t.deepEqual(
-		getBounds(scene),
-		{
-			min: [-2.5, -5.0, -2.5],
-			max: [2.5, 0.0, 2.5],
-		},
-		'above',
-	);
+		deepEqual(
+			getBounds(scene),
+			{
+				min: [-2.5, -5.0, -2.5],
+				max: [2.5, 0.0, 2.5],
+			},
+			'above',
+		);
 
-	await doc.transform(center({ pivot: 'below' }));
+		await doc.transform(center({ pivot: 'below' }));
 
-	t.deepEqual(
-		getBounds(scene),
-		{
-			min: [-2.5, 0.0, -2.5],
-			max: [2.5, 5.0, 2.5],
-		},
-		'below',
-	);
+		deepEqual(
+			getBounds(scene),
+			{
+				min: [-2.5, 0.0, -2.5],
+				max: [2.5, 5.0, 2.5],
+			},
+			'below',
+		);
+	});
 });

--- a/packages/functions/test/center.test.ts
+++ b/packages/functions/test/center.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, Document, getBounds } from '@gltf-transform/core';
 import { center } from '@gltf-transform/functions';
 
-describe('center', () => {
+describe('functions::center', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const position = doc

--- a/packages/functions/test/clear-node-parent.test.ts
+++ b/packages/functions/test/clear-node-parent.test.ts
@@ -1,28 +1,31 @@
+import { deepEqual, ok } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { clearNodeParent } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const nodeA = document.createNode('A').setTranslation([2, 0, 0]);
-	const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA);
-	const nodeC = document.createNode('C').addChild(nodeB);
-	const scene = document.createScene().addChild(nodeC);
+describe('clearNodeParent', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const nodeA = document.createNode('A').setTranslation([2, 0, 0]);
+		const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA);
+		const nodeC = document.createNode('C').addChild(nodeB);
+		const scene = document.createScene().addChild(nodeC);
 
-	t.truthy(nodeA.getParentNode() === nodeB, 'B → A (before)');
-	t.truthy(nodeB.getParentNode() === nodeC, 'C → B (before)');
-	t.truthy(nodeC.getParentNode() === null, 'Scene → C (before)');
-	t.deepEqual(scene.listChildren(), [nodeC], 'Scene → C (before)');
+		ok(nodeA.getParentNode() === nodeB, 'B → A (before)');
+		ok(nodeB.getParentNode() === nodeC, 'C → B (before)');
+		ok(nodeC.getParentNode() === null, 'Scene → C (before)');
+		deepEqual(scene.listChildren(), [nodeC], 'Scene → C (before)');
 
-	clearNodeParent(nodeA);
+		clearNodeParent(nodeA);
 
-	t.truthy(nodeA.getParentNode() === null, 'Scene → A (after)');
-	t.truthy(nodeB.getParentNode() === nodeC, 'C → B (after)');
-	t.truthy(nodeC.getParentNode() === null, 'Scene → C (after)');
-	t.deepEqual(scene.listChildren(), [nodeC, nodeA], 'Scene → [C, A] (after)');
+		ok(nodeA.getParentNode() === null, 'Scene → A (after)');
+		ok(nodeB.getParentNode() === nodeC, 'C → B (after)');
+		ok(nodeC.getParentNode() === null, 'Scene → C (after)');
+		deepEqual(scene.listChildren(), [nodeC, nodeA], 'Scene → [C, A] (after)');
 
-	t.deepEqual(nodeA.getTranslation(), [8, 0, 0], 'A.translation');
-	t.deepEqual(nodeA.getScale(), [4, 4, 4], 'A.scale');
-	t.deepEqual(nodeB.getScale(), [4, 4, 4], 'B.scale');
+		deepEqual(nodeA.getTranslation(), [8, 0, 0], 'A.translation');
+		deepEqual(nodeA.getScale(), [4, 4, 4], 'A.scale');
+		deepEqual(nodeB.getScale(), [4, 4, 4], 'B.scale');
+	});
 });

--- a/packages/functions/test/clear-node-parent.test.ts
+++ b/packages/functions/test/clear-node-parent.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { clearNodeParent } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('clearNodeParent', () => {
+describe('functions::clearNodeParent', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const nodeA = document.createNode('A').setTranslation([2, 0, 0]);

--- a/packages/functions/test/clear-node-transform.test.ts
+++ b/packages/functions/test/clear-node-transform.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { clearNodeTransform } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('clearNodeTransform', () => {
+describe('functions::clearNodeTransform', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 

--- a/packages/functions/test/clear-node-transform.test.ts
+++ b/packages/functions/test/clear-node-transform.test.ts
@@ -1,40 +1,43 @@
+import { deepEqual, ok } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { clearNodeTransform } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
+describe('clearNodeTransform', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
 
-	const camera = document.createCamera();
+		const camera = document.createCamera();
 
-	const position = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([1, 0, 1]));
-	const prim = document.createPrimitive().setAttribute('POSITION', position);
-	const mesh = document.createMesh().addPrimitive(prim);
+		const position = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float32Array([1, 0, 1]));
+		const prim = document.createPrimitive().setAttribute('POSITION', position);
+		const mesh = document.createMesh().addPrimitive(prim);
 
-	const childNode = document.createNode('B');
+		const childNode = document.createNode('B');
 
-	const parentNode = document
-		.createNode('A')
-		.setTranslation([2, 0, 0])
-		.setScale([4, 4, 4])
-		.addChild(childNode)
-		.setMesh(mesh)
-		.setCamera(camera);
+		const parentNode = document
+			.createNode('A')
+			.setTranslation([2, 0, 0])
+			.setScale([4, 4, 4])
+			.addChild(childNode)
+			.setMesh(mesh)
+			.setCamera(camera);
 
-	clearNodeTransform(parentNode);
+		clearNodeTransform(parentNode);
 
-	t.deepEqual(parentNode.getTranslation(), [0, 0, 0], 'parent.translation');
-	t.deepEqual(parentNode.getRotation(), [0, 0, 0, 1], 'parent.rotation');
-	t.deepEqual(parentNode.getScale(), [1, 1, 1], 'parent.scale');
+		deepEqual(parentNode.getTranslation(), [0, 0, 0], 'parent.translation');
+		deepEqual(parentNode.getRotation(), [0, 0, 0, 1], 'parent.rotation');
+		deepEqual(parentNode.getScale(), [1, 1, 1], 'parent.scale');
 
-	t.deepEqual(childNode.getTranslation(), [2, 0, 0], 'child.children[0].translation');
-	t.deepEqual(childNode.getRotation(), [0, 0, 0, 1], 'child.children[0].rotation');
-	t.deepEqual(childNode.getScale(), [4, 4, 4], 'child.children[0].scale');
+		deepEqual(childNode.getTranslation(), [2, 0, 0], 'child.children[0].translation');
+		deepEqual(childNode.getRotation(), [0, 0, 0, 1], 'child.children[0].rotation');
+		deepEqual(childNode.getScale(), [4, 4, 4], 'child.children[0].scale');
 
-	t.truthy(parentNode.getCamera(), 'parent.camera');
-	t.deepEqual(prim.getAttribute('POSITION')!.getElement(0, []), [6, 0, 4], 'parent.mesh');
+		ok(parentNode.getCamera(), 'parent.camera');
+		deepEqual(prim.getAttribute('POSITION')!.getElement(0, []), [6, 0, 4], 'parent.mesh');
+	});
 });

--- a/packages/functions/test/convert-primitive-to-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-mode.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, Primitive } from '@gltf-transform/core';
 import { convertPrimitiveToLines, convertPrimitiveToTriangles } from '@gltf-transform/functions';
 import {
@@ -7,24 +9,24 @@ import {
 	createTriangleStripPrim,
 	logger,
 } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-test('line-strip to lines', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createLineStripPrim(document);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+describe('convertPrimitiveToMode', () => {
+	test('line-strip to lines', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createLineStripPrim(document);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	convertPrimitiveToLines(prim);
+		convertPrimitiveToLines(prim);
 
-	t.is(prim.getMode(), LINES, 'mode');
-	t.deepEqual(
-		Array.from(prim.getIndices().getArray()),
-		// biome-ignore format: Readability.
-		[
+		strictEqual(prim.getMode(), LINES, 'mode');
+		deepEqual(
+			Array.from(prim.getIndices().getArray()),
+			// biome-ignore format: Readability.
+			[
 			0, 1,
 			1, 2,
 			2, 3,
@@ -34,24 +36,24 @@ test('line-strip to lines', async (t) => {
 			6, 7,
 			7, 8,
 		],
-		'indices',
-	);
-});
+			'indices',
+		);
+	});
 
-test('line-loop to lines', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createLineLoopPrim(document);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+	test('line-loop to lines', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createLineLoopPrim(document);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	convertPrimitiveToLines(prim);
+		convertPrimitiveToLines(prim);
 
-	t.is(prim.getMode(), LINES, 'mode');
-	t.deepEqual(
-		Array.from(prim.getIndices().getArray()),
-		// biome-ignore format: Readability.
-		[
+		strictEqual(prim.getMode(), LINES, 'mode');
+		deepEqual(
+			Array.from(prim.getIndices().getArray()),
+			// biome-ignore format: Readability.
+			[
 			0, 1,
 			1, 2,
 			2, 3,
@@ -62,24 +64,24 @@ test('line-loop to lines', async (t) => {
 			7, 8,
 			8, 0
 		],
-		'indices',
-	);
-});
+			'indices',
+		);
+	});
 
-test('triangle-strip to triangles', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTriangleStripPrim(document);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+	test('triangle-strip to triangles', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTriangleStripPrim(document);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	convertPrimitiveToTriangles(prim);
+		convertPrimitiveToTriangles(prim);
 
-	t.is(prim.getMode(), TRIANGLES, 'mode');
-	t.deepEqual(
-		Array.from(prim.getIndices().getArray()),
-		// biome-ignore format: Readability.
-		[
+		strictEqual(prim.getMode(), TRIANGLES, 'mode');
+		deepEqual(
+			Array.from(prim.getIndices().getArray()),
+			// biome-ignore format: Readability.
+			[
 			0, 1, 2,
 			2, 1, 3,
 			2, 3, 4,
@@ -89,24 +91,24 @@ test('triangle-strip to triangles', async (t) => {
 			6, 7, 8,
 			8, 7, 9
 		],
-		'indices',
-	);
-});
+			'indices',
+		);
+	});
 
-test('triangle-fan to triangles', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTriangleFanPrim(document);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+	test('triangle-fan to triangles', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTriangleFanPrim(document);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	convertPrimitiveToTriangles(prim);
+		convertPrimitiveToTriangles(prim);
 
-	t.is(prim.getMode(), TRIANGLES, 'mode');
-	t.deepEqual(
-		Array.from(prim.getIndices().getArray()),
-		// biome-ignore format: Readability.
-		[
+		strictEqual(prim.getMode(), TRIANGLES, 'mode');
+		deepEqual(
+			Array.from(prim.getIndices().getArray()),
+			// biome-ignore format: Readability.
+			[
 			0, 1, 2,
 			0, 2, 3,
 			0, 3, 4,
@@ -116,58 +118,59 @@ test('triangle-fan to triangles', async (t) => {
 			0, 7, 8,
 			0, 8, 9
 		],
-		'indices',
-	);
-});
+			'indices',
+		);
+	});
 
-test('unsupported', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTriangleFanPrim(document);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+	test('unsupported', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTriangleFanPrim(document);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	// ?? → TRIANGLES
-	t.throws(
-		() => convertPrimitiveToTriangles(prim.setMode(POINTS)),
-		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
-		'points to triangles',
-	);
-	t.throws(
-		() => convertPrimitiveToTriangles(prim.setMode(LINES)),
-		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
-		'lines to triangles',
-	);
-	t.throws(
-		() => convertPrimitiveToTriangles(prim.setMode(LINE_STRIP)),
-		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
-		'line-strip to triangles',
-	);
-	t.throws(
-		() => convertPrimitiveToTriangles(prim.setMode(LINE_LOOP)),
-		{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
-		'line-loop to triangles',
-	);
+		// ?? → TRIANGLES
+		throws(
+			() => convertPrimitiveToTriangles(prim.setMode(POINTS)),
+			{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+			'points to triangles',
+		);
+		throws(
+			() => convertPrimitiveToTriangles(prim.setMode(LINES)),
+			{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+			'lines to triangles',
+		);
+		throws(
+			() => convertPrimitiveToTriangles(prim.setMode(LINE_STRIP)),
+			{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+			'line-strip to triangles',
+		);
+		throws(
+			() => convertPrimitiveToTriangles(prim.setMode(LINE_LOOP)),
+			{ message: /Only TRIANGLE_STRIP and TRIANGLE_FAN/i },
+			'line-loop to triangles',
+		);
 
-	// ?? → LINES
-	t.throws(
-		() => convertPrimitiveToLines(prim.setMode(POINTS)),
-		{ message: /Only LINE_STRIP and LINE_LOOP/i },
-		'points to triangles',
-	);
-	t.throws(
-		() => convertPrimitiveToLines(prim.setMode(TRIANGLES)),
-		{ message: /Only LINE_STRIP and LINE_LOOP/i },
-		'lines to triangles',
-	);
-	t.throws(
-		() => convertPrimitiveToLines(prim.setMode(TRIANGLE_STRIP)),
-		{ message: /Only LINE_STRIP and LINE_LOOP/i },
-		'line-strip to triangles',
-	);
-	t.throws(
-		() => convertPrimitiveToLines(prim.setMode(TRIANGLE_FAN)),
-		{ message: /Only LINE_STRIP and LINE_LOOP/i },
-		'line-loop to triangles',
-	);
+		// ?? → LINES
+		throws(
+			() => convertPrimitiveToLines(prim.setMode(POINTS)),
+			{ message: /Only LINE_STRIP and LINE_LOOP/i },
+			'points to triangles',
+		);
+		throws(
+			() => convertPrimitiveToLines(prim.setMode(TRIANGLES)),
+			{ message: /Only LINE_STRIP and LINE_LOOP/i },
+			'lines to triangles',
+		);
+		throws(
+			() => convertPrimitiveToLines(prim.setMode(TRIANGLE_STRIP)),
+			{ message: /Only LINE_STRIP and LINE_LOOP/i },
+			'line-strip to triangles',
+		);
+		throws(
+			() => convertPrimitiveToLines(prim.setMode(TRIANGLE_FAN)),
+			{ message: /Only LINE_STRIP and LINE_LOOP/i },
+			'line-loop to triangles',
+		);
+	});
 });

--- a/packages/functions/test/convert-primitive-to-mode.test.ts
+++ b/packages/functions/test/convert-primitive-to-mode.test.ts
@@ -12,7 +12,7 @@ import {
 
 const { POINTS, LINES, LINE_STRIP, LINE_LOOP, TRIANGLES, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-describe('convertPrimitiveToMode', () => {
+describe('functions::convertPrimitiveToMode', () => {
 	test('line-strip to lines', async () => {
 		const document = new Document().setLogger(logger);
 		const prim = createLineStripPrim(document);

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('dedup', () => {
+describe('functions::dedup', () => {
 	test('accessors - geometry', async () => {
 		const io = new NodeIO();
 		const document = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));

--- a/packages/functions/test/dedup.test.ts
+++ b/packages/functions/test/dedup.test.ts
@@ -1,7 +1,8 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO, type Property, PropertyType } from '@gltf-transform/core';
 import { KHRMaterialsTransmission } from '@gltf-transform/extensions';
 import { dedup } from '@gltf-transform/functions';
-import test from 'ava';
 import ndarray from 'ndarray';
 import { savePixels } from 'ndarray-pixels';
 import path, { dirname } from 'path';
@@ -9,212 +10,214 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('accessors - geometry', async (t) => {
-	const io = new NodeIO();
-	const document = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));
-	t.is(document.getRoot().listAccessors().length, 1503, 'begins with duplicate accessors');
+describe('dedup', () => {
+	test('accessors - geometry', async () => {
+		const io = new NodeIO();
+		const document = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));
+		strictEqual(document.getRoot().listAccessors().length, 1503, 'begins with duplicate accessors');
 
-	dedup({ propertyTypes: [PropertyType.TEXTURE] })(document);
+		dedup({ propertyTypes: [PropertyType.TEXTURE] })(document);
 
-	t.is(document.getRoot().listAccessors().length, 1503, 'has no effect when disabled');
+		strictEqual(document.getRoot().listAccessors().length, 1503, 'has no effect when disabled');
 
-	dedup()(document);
+		dedup()(document);
 
-	t.is(document.getRoot().listAccessors().length, 3, 'prunes duplicate accessors');
-});
+		strictEqual(document.getRoot().listAccessors().length, 3, 'prunes duplicate accessors');
+	});
 
-test('accessors - animation', (t) => {
-	const document = new Document();
-	const a = document.createAccessor().setArray(new Float32Array([1, 2, 3]));
-	const b = document.createAccessor().setArray(new Float32Array([4, 5, 6]));
-	const sampler1 = document.createAnimationSampler().setInput(a).setOutput(b);
-	const sampler2 = document.createAnimationSampler().setInput(a.clone()).setOutput(b.clone());
-	const sampler3 = document.createAnimationSampler().setInput(a.clone()).setOutput(a.clone());
-	const prim = document.createPrimitive().setAttribute('POSITION', a.clone());
-	document.createMesh().addPrimitive(prim);
-	document.createAnimation().addSampler(sampler1).addSampler(sampler2).addSampler(sampler3);
+	test('accessors - animation', () => {
+		const document = new Document();
+		const a = document.createAccessor().setArray(new Float32Array([1, 2, 3]));
+		const b = document.createAccessor().setArray(new Float32Array([4, 5, 6]));
+		const sampler1 = document.createAnimationSampler().setInput(a).setOutput(b);
+		const sampler2 = document.createAnimationSampler().setInput(a.clone()).setOutput(b.clone());
+		const sampler3 = document.createAnimationSampler().setInput(a.clone()).setOutput(a.clone());
+		const prim = document.createPrimitive().setAttribute('POSITION', a.clone());
+		document.createMesh().addPrimitive(prim);
+		document.createAnimation().addSampler(sampler1).addSampler(sampler2).addSampler(sampler3);
 
-	t.is(document.getRoot().listAccessors().length, 7, 'begins with duplicate accessors');
+		strictEqual(document.getRoot().listAccessors().length, 7, 'begins with duplicate accessors');
 
-	dedup({ propertyTypes: [PropertyType.TEXTURE] })(document);
+		dedup({ propertyTypes: [PropertyType.TEXTURE] })(document);
 
-	t.is(document.getRoot().listAccessors().length, 7, 'has no effect when disabled');
+		strictEqual(document.getRoot().listAccessors().length, 7, 'has no effect when disabled');
 
-	dedup()(document);
+		dedup()(document);
 
-	t.is(document.getRoot().listAccessors().length, 4, 'prunes duplicate accessors');
-	t.truthy(sampler1.getInput() === a, 'sampler 1 input');
-	t.truthy(sampler1.getOutput() === b, 'sampler 1 output');
-	t.truthy(sampler2.getInput() === a, 'sampler 2 input');
-	t.truthy(sampler2.getOutput() === b, 'sampler 2 output');
-	t.truthy(sampler3.getInput() === a, 'sampler 3 input');
-	t.truthy(sampler3.getOutput() !== b, 'no mixing input/output');
-	t.truthy(sampler3.getOutput() !== b, 'no mixing input/output');
-	t.truthy(prim.getAttribute('POSITION') !== a, 'no mixing sampler/attribute');
-	t.truthy(prim.getAttribute('POSITION') !== b, 'no mixing sampler/attribute');
-});
+		strictEqual(document.getRoot().listAccessors().length, 4, 'prunes duplicate accessors');
+		ok(sampler1.getInput() === a, 'sampler 1 input');
+		ok(sampler1.getOutput() === b, 'sampler 1 output');
+		ok(sampler2.getInput() === a, 'sampler 2 input');
+		ok(sampler2.getOutput() === b, 'sampler 2 output');
+		ok(sampler3.getInput() === a, 'sampler 3 input');
+		ok(sampler3.getOutput() !== b, 'no mixing input/output');
+		ok(sampler3.getOutput() !== b, 'no mixing input/output');
+		ok(prim.getAttribute('POSITION') !== a, 'no mixing sampler/attribute');
+		ok(prim.getAttribute('POSITION') !== b, 'no mixing sampler/attribute');
+	});
 
-test('materials', (t) => {
-	const document = new Document();
-	const root = document.getRoot();
+	test('materials', () => {
+		const document = new Document();
+		const root = document.getRoot();
 
-	const mat = document
-		.createMaterial('MatA')
-		.setBaseColorFactor([0.8, 0.8, 0.8, 1])
-		.setAlpha(0.9)
-		.setAlphaMode('OPAQUE');
-	const matCloned = mat.clone();
-	const matRenamed = mat.clone().setName('MatC');
-	const matUnequal = mat.clone().setName('MatD').setAlphaMode('MASK');
+		const mat = document
+			.createMaterial('MatA')
+			.setBaseColorFactor([0.8, 0.8, 0.8, 1])
+			.setAlpha(0.9)
+			.setAlphaMode('OPAQUE');
+		const matCloned = mat.clone();
+		const matRenamed = mat.clone().setName('MatC');
+		const matUnequal = mat.clone().setName('MatD').setAlphaMode('MASK');
 
-	t.truthy(mat.equals(matCloned), 'material.equals(material.clone())');
+		ok(mat.equals(matCloned), 'material.equals(material.clone())');
 
-	dedup({ propertyTypes: [] })(document);
+		dedup({ propertyTypes: [] })(document);
 
-	t.is(root.listMaterials().length, 4, 'no-op when disabled');
+		strictEqual(root.listMaterials().length, 4, 'no-op when disabled');
 
-	dedup()(document);
+		dedup()(document);
 
-	t.is(root.listMaterials().length, 2, 'removes all duplicate materials');
-	t.falsy(mat.isDisposed(), 'base = ✓');
-	t.truthy(matCloned.isDisposed(), 'cloned = ⨉');
-	t.truthy(matRenamed.isDisposed(), 'renamed = ⨉');
-	t.falsy(matUnequal.isDisposed(), 'unequal = ✓');
-});
+		strictEqual(root.listMaterials().length, 2, 'removes all duplicate materials');
+		strictEqual(mat.isDisposed(), false, 'base = ✓');
+		ok(matCloned.isDisposed(), 'cloned = ⨉');
+		ok(matRenamed.isDisposed(), 'renamed = ⨉');
+		strictEqual(matUnequal.isDisposed(), false, 'unequal = ✓');
+	});
 
-test('materials - animation', (t) => {
-	const document = new Document();
-	const root = document.getRoot();
+	test('materials - animation', () => {
+		const document = new Document();
+		const root = document.getRoot();
 
-	const matA = document
-		.createMaterial('MatA')
-		.setBaseColorFactor([0.8, 0.8, 0.8, 1])
-		.setAlpha(0.9)
-		.setAlphaMode('OPAQUE');
-	const matB = matA.clone();
-	const matC = matA.clone();
-	const matD = matA.clone();
+		const matA = document
+			.createMaterial('MatA')
+			.setBaseColorFactor([0.8, 0.8, 0.8, 1])
+			.setAlpha(0.9)
+			.setAlphaMode('OPAQUE');
+		const matB = matA.clone();
+		const matC = matA.clone();
+		const matD = matA.clone();
 
-	const edgeC = document.getGraph().listChildEdges(matC)[0];
-	edgeC.getAttributes().modifyChild = true; // monkeypatch, emulating KHR_animation_pointer.
+		const edgeC = document.getGraph().listChildEdges(matC)[0];
+		edgeC.getAttributes().modifyChild = true; // monkeypatch, emulating KHR_animation_pointer.
 
-	const edgeD = document.getGraph().listParentEdges(matD)[0];
-	edgeD.getAttributes().modifyChild = true; // monkeypatch, emulating KHR_animation_pointer.
+		const edgeD = document.getGraph().listParentEdges(matD)[0];
+		edgeD.getAttributes().modifyChild = true; // monkeypatch, emulating KHR_animation_pointer.
 
-	dedup()(document);
+		dedup()(document);
 
-	t.is(root.listMaterials().length, 3, 'removes duplicate materials');
-	t.false(matA.isDisposed(), 'base = ✓');
-	t.true(matB.isDisposed(), 'cloned = ⨉');
-	t.false(matC.isDisposed(), 'animated TextureInfo = ✓');
-	t.false(matD.isDisposed(), 'animated Material = ✓');
-});
+		strictEqual(root.listMaterials().length, 3, 'removes duplicate materials');
+		strictEqual(matA.isDisposed(), false, 'base = ✓');
+		ok(matB.isDisposed(), 'cloned = ⨉');
+		strictEqual(matC.isDisposed(), false, 'animated TextureInfo = ✓');
+		strictEqual(matD.isDisposed(), false, 'animated Material = ✓');
+	});
 
-test('meshes', async (t) => {
-	const io = new NodeIO();
-	const document = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));
-	const root = document.getRoot();
-	t.is(root.listMeshes().length, 501, 'begins with duplicate meshes');
+	test('meshes', async () => {
+		const io = new NodeIO();
+		const document = await io.read(path.join(__dirname, 'in/many-cubes.gltf'));
+		const root = document.getRoot();
+		strictEqual(root.listMeshes().length, 501, 'begins with duplicate meshes');
 
-	dedup({ propertyTypes: [PropertyType.ACCESSOR] })(document);
+		dedup({ propertyTypes: [PropertyType.ACCESSOR] })(document);
 
-	t.is(root.listMeshes().length, 501, 'has no effect when disabled');
+		strictEqual(root.listMeshes().length, 501, 'has no effect when disabled');
 
-	// Put unique materials on two meshes to prevent merging.
-	root.listMeshes()[0].listPrimitives()[0].setMaterial(document.createMaterial('A'));
-	root.listMeshes()[1].listPrimitives()[0].setMaterial(document.createMaterial('B'));
-	root.listMeshes()[2].listPrimitives()[0].setMaterial(document.createMaterial('C').setRoughnessFactor(0.5));
+		// Put unique materials on two meshes to prevent merging.
+		root.listMeshes()[0].listPrimitives()[0].setMaterial(document.createMaterial('A'));
+		root.listMeshes()[1].listPrimitives()[0].setMaterial(document.createMaterial('B'));
+		root.listMeshes()[2].listPrimitives()[0].setMaterial(document.createMaterial('C').setRoughnessFactor(0.5));
 
-	dedup()(document);
+		dedup()(document);
 
-	t.is(root.listMeshes().length, 3, 'prunes duplicate meshes');
-});
+		strictEqual(root.listMeshes().length, 3, 'prunes duplicate meshes');
+	});
 
-test('skins', async (t) => {
-	const document = new Document();
-	const root = document.getRoot();
-	const boneA = document.createNode('A');
-	const boneB = document.createNode('B');
-	document.createScene().addChild(boneA).addChild(boneB);
-	const skinA = document.createSkin().addJoint(boneA).addJoint(boneB);
-	const skinB = document.createSkin().addJoint(boneA).addJoint(boneB);
-	const skinC = document.createSkin().addJoint(boneA);
+	test('skins', async () => {
+		const document = new Document();
+		const root = document.getRoot();
+		const boneA = document.createNode('A');
+		const boneB = document.createNode('B');
+		document.createScene().addChild(boneA).addChild(boneB);
+		const skinA = document.createSkin().addJoint(boneA).addJoint(boneB);
+		const skinB = document.createSkin().addJoint(boneA).addJoint(boneB);
+		const skinC = document.createSkin().addJoint(boneA);
 
-	t.is(root.listSkins().length, 3, 'begins with duplicate skins');
+		strictEqual(root.listSkins().length, 3, 'begins with duplicate skins');
 
-	await document.transform(dedup({ propertyTypes: [PropertyType.MESH] }));
+		await document.transform(dedup({ propertyTypes: [PropertyType.MESH] }));
 
-	t.is(root.listSkins().length, 3, 'has no effect if disabled');
+		strictEqual(root.listSkins().length, 3, 'has no effect if disabled');
 
-	await document.transform(dedup({ propertyTypes: [PropertyType.SKIN] }));
+		await document.transform(dedup({ propertyTypes: [PropertyType.SKIN] }));
 
-	t.is(root.listSkins().length, 2, 'prunes duplicate skins');
-	t.false(skinA.isDisposed(), 'keep skin A');
-	t.true(skinB.isDisposed(), 'dispose skin B');
-	t.false(skinC.isDisposed(), 'keep skin C');
-});
+		strictEqual(root.listSkins().length, 2, 'prunes duplicate skins');
+		strictEqual(skinA.isDisposed(), false, 'keep skin A');
+		ok(skinB.isDisposed(), 'dispose skin B');
+		strictEqual(skinC.isDisposed(), false, 'keep skin C');
+	});
 
-test('textures', async (t) => {
-	const document = new Document();
-	const transmissionExt = document.createExtension(KHRMaterialsTransmission);
+	test('textures', async () => {
+		const document = new Document();
+		const transmissionExt = document.createExtension(KHRMaterialsTransmission);
 
-	const pixels = ndarray(new Uint8Array(100 * 50 * 4), [100, 50, 4]);
-	const image = await savePixels(pixels, 'image/png');
+		const pixels = ndarray(new Uint8Array(100 * 50 * 4), [100, 50, 4]);
+		const image = await savePixels(pixels, 'image/png');
 
-	const tex1 = document.createTexture('copy 1').setMimeType('image/png').setImage(image);
-	const tex2 = document.createTexture('copy 2').setMimeType('image/png').setImage(image.slice());
+		const tex1 = document.createTexture('copy 1').setMimeType('image/png').setImage(image);
+		const tex2 = document.createTexture('copy 2').setMimeType('image/png').setImage(image.slice());
 
-	const transmission = transmissionExt.createTransmission().setTransmissionTexture(tex2);
-	const mat = document
-		.createMaterial()
-		.setBaseColorTexture(tex1)
-		.setExtension('KHR_materials_transmission', transmission);
+		const transmission = transmissionExt.createTransmission().setTransmissionTexture(tex2);
+		const mat = document
+			.createMaterial()
+			.setBaseColorTexture(tex1)
+			.setExtension('KHR_materials_transmission', transmission);
 
-	t.is(document.getRoot().listTextures().length, 2, 'begins with duplicate textures');
+		strictEqual(document.getRoot().listTextures().length, 2, 'begins with duplicate textures');
 
-	dedup({ propertyTypes: [PropertyType.ACCESSOR] })(document);
+		dedup({ propertyTypes: [PropertyType.ACCESSOR] })(document);
 
-	t.is(document.getRoot().listTextures().length, 2, 'has no effect when disabled');
+		strictEqual(document.getRoot().listTextures().length, 2, 'has no effect when disabled');
 
-	dedup()(document);
+		dedup()(document);
 
-	t.is(document.getRoot().listTextures().length, 1, 'prunes duplicate textures');
-	t.is(mat.getBaseColorTexture(), tex1, 'retains baseColorTexture');
-	t.is(transmission.getTransmissionTexture(), tex1, 'retains transmissionTexture');
-});
+		strictEqual(document.getRoot().listTextures().length, 1, 'prunes duplicate textures');
+		strictEqual(mat.getBaseColorTexture(), tex1, 'retains baseColorTexture');
+		strictEqual(transmission.getTransmissionTexture(), tex1, 'retains transmissionTexture');
+	});
 
-test('unique names', async (t) => {
-	const document = new Document();
+	test('unique names', async () => {
+		const document = new Document();
 
-	const matA = document.createMaterial('A').setBaseColorFactor([0.5, 0.5, 0.5, 1]);
-	const matB = matA.clone().setName('B');
-	const matC = matA.clone().setName('C').setBaseColorFactor([0.6, 0.6, 0.6, 1]);
+		const matA = document.createMaterial('A').setBaseColorFactor([0.5, 0.5, 0.5, 1]);
+		const matB = matA.clone().setName('B');
+		const matC = matA.clone().setName('C').setBaseColorFactor([0.6, 0.6, 0.6, 1]);
 
-	const positionA = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([0, 0, 0]));
-	const positionB = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([1, 1, 1]));
+		const positionA = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float32Array([0, 0, 0]));
+		const positionB = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float32Array([1, 1, 1]));
 
-	const primA = document.createPrimitive().setAttribute('POSITION', positionA);
-	const primB = document.createPrimitive().setAttribute('POSITION', positionB);
+		const primA = document.createPrimitive().setAttribute('POSITION', positionA);
+		const primB = document.createPrimitive().setAttribute('POSITION', positionB);
 
-	const meshA = document.createMesh('A').addPrimitive(primA);
-	const meshB = document.createMesh('B').addPrimitive(primA);
-	const meshC = document.createMesh('C').addPrimitive(primB);
+		const meshA = document.createMesh('A').addPrimitive(primA);
+		const meshB = document.createMesh('B').addPrimitive(primA);
+		const meshC = document.createMesh('C').addPrimitive(primB);
 
-	await document.transform(dedup({ keepUniqueNames: true }));
+		await document.transform(dedup({ keepUniqueNames: true }));
 
-	t.deepEqual([matA, matB, matC].map(isDisposed), [false, false, false], 'materials - keep unique names');
-	t.deepEqual([meshA, meshB, meshC].map(isDisposed), [false, false, false], 'meshes - keep unique names');
+		deepEqual([matA, matB, matC].map(isDisposed), [false, false, false], 'materials - keep unique names');
+		deepEqual([meshA, meshB, meshC].map(isDisposed), [false, false, false], 'meshes - keep unique names');
 
-	await document.transform(dedup({ keepUniqueNames: false }));
+		await document.transform(dedup({ keepUniqueNames: false }));
 
-	t.deepEqual([matA, matB, matC].map(isDisposed), [false, true, false], 'materials - discard unique names');
-	t.deepEqual([meshA, meshB, meshC].map(isDisposed), [false, true, false], 'meshes - discard unique names');
+		deepEqual([matA, matB, matC].map(isDisposed), [false, true, false], 'materials - discard unique names');
+		deepEqual([meshA, meshB, meshC].map(isDisposed), [false, true, false], 'meshes - discard unique names');
+	});
 });
 
 const isDisposed = (prop: Property) => prop.isDisposed();

--- a/packages/functions/test/dequantize.test.ts
+++ b/packages/functions/test/dequantize.test.ts
@@ -14,7 +14,7 @@ import { dequantize } from '@gltf-transform/functions';
 
 const logger = new Logger(Logger.Verbosity.WARN);
 
-describe('dequantize', () => {
+describe('functions::dequantize', () => {
 	test('basic', async () => {
 		const doc = new Document().setLogger(logger);
 		const scene = createScene(doc);

--- a/packages/functions/test/dequantize.test.ts
+++ b/packages/functions/test/dequantize.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import {
 	type bbox,
 	Document,
@@ -9,38 +11,39 @@ import {
 	type vec3,
 } from '@gltf-transform/core';
 import { dequantize } from '@gltf-transform/functions';
-import test from 'ava';
 
 const logger = new Logger(Logger.Verbosity.WARN);
 
-test('basic', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const scene = createScene(doc);
-	const node = doc.getRoot().listNodes()[0];
-	const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+describe('dequantize', () => {
+	test('basic', async () => {
+		const doc = new Document().setLogger(logger);
+		const scene = createScene(doc);
+		const node = doc.getRoot().listNodes()[0];
+		const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
 
-	const bboxScenePrev = getBounds(scene);
-	const bboxNodePrev = getBounds(node);
-	const bboxMeshPrev = primBounds(prim);
+		const bboxScenePrev = getBounds(scene);
+		const bboxNodePrev = getBounds(node);
+		const bboxMeshPrev = primBounds(prim);
 
-	t.deepEqual(bboxScenePrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
-	t.deepEqual(bboxNodePrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - node');
-	t.deepEqual(bboxMeshPrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - mesh');
+		deepEqual(bboxScenePrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
+		deepEqual(bboxNodePrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - node');
+		deepEqual(bboxMeshPrev, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - mesh');
 
-	await doc.transform(dequantize());
+		await doc.transform(dequantize());
 
-	const bboxScene = getBounds(scene);
-	const bboxNode = getBounds(node);
-	const bboxMesh = primBounds(prim);
+		const bboxScene = getBounds(scene);
+		const bboxNode = getBounds(node);
+		const bboxMesh = primBounds(prim);
 
-	t.truthy(prim.getAttribute('POSITION').getArray() instanceof Float32Array, 'position - float32');
-	t.truthy(prim.getAttribute('JOINTS_0').getArray() instanceof Uint8Array, 'joints - uint8');
-	t.truthy(prim.getAttribute('WEIGHTS_0').getArray() instanceof Float32Array, 'weights - float32');
-	t.deepEqual(bboxScene, bboxScenePrev, 'bbox - scene');
-	t.deepEqual(bboxNode, bboxNodePrev, 'bbox - nodeA');
-	t.deepEqual(bboxMesh, bboxMeshPrev, 'bbox - meshA');
-	t.is(doc.getRoot().listNodes().length, 1, 'total nodes');
-	t.is(doc.getRoot().listAccessors().length, 3, 'total accessors');
+		ok(prim.getAttribute('POSITION').getArray() instanceof Float32Array, 'position - float32');
+		ok(prim.getAttribute('JOINTS_0').getArray() instanceof Uint8Array, 'joints - uint8');
+		ok(prim.getAttribute('WEIGHTS_0').getArray() instanceof Float32Array, 'weights - float32');
+		deepEqual(bboxScene, bboxScenePrev, 'bbox - scene');
+		deepEqual(bboxNode, bboxNodePrev, 'bbox - nodeA');
+		deepEqual(bboxMesh, bboxMeshPrev, 'bbox - meshA');
+		strictEqual(doc.getRoot().listNodes().length, 1, 'total nodes');
+		strictEqual(doc.getRoot().listAccessors().length, 3, 'total accessors');
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/document-utils.test.ts
+++ b/packages/functions/test/document-utils.test.ts
@@ -5,7 +5,7 @@ import { KHRMaterialsUnlit, KHRTextureTransform, Transform, Unlit } from '@gltf-
 import { cloneDocument, copyToDocument, mergeDocuments, moveToDocument, prune } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
 
-describe('DocumentUtils', () => {
+describe('functions::DocumentUtils', () => {
 	test('cloneDocument', () => {
 		const document1 = new Document().setLogger(logger);
 		document1.createMaterial('MyMaterial');

--- a/packages/functions/test/document-utils.test.ts
+++ b/packages/functions/test/document-utils.test.ts
@@ -1,172 +1,181 @@
+import { deepEqual, notStrictEqual, ok, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type Property } from '@gltf-transform/core';
 import { KHRMaterialsUnlit, KHRTextureTransform, Transform, Unlit } from '@gltf-transform/extensions';
 import { cloneDocument, copyToDocument, mergeDocuments, moveToDocument, prune } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('cloneDocument', (t) => {
-	const document1 = new Document().setLogger(logger);
-	document1.createMaterial('MyMaterial');
-	const rootNode = document1.createNode('A').addChild(document1.createNode('B').addChild(document1.createNode('C')));
-	document1.createScene('MyScene').addChild(rootNode);
+describe('DocumentUtils', () => {
+	test('cloneDocument', () => {
+		const document1 = new Document().setLogger(logger);
+		document1.createMaterial('MyMaterial');
+		const rootNode = document1
+			.createNode('A')
+			.addChild(document1.createNode('B').addChild(document1.createNode('C')));
+		document1.createScene('MyScene').addChild(rootNode);
 
-	const document2 = cloneDocument(document1);
+		const document2 = cloneDocument(document1);
 
-	t.is(document2.getRoot().listScenes()[0].getName(), 'MyScene', 'transfers scene');
-	t.is(document2.getRoot().listScenes()[0].listChildren().length, 1, 'transfers scene root node');
-	t.is(document2.getRoot().listNodes().length, 3, 'transfers nodes');
-	t.is(document2.getRoot().listNodes()[0].listChildren().length, 1, 'transfers node hierarchy (1/3)');
-	t.is(document2.getRoot().listNodes()[1].listChildren().length, 1, 'transfers node hierarchy (2/3)');
-	t.is(document2.getRoot().listNodes()[2].listChildren().length, 0, 'transfers node hierarchy (3/3)');
-	t.is(document2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'transfers material');
-	t.not(document2.getRoot().listScenes()[0], document1.getRoot().listScenes()[0], 'does not reference old scene');
-	t.not(
-		document2.getRoot().listMaterials()[0],
-		document1.getRoot().listMaterials()[0],
-		'does not reference old material',
-	);
-});
+		strictEqual(document2.getRoot().listScenes()[0].getName(), 'MyScene', 'transfers scene');
+		strictEqual(document2.getRoot().listScenes()[0].listChildren().length, 1, 'transfers scene root node');
+		strictEqual(document2.getRoot().listNodes().length, 3, 'transfers nodes');
+		strictEqual(document2.getRoot().listNodes()[0].listChildren().length, 1, 'transfers node hierarchy (1/3)');
+		strictEqual(document2.getRoot().listNodes()[1].listChildren().length, 1, 'transfers node hierarchy (2/3)');
+		strictEqual(document2.getRoot().listNodes()[2].listChildren().length, 0, 'transfers node hierarchy (3/3)');
+		strictEqual(document2.getRoot().listMaterials()[0].getName(), 'MyMaterial', 'transfers material');
+		notStrictEqual(
+			document2.getRoot().listScenes()[0],
+			document1.getRoot().listScenes()[0],
+			'does not reference old scene',
+		);
+		notStrictEqual(
+			document2.getRoot().listMaterials()[0],
+			document1.getRoot().listMaterials()[0],
+			'does not reference old material',
+		);
+	});
 
-test('mergeDocuments - scenes', (t) => {
-	const targetDocument = new Document().setLogger(logger);
-	targetDocument.createScene('SceneA');
-	const sourceDocument = new Document().setLogger(logger);
-	sourceDocument.createScene('SceneB');
+	test('mergeDocuments - scenes', () => {
+		const targetDocument = new Document().setLogger(logger);
+		targetDocument.createScene('SceneA');
+		const sourceDocument = new Document().setLogger(logger);
+		sourceDocument.createScene('SceneB');
 
-	mergeDocuments(targetDocument, sourceDocument);
+		mergeDocuments(targetDocument, sourceDocument);
 
-	const toName = (prop: Property) => prop.getName();
-	t.deepEqual(targetDocument.getRoot().listScenes().map(toName), ['SceneA', 'SceneB'], 'target.scenes');
-	t.deepEqual(sourceDocument.getRoot().listScenes().map(toName), ['SceneB'], 'source.scenes');
-});
+		const toName = (prop: Property) => prop.getName();
+		deepEqual(targetDocument.getRoot().listScenes().map(toName), ['SceneA', 'SceneB'], 'target.scenes');
+		deepEqual(sourceDocument.getRoot().listScenes().map(toName), ['SceneB'], 'source.scenes');
+	});
 
-test('mergeDocuments - generator', (t) => {
-	const targetDocument = new Document().setLogger(logger);
-	targetDocument.getRoot().getAsset().generator = 'GeneratorA';
-	const sourceDocument = new Document().setLogger(logger);
-	sourceDocument.getRoot().getAsset().generator = 'GeneratorB';
+	test('mergeDocuments - generator', () => {
+		const targetDocument = new Document().setLogger(logger);
+		targetDocument.getRoot().getAsset().generator = 'GeneratorA';
+		const sourceDocument = new Document().setLogger(logger);
+		sourceDocument.getRoot().getAsset().generator = 'GeneratorB';
 
-	mergeDocuments(targetDocument, sourceDocument);
+		mergeDocuments(targetDocument, sourceDocument);
 
-	t.is(targetDocument.getRoot().getAsset().generator, 'GeneratorA', 'target.asset.generator');
-	t.is(sourceDocument.getRoot().getAsset().generator, 'GeneratorB', 'source.asset.generator');
-});
+		strictEqual(targetDocument.getRoot().getAsset().generator, 'GeneratorA', 'target.asset.generator');
+		strictEqual(sourceDocument.getRoot().getAsset().generator, 'GeneratorB', 'source.asset.generator');
+	});
 
-test('copyToDocument - basic', async (t) => {
-	const srcDocument = new Document().setLogger(logger);
-	const dstDocument = new Document().setLogger(logger);
+	test('copyToDocument - basic', async () => {
+		const srcDocument = new Document().setLogger(logger);
+		const dstDocument = new Document().setLogger(logger);
 
-	const srcPrim = createTorusKnotPrimitive(srcDocument, { tubularSegments: 6 });
-	const srcPosition = srcPrim.getAttribute('POSITION');
-	const srcMesh = srcDocument.createMesh('TorusMesh').addPrimitive(srcPrim);
-	const srcNode = srcDocument.createNode('TorusNode').setMesh(srcMesh);
-	const srcScene = srcDocument.createScene().addChild(srcNode);
+		const srcPrim = createTorusKnotPrimitive(srcDocument, { tubularSegments: 6 });
+		const srcPosition = srcPrim.getAttribute('POSITION');
+		const srcMesh = srcDocument.createMesh('TorusMesh').addPrimitive(srcPrim);
+		const srcNode = srcDocument.createNode('TorusNode').setMesh(srcMesh);
+		const srcScene = srcDocument.createScene().addChild(srcNode);
 
-	const map = copyToDocument(dstDocument, srcDocument, [srcMesh]);
-	await srcDocument.transform(prune({ keepLeaves: true }));
+		const map = copyToDocument(dstDocument, srcDocument, [srcMesh]);
+		await srcDocument.transform(prune({ keepLeaves: true }));
 
-	t.false(srcPosition.isDisposed(), 'srcPosition ok');
-	t.false(srcPrim.isDisposed(), 'srcPrim ok');
-	t.false(srcMesh.isDisposed(), 'srcMesh ok');
-	t.false(srcNode.isDisposed(), 'srcNode ok');
-	t.false(srcScene.isDisposed(), 'srcScene ok');
+		strictEqual(srcPosition.isDisposed(), false, 'srcPosition ok');
+		strictEqual(srcPrim.isDisposed(), false, 'srcPrim ok');
+		strictEqual(srcMesh.isDisposed(), false, 'srcMesh ok');
+		strictEqual(srcNode.isDisposed(), false, 'srcNode ok');
+		strictEqual(srcScene.isDisposed(), false, 'srcScene ok');
 
-	const dstMesh = dstDocument.getRoot().listMeshes()[0];
-	const dstPrim = dstMesh.listPrimitives()[0];
-	const dstPosition = dstPrim.getAttribute('POSITION');
+		const dstMesh = dstDocument.getRoot().listMeshes()[0];
+		const dstPrim = dstMesh.listPrimitives()[0];
+		const dstPosition = dstPrim.getAttribute('POSITION');
 
-	t.is(dstMesh.getName(), 'TorusMesh', 'dstMesh.name');
-	t.is(map.get(srcMesh), dstMesh, 'mesh <-> mesh');
-	t.is(map.get(srcPrim), dstPrim, 'prim <-> prim');
-	t.is(map.get(srcPosition), dstPosition, 'position <-> position');
-	t.is(map.has(srcNode), false, 'node <-> null');
-	t.is(map.has(srcScene), false, 'scene <-> null');
-});
+		strictEqual(dstMesh.getName(), 'TorusMesh', 'dstMesh.name');
+		strictEqual(map.get(srcMesh), dstMesh, 'mesh <-> mesh');
+		strictEqual(map.get(srcPrim), dstPrim, 'prim <-> prim');
+		strictEqual(map.get(srcPosition), dstPosition, 'position <-> position');
+		strictEqual(map.has(srcNode), false, 'node <-> null');
+		strictEqual(map.has(srcScene), false, 'scene <-> null');
+	});
 
-test('copyToDocument - unsupported', async (t) => {
-	const srcDocument = new Document().setLogger(logger);
-	const dstDocument = new Document().setLogger(logger);
+	test('copyToDocument - unsupported', async () => {
+		const srcDocument = new Document().setLogger(logger);
+		const dstDocument = new Document().setLogger(logger);
 
-	const srcRoot = srcDocument.getRoot();
-	const srcTexture = srcDocument.createTexture();
-	const srcTextureInfo = srcDocument.createMaterial().setBaseColorTexture(srcTexture).getBaseColorTextureInfo()!;
+		const srcRoot = srcDocument.getRoot();
+		const srcTexture = srcDocument.createTexture();
+		const srcTextureInfo = srcDocument.createMaterial().setBaseColorTexture(srcTexture).getBaseColorTextureInfo()!;
 
-	t.throws(() => void copyToDocument(dstDocument, srcDocument, [srcRoot]));
-	t.throws(() => void copyToDocument(dstDocument, srcDocument, [srcTextureInfo]));
-});
+		throws(() => void copyToDocument(dstDocument, srcDocument, [srcRoot]));
+		throws(() => void copyToDocument(dstDocument, srcDocument, [srcTextureInfo]));
+	});
 
-test('copyToDocument - material', async (t) => {
-	const srcDocument = new Document().setLogger(logger);
-	const dstDocument = new Document().setLogger(logger);
+	test('copyToDocument - material', async () => {
+		const srcDocument = new Document().setLogger(logger);
+		const dstDocument = new Document().setLogger(logger);
 
-	const unlitExtension = srcDocument.createExtension(KHRMaterialsUnlit);
-	const unlit = unlitExtension.createUnlit();
+		const unlitExtension = srcDocument.createExtension(KHRMaterialsUnlit);
+		const unlit = unlitExtension.createUnlit();
 
-	const transformExtension = srcDocument.createExtension(KHRTextureTransform);
-	const transform = transformExtension.createTransform().setScale([2, 2]);
+		const transformExtension = srcDocument.createExtension(KHRTextureTransform);
+		const transform = transformExtension.createTransform().setScale([2, 2]);
 
-	dstDocument.createExtension(KHRMaterialsUnlit);
-	dstDocument.createExtension(KHRTextureTransform);
+		dstDocument.createExtension(KHRMaterialsUnlit);
+		dstDocument.createExtension(KHRTextureTransform);
 
-	const srcTexture = srcDocument.createTexture();
-	const srcMaterial = srcDocument
-		.createMaterial()
-		.setBaseColorFactor([0.5, 0, 0, 1])
-		.setBaseColorTexture(srcTexture)
-		.setExtension('KHR_materials_unlit', unlit);
-	srcMaterial.getBaseColorTextureInfo()!.setExtension('KHR_texture_transform', transform);
+		const srcTexture = srcDocument.createTexture();
+		const srcMaterial = srcDocument
+			.createMaterial()
+			.setBaseColorFactor([0.5, 0, 0, 1])
+			.setBaseColorTexture(srcTexture)
+			.setExtension('KHR_materials_unlit', unlit);
+		srcMaterial.getBaseColorTextureInfo()!.setExtension('KHR_texture_transform', transform);
 
-	copyToDocument(dstDocument, srcDocument, [srcMaterial]);
+		copyToDocument(dstDocument, srcDocument, [srcMaterial]);
 
-	const dstMaterial = dstDocument.getRoot().listMaterials()[0];
-	const dstTextureInfo = dstMaterial.getBaseColorTextureInfo();
-	const dstTransform = dstTextureInfo.getExtension<Transform>('KHR_texture_transform');
+		const dstMaterial = dstDocument.getRoot().listMaterials()[0];
+		const dstTextureInfo = dstMaterial.getBaseColorTextureInfo();
+		const dstTransform = dstTextureInfo.getExtension<Transform>('KHR_texture_transform');
 
-	t.deepEqual(dstMaterial.getBaseColorFactor(), [0.5, 0, 0, 1], 'baseColorFactor');
-	t.true(dstMaterial.getExtension('KHR_materials_unlit') instanceof Unlit, 'unlit');
-	t.true(dstTransform instanceof Transform, 'transform');
-	t.deepEqual(dstTransform.getScale(), [2, 2], 'transform.scale');
-});
+		deepEqual(dstMaterial.getBaseColorFactor(), [0.5, 0, 0, 1], 'baseColorFactor');
+		ok(dstMaterial.getExtension('KHR_materials_unlit') instanceof Unlit, 'unlit');
+		ok(dstTransform instanceof Transform, 'transform');
+		deepEqual(dstTransform.getScale(), [2, 2], 'transform.scale');
+	});
 
-test('moveToDocument - basic', async (t) => {
-	const srcDocument = new Document().setLogger(logger);
-	const dstDocument = new Document().setLogger(logger);
+	test('moveToDocument - basic', async () => {
+		const srcDocument = new Document().setLogger(logger);
+		const dstDocument = new Document().setLogger(logger);
 
-	const srcPrim = createTorusKnotPrimitive(srcDocument, { tubularSegments: 6 });
-	const srcPosition = srcPrim.getAttribute('POSITION');
-	const srcMesh = srcDocument.createMesh('TorusMesh').addPrimitive(srcPrim);
-	const srcNode = srcDocument.createNode('TorusNode').setMesh(srcMesh);
-	const srcScene = srcDocument.createScene().addChild(srcNode);
+		const srcPrim = createTorusKnotPrimitive(srcDocument, { tubularSegments: 6 });
+		const srcPosition = srcPrim.getAttribute('POSITION');
+		const srcMesh = srcDocument.createMesh('TorusMesh').addPrimitive(srcPrim);
+		const srcNode = srcDocument.createNode('TorusNode').setMesh(srcMesh);
+		const srcScene = srcDocument.createScene().addChild(srcNode);
 
-	const map = moveToDocument(dstDocument, srcDocument, [srcMesh]);
-	await srcDocument.transform(prune({ keepLeaves: true }));
+		const map = moveToDocument(dstDocument, srcDocument, [srcMesh]);
+		await srcDocument.transform(prune({ keepLeaves: true }));
 
-	t.true(srcPosition.isDisposed(), 'srcPosition disposed');
-	t.true(srcPrim.isDisposed(), 'srcPrim disposed');
-	t.true(srcMesh.isDisposed(), 'srcMesh disposed');
-	t.false(srcNode.isDisposed(), 'srcNode ok');
-	t.false(srcScene.isDisposed(), 'srcScene ok');
+		ok(srcPosition.isDisposed(), 'srcPosition disposed');
+		ok(srcPrim.isDisposed(), 'srcPrim disposed');
+		ok(srcMesh.isDisposed(), 'srcMesh disposed');
+		strictEqual(srcNode.isDisposed(), false, 'srcNode ok');
+		strictEqual(srcScene.isDisposed(), false, 'srcScene ok');
 
-	const dstMesh = dstDocument.getRoot().listMeshes()[0];
-	const dstPrim = dstMesh.listPrimitives()[0];
-	const dstPosition = dstPrim.getAttribute('POSITION');
+		const dstMesh = dstDocument.getRoot().listMeshes()[0];
+		const dstPrim = dstMesh.listPrimitives()[0];
+		const dstPosition = dstPrim.getAttribute('POSITION');
 
-	t.is(dstMesh.getName(), 'TorusMesh', 'dstMesh.name');
-	t.is(map.get(srcMesh), dstMesh, 'mesh <-> mesh');
-	t.is(map.get(srcPrim), dstPrim, 'prim <-> prim');
-	t.is(map.get(srcPosition), dstPosition, 'position <-> position');
-	t.is(map.has(srcNode), false, 'node <-> null');
-	t.is(map.has(srcScene), false, 'scene <-> null');
-});
+		strictEqual(dstMesh.getName(), 'TorusMesh', 'dstMesh.name');
+		strictEqual(map.get(srcMesh), dstMesh, 'mesh <-> mesh');
+		strictEqual(map.get(srcPrim), dstPrim, 'prim <-> prim');
+		strictEqual(map.get(srcPosition), dstPosition, 'position <-> position');
+		strictEqual(map.has(srcNode), false, 'node <-> null');
+		strictEqual(map.has(srcScene), false, 'scene <-> null');
+	});
 
-test('moveToDocument - unsupported', async (t) => {
-	const srcDocument = new Document().setLogger(logger);
-	const dstDocument = new Document().setLogger(logger);
+	test('moveToDocument - unsupported', async () => {
+		const srcDocument = new Document().setLogger(logger);
+		const dstDocument = new Document().setLogger(logger);
 
-	const srcRoot = srcDocument.getRoot();
-	const srcTexture = srcDocument.createTexture();
-	const srcTextureInfo = srcDocument.createMaterial().setBaseColorTexture(srcTexture).getBaseColorTextureInfo()!;
+		const srcRoot = srcDocument.getRoot();
+		const srcTexture = srcDocument.createTexture();
+		const srcTextureInfo = srcDocument.createMaterial().setBaseColorTexture(srcTexture).getBaseColorTextureInfo()!;
 
-	t.throws(() => void moveToDocument(dstDocument, srcDocument, [srcRoot]));
-	t.throws(() => void moveToDocument(dstDocument, srcDocument, [srcTextureInfo]));
+		throws(() => void moveToDocument(dstDocument, srcDocument, [srcRoot]));
+		throws(() => void moveToDocument(dstDocument, srcDocument, [srcTextureInfo]));
+	});
 });

--- a/packages/functions/test/draco.test.ts
+++ b/packages/functions/test/draco.test.ts
@@ -1,12 +1,15 @@
+import { strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { draco } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	await document.transform(draco({ method: 'edgebreaker' }));
-	await document.transform(draco({ method: 'sequential' }));
-	const dracoExtension = document.getRoot().listExtensionsUsed()[0];
-	t.is(dracoExtension.extensionName, 'KHR_draco_mesh_compression', 'adds extension');
+describe('draco', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		await document.transform(draco({ method: 'edgebreaker' }));
+		await document.transform(draco({ method: 'sequential' }));
+		const dracoExtension = document.getRoot().listExtensionsUsed()[0];
+		strictEqual(dracoExtension.extensionName, 'KHR_draco_mesh_compression', 'adds extension');
+	});
 });

--- a/packages/functions/test/draco.test.ts
+++ b/packages/functions/test/draco.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { draco } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('draco', () => {
+describe('functions::draco', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		await document.transform(draco({ method: 'edgebreaker' }));

--- a/packages/functions/test/flatten.test.ts
+++ b/packages/functions/test/flatten.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { flatten } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('flatten', () => {
+describe('functions::flatten', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const mesh = document.createMesh();

--- a/packages/functions/test/flatten.test.ts
+++ b/packages/functions/test/flatten.test.ts
@@ -1,94 +1,97 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { flatten } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const mesh = document.createMesh();
-	const nodeA = document.createNode('A').setTranslation([2, 0, 0]).setMesh(mesh);
-	const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA).setMesh(mesh);
-	const nodeC = document.createNode('C').addChild(nodeB).setMesh(mesh);
-	const scene = document.createScene().addChild(nodeC);
+describe('flatten', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const mesh = document.createMesh();
+		const nodeA = document.createNode('A').setTranslation([2, 0, 0]).setMesh(mesh);
+		const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA).setMesh(mesh);
+		const nodeC = document.createNode('C').addChild(nodeB).setMesh(mesh);
+		const scene = document.createScene().addChild(nodeC);
 
-	t.truthy(nodeA.getParentNode() === nodeB, 'B → A (before)');
-	t.truthy(nodeB.getParentNode() === nodeC, 'C → B (before)');
-	t.truthy(nodeC.getParentNode() === null, 'Scene → C (before)');
+		ok(nodeA.getParentNode() === nodeB, 'B → A (before)');
+		ok(nodeB.getParentNode() === nodeC, 'C → B (before)');
+		ok(nodeC.getParentNode() === null, 'Scene → C (before)');
 
-	await document.transform(flatten());
+		await document.transform(flatten());
 
-	t.truthy(nodeA.getParentNode() === null, 'Scene → A (after)');
-	t.truthy(nodeB.getParentNode() === null, 'Scene → B (after)');
-	t.truthy(nodeC.getParentNode() === null, 'Scene → C (after)');
-	t.deepEqual(scene.listChildren(), [nodeC, nodeB, nodeA], 'Scene → [C, B, A] (after)');
+		ok(nodeA.getParentNode() === null, 'Scene → A (after)');
+		ok(nodeB.getParentNode() === null, 'Scene → B (after)');
+		ok(nodeC.getParentNode() === null, 'Scene → C (after)');
+		deepEqual(scene.listChildren(), [nodeC, nodeB, nodeA], 'Scene → [C, B, A] (after)');
 
-	t.deepEqual(nodeA.getTranslation(), [8, 0, 0], 'A.translation');
-	t.deepEqual(nodeA.getScale(), [4, 4, 4], 'A.scale');
-	t.deepEqual(nodeB.getScale(), [4, 4, 4], 'B.scale');
-});
+		deepEqual(nodeA.getTranslation(), [8, 0, 0], 'A.translation');
+		deepEqual(nodeA.getScale(), [4, 4, 4], 'A.scale');
+		deepEqual(nodeB.getScale(), [4, 4, 4], 'B.scale');
+	});
 
-test('skins', async (t) => {
-	const document = new Document().setLogger(logger);
-	const mesh = document.createMesh();
-	const skin = document.createSkin();
-	const nodeA = document.createNode('JointLeaf').setMesh(mesh);
-	const nodeB = document.createNode('JointMid').addChild(nodeA);
-	const nodeC = document.createNode('JointRoot').addChild(nodeB).setSkin(skin);
-	const nodeD = document.createNode('Empty').addChild(nodeC);
-	const scene = document.createScene().addChild(nodeD);
+	test('skins', async () => {
+		const document = new Document().setLogger(logger);
+		const mesh = document.createMesh();
+		const skin = document.createSkin();
+		const nodeA = document.createNode('JointLeaf').setMesh(mesh);
+		const nodeB = document.createNode('JointMid').addChild(nodeA);
+		const nodeC = document.createNode('JointRoot').addChild(nodeB).setSkin(skin);
+		const nodeD = document.createNode('Empty').addChild(nodeC);
+		const scene = document.createScene().addChild(nodeD);
 
-	skin.addJoint(nodeA).addJoint(nodeB).addJoint(nodeC).setSkeleton(nodeC);
+		skin.addJoint(nodeA).addJoint(nodeB).addJoint(nodeC).setSkeleton(nodeC);
 
-	t.truthy(nodeA.getParentNode() === nodeB, 'JointMid → JointLeaf (before)');
-	t.truthy(nodeB.getParentNode() === nodeC, 'JointRoot → JointMid (before)');
-	t.truthy(nodeC.getParentNode() === nodeD, 'Group → JointRoot (before)');
-	t.truthy(nodeD.getParentNode() === null, 'Scene → Group (before)');
-	t.deepEqual(scene.listChildren(), [nodeD], 'Scene → Group (before)');
+		ok(nodeA.getParentNode() === nodeB, 'JointMid → JointLeaf (before)');
+		ok(nodeB.getParentNode() === nodeC, 'JointRoot → JointMid (before)');
+		ok(nodeC.getParentNode() === nodeD, 'Group → JointRoot (before)');
+		ok(nodeD.getParentNode() === null, 'Scene → Group (before)');
+		deepEqual(scene.listChildren(), [nodeD], 'Scene → Group (before)');
 
-	await document.transform(flatten());
+		await document.transform(flatten());
 
-	t.truthy(nodeA.getMesh(), 'JointLeaf → mesh');
-	t.truthy(nodeA.getParentNode() === nodeB, 'JointMid → JointLeaf (after)');
-	t.truthy(nodeB.getParentNode() === nodeC, 'JointRoot → JointMid (after)');
-	t.truthy(nodeC.getParentNode() === null, 'Scene → JointRoot (after)');
-	t.truthy(nodeD.isDisposed(), 'Group disposed');
-	t.deepEqual(scene.listChildren(), [nodeC], 'Scene → JointRoot (after)');
-});
+		ok(nodeA.getMesh(), 'JointLeaf → mesh');
+		ok(nodeA.getParentNode() === nodeB, 'JointMid → JointLeaf (after)');
+		ok(nodeB.getParentNode() === nodeC, 'JointRoot → JointMid (after)');
+		ok(nodeC.getParentNode() === null, 'Scene → JointRoot (after)');
+		ok(nodeD.isDisposed(), 'Group disposed');
+		deepEqual(scene.listChildren(), [nodeC], 'Scene → JointRoot (after)');
+	});
 
-test('trs animation', async (t) => {
-	const document = new Document().setLogger(logger);
-	const mesh = document.createMesh();
-	const nodeA = document.createNode('A').setMesh(mesh);
-	const nodeB = document.createNode('B').setMesh(mesh);
-	const nodeC = document.createNode('Group').addChild(nodeA).addChild(nodeB).setScale([2, 2, 2]);
-	const scene = document.createScene().addChild(nodeC);
-	const channel = document.createAnimationChannel().setTargetNode(nodeA).setTargetPath('scale');
-	document.createAnimation().addChannel(channel);
+	test('trs animation', async () => {
+		const document = new Document().setLogger(logger);
+		const mesh = document.createMesh();
+		const nodeA = document.createNode('A').setMesh(mesh);
+		const nodeB = document.createNode('B').setMesh(mesh);
+		const nodeC = document.createNode('Group').addChild(nodeA).addChild(nodeB).setScale([2, 2, 2]);
+		const scene = document.createScene().addChild(nodeC);
+		const channel = document.createAnimationChannel().setTargetNode(nodeA).setTargetPath('scale');
+		document.createAnimation().addChannel(channel);
 
-	await document.transform(flatten());
+		await document.transform(flatten());
 
-	t.truthy(nodeA.getMesh(), 'A → mesh');
-	t.truthy(nodeB.getMesh(), 'B → mesh');
-	t.truthy(nodeA.getParentNode() === nodeC, 'Group → A');
-	t.truthy(nodeB.getParentNode() === null, 'Scene → B');
-	t.deepEqual(scene.listChildren(), [nodeC, nodeB], 'Scene → [Group, B]');
-});
+		ok(nodeA.getMesh(), 'A → mesh');
+		ok(nodeB.getMesh(), 'B → mesh');
+		ok(nodeA.getParentNode() === nodeC, 'Group → A');
+		ok(nodeB.getParentNode() === null, 'Scene → B');
+		deepEqual(scene.listChildren(), [nodeC, nodeB], 'Scene → [Group, B]');
+	});
 
-test('no side effects', async (t) => {
-	const document = new Document().setLogger(logger);
-	const attributeA = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([1, 2, 3]));
-	const attributeB = attributeA.clone();
-	const prim = document.createPrimitive().setAttribute('POSITION', attributeA).setAttribute('NORMAL', attributeB);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const nodeA = document.createNode('A').setMesh(mesh);
-	const nodeB = document.createNode('B');
-	document.createScene().addChild(nodeA).addChild(nodeB);
+	test('no side effects', async () => {
+		const document = new Document().setLogger(logger);
+		const attributeA = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float32Array([1, 2, 3]));
+		const attributeB = attributeA.clone();
+		const prim = document.createPrimitive().setAttribute('POSITION', attributeA).setAttribute('NORMAL', attributeB);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const nodeA = document.createNode('A').setMesh(mesh);
+		const nodeB = document.createNode('B');
+		document.createScene().addChild(nodeA).addChild(nodeB);
 
-	await document.transform(flatten({ cleanup: false }));
+		await document.transform(flatten({ cleanup: false }));
 
-	t.is(document.getRoot().listNodes().length, 2, 'skips prune');
-	t.is(document.getRoot().listAccessors().length, 2, 'skips dedup');
+		strictEqual(document.getRoot().listNodes().length, 2, 'skips prune');
+		strictEqual(document.getRoot().listAccessors().length, 2, 'skips dedup');
+	});
 });

--- a/packages/functions/test/get-bounds.test.ts
+++ b/packages/functions/test/get-bounds.test.ts
@@ -1,73 +1,76 @@
+import { deepEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, getBounds, Primitive } from '@gltf-transform/core';
-import test from 'ava';
 
-test('unindexed', (t) => {
-	const document = new Document();
-	const position = document
-		.createAccessor()
-		.setArray(new Float32Array([0, 0, 0, 1, 1, 1]))
-		.setType(Accessor.Type.VEC3);
-	const prim = document.createPrimitive().setMode(Primitive.Mode.POINTS).setAttribute('POSITION', position);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh).setTranslation([100, 100, 100]).setScale([5, 5, 5]);
-	const scene = document.createScene().addChild(node);
+describe('getBounds', () => {
+	test('unindexed', () => {
+		const document = new Document();
+		const position = document
+			.createAccessor()
+			.setArray(new Float32Array([0, 0, 0, 1, 1, 1]))
+			.setType(Accessor.Type.VEC3);
+		const prim = document.createPrimitive().setMode(Primitive.Mode.POINTS).setAttribute('POSITION', position);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh).setTranslation([100, 100, 100]).setScale([5, 5, 5]);
+		const scene = document.createScene().addChild(node);
 
-	t.deepEqual(
-		getBounds(scene),
-		{
-			min: [100, 100, 100],
-			max: [105, 105, 105],
-		},
-		'computes world bounds',
-	);
-});
+		deepEqual(
+			getBounds(scene),
+			{
+				min: [100, 100, 100],
+				max: [105, 105, 105],
+			},
+			'computes world bounds',
+		);
+	});
 
-test('indexed', (t) => {
-	const document = new Document();
-	const position = document
-		.createAccessor()
-		.setArray(new Float32Array([10, 15, 20, 0, 0, 0, 1, 2, 3]))
-		.setType(Accessor.Type.VEC3);
-	const indices = document.createAccessor().setArray(new Uint16Array([1, 2]));
-	const prim = document
-		.createPrimitive()
-		.setMode(Primitive.Mode.POINTS)
-		.setIndices(indices)
-		.setAttribute('POSITION', position);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	const scene = document.createScene().addChild(node);
+	test('indexed', () => {
+		const document = new Document();
+		const position = document
+			.createAccessor()
+			.setArray(new Float32Array([10, 15, 20, 0, 0, 0, 1, 2, 3]))
+			.setType(Accessor.Type.VEC3);
+		const indices = document.createAccessor().setArray(new Uint16Array([1, 2]));
+		const prim = document
+			.createPrimitive()
+			.setMode(Primitive.Mode.POINTS)
+			.setIndices(indices)
+			.setAttribute('POSITION', position);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		const scene = document.createScene().addChild(node);
 
-	t.deepEqual(
-		getBounds(scene),
-		{
-			min: [0, 0, 0],
-			max: [1, 2, 3],
-		},
-		'computes world bounds',
-	);
-});
+		deepEqual(
+			getBounds(scene),
+			{
+				min: [0, 0, 0],
+				max: [1, 2, 3],
+			},
+			'computes world bounds',
+		);
+	});
 
-test('missing POSITION attribute', (t) => {
-	const document = new Document();
-	const position = document
-		.createAccessor()
-		.setArray(new Float32Array([0, 0, 0, 1, 1, 1]))
-		.setType(Accessor.Type.VEC3);
-	const primA = document.createPrimitive().setMode(Primitive.Mode.POINTS).setAttribute('POSITION', position);
-	const primB = document.createPrimitive().setMode(Primitive.Mode.POINTS).setAttribute('COLOR_0', position);
-	const meshA = document.createMesh().addPrimitive(primA);
-	const meshB = document.createMesh().addPrimitive(primB);
-	const nodeA = document.createNode().setMesh(meshA).setTranslation([100, 100, 100]).setScale([5, 5, 5]);
-	const nodeB = document.createNode().setMesh(meshB).setTranslation([-100, -100, -100]).setScale([5, 5, 5]);
-	const scene = document.createScene().addChild(nodeA).addChild(nodeB);
+	test('missing POSITION attribute', () => {
+		const document = new Document();
+		const position = document
+			.createAccessor()
+			.setArray(new Float32Array([0, 0, 0, 1, 1, 1]))
+			.setType(Accessor.Type.VEC3);
+		const primA = document.createPrimitive().setMode(Primitive.Mode.POINTS).setAttribute('POSITION', position);
+		const primB = document.createPrimitive().setMode(Primitive.Mode.POINTS).setAttribute('COLOR_0', position);
+		const meshA = document.createMesh().addPrimitive(primA);
+		const meshB = document.createMesh().addPrimitive(primB);
+		const nodeA = document.createNode().setMesh(meshA).setTranslation([100, 100, 100]).setScale([5, 5, 5]);
+		const nodeB = document.createNode().setMesh(meshB).setTranslation([-100, -100, -100]).setScale([5, 5, 5]);
+		const scene = document.createScene().addChild(nodeA).addChild(nodeB);
 
-	t.deepEqual(
-		getBounds(scene),
-		{
-			min: [100, 100, 100],
-			max: [105, 105, 105],
-		},
-		'omit mesh without position attribute',
-	);
+		deepEqual(
+			getBounds(scene),
+			{
+				min: [100, 100, 100],
+				max: [105, 105, 105],
+			},
+			'omit mesh without position attribute',
+		);
+	});
 });

--- a/packages/functions/test/get-bounds.test.ts
+++ b/packages/functions/test/get-bounds.test.ts
@@ -2,7 +2,7 @@ import { deepEqual } from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { Accessor, Document, getBounds, Primitive } from '@gltf-transform/core';
 
-describe('getBounds', () => {
+describe('functions::getBounds', () => {
 	test('unindexed', () => {
 		const document = new Document();
 		const position = document

--- a/packages/functions/test/get-vertex-count.test.ts
+++ b/packages/functions/test/get-vertex-count.test.ts
@@ -1,3 +1,5 @@
+import { strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type Scene } from '@gltf-transform/core';
 import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import {
@@ -8,61 +10,69 @@ import {
 	VertexCountMethod,
 } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const { RENDER, RENDER_CACHED, UPLOAD, UPLOAD_NAIVE, UNUSED } = VertexCountMethod;
+describe('getVertexCount', () => {
+	test('method = RENDER', async (_t) => {
+		const document = new Document().setLogger(logger);
+		strictEqual(getSceneVertexCount(createSceneBasic(document), RENDER), 32 * 4, 'basic');
+		strictEqual(getSceneVertexCount(createSceneIndexed(document), RENDER), 32 + 9, 'indexed');
+		strictEqual(getSceneVertexCount(createSceneInstanced(document), RENDER), 32 * 5, 'instanced');
+		strictEqual(getSceneVertexCount(createSceneMixedAttributes(document), RENDER), 32 * 2, 'mixed attributes');
+		strictEqual(getSceneVertexCount(createSceneUnused(document), RENDER), 15, 'unused');
+	});
 
-test('method = RENDER', async (t) => {
-	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), RENDER), 32 * 4, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), RENDER), 32 + 9, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), RENDER), 32 * 5, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), RENDER), 32 * 2, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), RENDER), 15, 'unused');
-});
+	test('method = RENDER_CACHED', async (_t) => {
+		const document = new Document().setLogger(logger);
+		strictEqual(getSceneVertexCount(createSceneBasic(document), RENDER_CACHED), 32 * 4, 'basic');
+		strictEqual(getSceneVertexCount(createSceneIndexed(document), RENDER_CACHED), 32 + 5, 'indexed');
+		strictEqual(getSceneVertexCount(createSceneInstanced(document), RENDER_CACHED), 32 * 5, 'instanced');
+		strictEqual(
+			getSceneVertexCount(createSceneMixedAttributes(document), RENDER_CACHED),
+			32 * 2,
+			'mixed attributes',
+		);
+		strictEqual(getSceneVertexCount(createSceneUnused(document), RENDER_CACHED), 11, 'unused');
+	});
 
-test('method = RENDER_CACHED', async (t) => {
-	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), RENDER_CACHED), 32 * 4, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), RENDER_CACHED), 32 + 5, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), RENDER_CACHED), 32 * 5, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), RENDER_CACHED), 32 * 2, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), RENDER_CACHED), 11, 'unused');
-});
+	test('method = UPLOAD_NAIVE', async (_t) => {
+		const document = new Document().setLogger(logger);
+		strictEqual(getSceneVertexCount(createSceneBasic(document), UPLOAD_NAIVE), 32 * 4, 'basic');
+		strictEqual(getSceneVertexCount(createSceneIndexed(document), UPLOAD_NAIVE), 32 * 2, 'indexed');
+		strictEqual(getSceneVertexCount(createSceneInstanced(document), UPLOAD_NAIVE), 32, 'instanced');
+		strictEqual(
+			getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD_NAIVE),
+			32 * 2,
+			'mixed attributes',
+		);
+		strictEqual(getSceneVertexCount(createSceneUnused(document), UPLOAD_NAIVE), 32 * 2, 'unused');
+	});
 
-test('method = UPLOAD_NAIVE', async (t) => {
-	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), UPLOAD_NAIVE), 32 * 4, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), UPLOAD_NAIVE), 32 * 2, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), UPLOAD_NAIVE), 32, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD_NAIVE), 32 * 2, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), UPLOAD_NAIVE), 32 * 2, 'unused');
-});
+	test('method = UPLOAD', async (_t) => {
+		const document = new Document().setLogger(logger);
+		strictEqual(getSceneVertexCount(createSceneBasic(document), UPLOAD), 32 * 4, 'basic');
+		strictEqual(getSceneVertexCount(createSceneIndexed(document), UPLOAD), 32, 'indexed');
+		strictEqual(getSceneVertexCount(createSceneInstanced(document), UPLOAD), 32, 'instanced');
+		strictEqual(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD), 32, 'mixed attributes');
+		strictEqual(getSceneVertexCount(createSceneUnused(document), UPLOAD), 32, 'unused');
+	});
 
-test('method = UPLOAD', async (t) => {
-	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), UPLOAD), 32 * 4, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), UPLOAD), 32, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), UPLOAD), 32, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UPLOAD), 32, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), UPLOAD), 32, 'unused');
-});
+	test('method = UNUSED', async (_t) => {
+		const document = new Document().setLogger(logger);
+		strictEqual(getSceneVertexCount(createSceneBasic(document), UNUSED), 0, 'basic');
+		strictEqual(getSceneVertexCount(createSceneIndexed(document), UNUSED), 0, 'indexed');
+		strictEqual(getSceneVertexCount(createSceneInstanced(document), UNUSED), 0, 'instanced');
+		strictEqual(getSceneVertexCount(createSceneMixedAttributes(document), UNUSED), 0, 'mixed attributes');
+		strictEqual(getSceneVertexCount(createSceneUnused(document), UNUSED), 24, 'unused');
+	});
 
-test('method = UNUSED', async (t) => {
-	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(createSceneBasic(document), UNUSED), 0, 'basic');
-	t.is(getSceneVertexCount(createSceneIndexed(document), UNUSED), 0, 'indexed');
-	t.is(getSceneVertexCount(createSceneInstanced(document), UNUSED), 0, 'instanced');
-	t.is(getSceneVertexCount(createSceneMixedAttributes(document), UNUSED), 0, 'mixed attributes');
-	t.is(getSceneVertexCount(createSceneUnused(document), UNUSED), 24, 'unused');
-});
-
-test('empty properties', async (t) => {
-	const document = new Document().setLogger(logger);
-	t.is(getSceneVertexCount(document.createScene(), RENDER), 0, 'scene');
-	t.is(getNodeVertexCount(document.createNode(), RENDER), 0, 'node');
-	t.is(getMeshVertexCount(document.createMesh(), RENDER), 0, 'mesh');
-	t.is(getPrimitiveVertexCount(document.createPrimitive(), RENDER), 0, 'prim');
+	test('empty properties', async (_t) => {
+		const document = new Document().setLogger(logger);
+		strictEqual(getSceneVertexCount(document.createScene(), RENDER), 0, 'scene');
+		strictEqual(getNodeVertexCount(document.createNode(), RENDER), 0, 'node');
+		strictEqual(getMeshVertexCount(document.createMesh(), RENDER), 0, 'mesh');
+		strictEqual(getPrimitiveVertexCount(document.createPrimitive(), RENDER), 0, 'prim');
+	});
 });
 
 /**

--- a/packages/functions/test/get-vertex-count.test.ts
+++ b/packages/functions/test/get-vertex-count.test.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from '@gltf-transform/test-utils';
 
 const { RENDER, RENDER_CACHED, UPLOAD, UPLOAD_NAIVE, UNUSED } = VertexCountMethod;
+
 describe('getVertexCount', () => {
 	test('method = RENDER', async (_t) => {
 		const document = new Document().setLogger(logger);

--- a/packages/functions/test/get-vertex-count.test.ts
+++ b/packages/functions/test/get-vertex-count.test.ts
@@ -13,7 +13,7 @@ import { logger } from '@gltf-transform/test-utils';
 
 const { RENDER, RENDER_CACHED, UPLOAD, UPLOAD_NAIVE, UNUSED } = VertexCountMethod;
 
-describe('getVertexCount', () => {
+describe('functions::getVertexCount', () => {
 	test('method = RENDER', async (_t) => {
 		const document = new Document().setLogger(logger);
 		strictEqual(getSceneVertexCount(createSceneBasic(document), RENDER), 32 * 4, 'basic');

--- a/packages/functions/test/inspect.test.ts
+++ b/packages/functions/test/inspect.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('inspect', () => {
+describe('functions::inspect', () => {
 	test('basic', async () => {
 		const io = new NodeIO();
 		const doc = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));

--- a/packages/functions/test/inspect.test.ts
+++ b/packages/functions/test/inspect.test.ts
@@ -1,26 +1,29 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { NodeIO } from '@gltf-transform/core';
 import { inspect } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('basic', async (t) => {
-	const io = new NodeIO();
-	const doc = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));
-	doc.setLogger(logger);
+describe('inspect', () => {
+	test('basic', async () => {
+		const io = new NodeIO();
+		const doc = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));
+		doc.setLogger(logger);
 
-	doc.createAnimation('TestAnim');
-	doc.createTexture('TestTex').setImage(new Uint8Array(10)).setMimeType('image/fake');
+		doc.createAnimation('TestAnim');
+		doc.createTexture('TestTex').setImage(new Uint8Array(10)).setMimeType('image/fake');
 
-	const report = inspect(doc);
+		const report = inspect(doc);
 
-	t.truthy(report, 'report');
-	t.is(report.scenes.properties.length, 1, 'report.scenes');
-	t.is(report.meshes.properties.length, 2, 'report.meshes');
-	t.is(report.materials.properties.length, 2, 'report.materials');
-	t.is(report.animations.properties.length, 1, 'report.animations');
-	t.is(report.textures.properties.length, 1, 'report.textures');
+		ok(report, 'report');
+		strictEqual(report.scenes.properties.length, 1, 'report.scenes');
+		strictEqual(report.meshes.properties.length, 2, 'report.meshes');
+		strictEqual(report.materials.properties.length, 2, 'report.materials');
+		strictEqual(report.animations.properties.length, 1, 'report.animations');
+		strictEqual(report.textures.properties.length, 1, 'report.textures');
+	});
 });

--- a/packages/functions/test/instance.test.ts
+++ b/packages/functions/test/instance.test.ts
@@ -5,7 +5,7 @@ import { EXTMeshGPUInstancing, type InstancedMesh } from '@gltf-transform/extens
 import { instance } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
 
-describe('instance', () => {
+describe('functions::instance', () => {
 	test('translation', async () => {
 		const doc = new Document().setLogger(logger);
 		const root = doc.getRoot();

--- a/packages/functions/test/instance.test.ts
+++ b/packages/functions/test/instance.test.ts
@@ -1,175 +1,178 @@
+import { deepEqual, notStrictEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { EXTMeshGPUInstancing, type InstancedMesh } from '@gltf-transform/extensions';
 import { instance } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('translation', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const buffer = doc.createBuffer();
-	const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
-	const mesh = doc.createMesh().addPrimitive(prim);
-	const node1 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 0]);
-	const node2 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 1]);
-	const node3 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 2]);
-	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
+describe('instance', () => {
+	test('translation', async () => {
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const buffer = doc.createBuffer();
+		const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
+		const mesh = doc.createMesh().addPrimitive(prim);
+		const node1 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 0]);
+		const node2 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 1]);
+		const node3 = doc.createNode().setMesh(mesh).setTranslation([0, 0, 2]);
+		doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance({ min: 2 }));
+		await doc.transform(instance({ min: 2 }));
 
-	t.is(root.listNodes().length, 1, 'creates batch node');
-	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
-	t.truthy(node1.isDisposed(), 'disposed node (1/3)');
-	t.truthy(node2.isDisposed(), 'disposed node (2/3)');
-	t.truthy(node3.isDisposed(), 'disposed node (3/3)');
+		strictEqual(root.listNodes().length, 1, 'creates batch node');
+		strictEqual(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
+		ok(node1.isDisposed(), 'disposed node (1/3)');
+		ok(node2.isDisposed(), 'disposed node (2/3)');
+		ok(node3.isDisposed(), 'disposed node (3/3)');
 
-	const batchNode = root.listNodes()[0];
-	const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		const batchNode = root.listNodes()[0];
+		const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 
-	t.truthy(batch, 'creates batch');
-	t.deepEqual(
-		batch.getAttribute('TRANSLATION').getArray(),
-		new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, 2]),
-		'sets batch translation',
-	);
-	t.is(batch.getAttribute('TRANSLATION').getBuffer(), buffer, 'sets batch buffer');
-	t.falsy(batch.getAttribute('ROTATION'), 'skips batch rotation');
-	t.falsy(batch.getAttribute('SCALE'), 'skips batch scale');
-});
+		ok(batch, 'creates batch');
+		deepEqual(
+			batch.getAttribute('TRANSLATION').getArray(),
+			new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, 2]),
+			'sets batch translation',
+		);
+		strictEqual(batch.getAttribute('TRANSLATION').getBuffer(), buffer, 'sets batch buffer');
+		strictEqual(batch.getAttribute('ROTATION'), null, 'skips batch rotation');
+		strictEqual(batch.getAttribute('SCALE'), null, 'skips batch scale');
+	});
 
-test('rotation', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const buffer = doc.createBuffer();
-	const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
-	const mesh = doc.createMesh().addPrimitive(prim);
-	const x = Math.sqrt(0.5);
-	const node1 = doc.createNode().setMesh(mesh).setRotation([0, 0, 0, 1]);
-	const node2 = doc.createNode().setMesh(mesh).setRotation([x, 0, 0, x]);
-	const node3 = doc.createNode().setMesh(mesh).setRotation([0, x, 0, x]);
-	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
+	test('rotation', async () => {
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const buffer = doc.createBuffer();
+		const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
+		const mesh = doc.createMesh().addPrimitive(prim);
+		const x = Math.sqrt(0.5);
+		const node1 = doc.createNode().setMesh(mesh).setRotation([0, 0, 0, 1]);
+		const node2 = doc.createNode().setMesh(mesh).setRotation([x, 0, 0, x]);
+		const node3 = doc.createNode().setMesh(mesh).setRotation([0, x, 0, x]);
+		doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance({ min: 2 }));
+		await doc.transform(instance({ min: 2 }));
 
-	t.is(root.listNodes().length, 1, 'creates batch node');
-	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
-	t.truthy(node1.isDisposed(), 'disposed node (1/3)');
-	t.truthy(node2.isDisposed(), 'disposed node (2/3)');
-	t.truthy(node3.isDisposed(), 'disposed node (3/3)');
+		strictEqual(root.listNodes().length, 1, 'creates batch node');
+		strictEqual(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
+		ok(node1.isDisposed(), 'disposed node (1/3)');
+		ok(node2.isDisposed(), 'disposed node (2/3)');
+		ok(node3.isDisposed(), 'disposed node (3/3)');
 
-	const batchNode = root.listNodes()[0];
-	const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		const batchNode = root.listNodes()[0];
+		const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 
-	t.truthy(batch, 'creates batch');
-	t.deepEqual(
-		batch.getAttribute('ROTATION').getArray(),
-		new Float32Array([0, 0, 0, 1, x, 0, 0, x, 0, x, 0, x]),
-		'sets batch rotation',
-	);
-	t.is(batch.getAttribute('ROTATION').getBuffer(), buffer, 'sets batch buffer');
-	t.falsy(batch.getAttribute('TRANSLATION'), 'skips batch translation');
-	t.falsy(batch.getAttribute('SCALE'), 'skips batch scale');
-});
+		ok(batch, 'creates batch');
+		deepEqual(
+			batch.getAttribute('ROTATION').getArray(),
+			new Float32Array([0, 0, 0, 1, x, 0, 0, x, 0, x, 0, x]),
+			'sets batch rotation',
+		);
+		strictEqual(batch.getAttribute('ROTATION').getBuffer(), buffer, 'sets batch buffer');
+		strictEqual(batch.getAttribute('TRANSLATION'), null, 'skips batch translation');
+		strictEqual(batch.getAttribute('SCALE'), null, 'skips batch scale');
+	});
 
-test('scale', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const buffer = doc.createBuffer();
-	const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
-	const mesh = doc.createMesh().addPrimitive(prim);
-	const node1 = doc.createNode().setMesh(mesh).setScale([1, 1, 1]);
-	const node2 = doc.createNode().setMesh(mesh).setScale([2, 2, 2]);
-	const node3 = doc.createNode().setMesh(mesh).setScale([1, 1, 5]);
-	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
+	test('scale', async () => {
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const buffer = doc.createBuffer();
+		const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
+		const mesh = doc.createMesh().addPrimitive(prim);
+		const node1 = doc.createNode().setMesh(mesh).setScale([1, 1, 1]);
+		const node2 = doc.createNode().setMesh(mesh).setScale([2, 2, 2]);
+		const node3 = doc.createNode().setMesh(mesh).setScale([1, 1, 5]);
+		doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance({ min: 2 }));
+		await doc.transform(instance({ min: 2 }));
 
-	t.is(root.listNodes().length, 1, 'creates batch node');
-	t.is(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
-	t.truthy(node1.isDisposed(), 'disposed node (1/3)');
-	t.truthy(node2.isDisposed(), 'disposed node (2/3)');
-	t.truthy(node3.isDisposed(), 'disposed node (3/3)');
+		strictEqual(root.listNodes().length, 1, 'creates batch node');
+		strictEqual(root.listScenes()[0].listChildren().length, 1, 'attaches batch node');
+		ok(node1.isDisposed(), 'disposed node (1/3)');
+		ok(node2.isDisposed(), 'disposed node (2/3)');
+		ok(node3.isDisposed(), 'disposed node (3/3)');
 
-	const batchNode = root.listNodes()[0];
-	const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		const batchNode = root.listNodes()[0];
+		const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 
-	t.truthy(batch, 'creates batch');
-	t.deepEqual(
-		batch.getAttribute('SCALE').getArray(),
-		new Float32Array([1, 1, 1, 2, 2, 2, 1, 1, 5]),
-		'sets batch scale',
-	);
-	t.is(batch.getAttribute('SCALE').getBuffer(), buffer, 'sets batch buffer');
-	t.falsy(batch.getAttribute('TRANSLATION'), 'skips batch translation');
-	t.falsy(batch.getAttribute('ROTATION'), 'skips batch rotation');
-});
+		ok(batch, 'creates batch');
+		deepEqual(
+			batch.getAttribute('SCALE').getArray(),
+			new Float32Array([1, 1, 1, 2, 2, 2, 1, 1, 5]),
+			'sets batch scale',
+		);
+		strictEqual(batch.getAttribute('SCALE').getBuffer(), buffer, 'sets batch buffer');
+		strictEqual(batch.getAttribute('TRANSLATION'), null, 'skips batch translation');
+		strictEqual(batch.getAttribute('ROTATION'), null, 'skips batch rotation');
+	});
 
-test('skip distinct meshes', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const buffer = doc.createBuffer();
-	const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
-	const mesh = doc.createMesh().addPrimitive(prim);
-	const node1 = doc.createNode().setMesh(mesh).setScale([1, 1, 1]);
-	const node2 = doc.createNode().setMesh(mesh.clone() /* 🚩 */).setScale([2, 2, 2]);
-	const node3 = doc.createNode().setMesh(mesh.clone() /* 🚩 */).setScale([1, 1, 5]);
-	doc.createScene().addChild(node1).addChild(node2).addChild(node3);
+	test('skip distinct meshes', async () => {
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const buffer = doc.createBuffer();
+		const prim = doc.createPrimitive().setAttribute('POSITION', doc.createAccessor().setBuffer(buffer));
+		const mesh = doc.createMesh().addPrimitive(prim);
+		const node1 = doc.createNode().setMesh(mesh).setScale([1, 1, 1]);
+		const node2 = doc.createNode().setMesh(mesh.clone() /* 🚩 */).setScale([2, 2, 2]);
+		const node3 = doc.createNode().setMesh(mesh.clone() /* 🚩 */).setScale([1, 1, 5]);
+		doc.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await doc.transform(instance());
+		await doc.transform(instance());
 
-	t.is(root.listNodes().length, 3, 'keeps original nodes');
-	t.falsy(node1.isDisposed(), 'node (1/3)');
-	t.falsy(node2.isDisposed(), 'node (2/3)');
-	t.falsy(node3.isDisposed(), 'node (3/3)');
+		strictEqual(root.listNodes().length, 3, 'keeps original nodes');
+		strictEqual(node1.isDisposed(), false, 'node (1/3)');
+		strictEqual(node2.isDisposed(), false, 'node (2/3)');
+		strictEqual(node3.isDisposed(), false, 'node (3/3)');
 
-	const batchNode = root.listNodes()[0];
-	const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
+		const batchNode = root.listNodes()[0];
+		const batch = batchNode.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing');
 
-	t.falsy(batch, 'does not create batch');
-});
+		strictEqual(batch, null, 'does not create batch');
+	});
 
-test('skip existing instances', async (t) => {
-	const document = new Document().setLogger(logger);
-	const root = document.getRoot();
+	test('skip existing instances', async () => {
+		const document = new Document().setLogger(logger);
+		const root = document.getRoot();
 
-	const batchExtension = document.createExtension(EXTMeshGPUInstancing);
-	const batch = batchExtension.createInstancedMesh();
+		const batchExtension = document.createExtension(EXTMeshGPUInstancing);
+		const batch = batchExtension.createInstancedMesh();
 
-	const prim = createTorusKnotPrimitive(document, { radialSegments: 4, tubularSegments: 6 });
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node1 = document.createNode().setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch);
-	const node2 = document.createNode().setMesh(mesh).setTranslation([0, 0, 0]);
-	const node3 = document.createNode().setMesh(mesh).setTranslation([10, 0, 0]);
+		const prim = createTorusKnotPrimitive(document, { radialSegments: 4, tubularSegments: 6 });
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node1 = document.createNode().setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch);
+		const node2 = document.createNode().setMesh(mesh).setTranslation([0, 0, 0]);
+		const node3 = document.createNode().setMesh(mesh).setTranslation([10, 0, 0]);
 
-	document.createScene().addChild(node1).addChild(node2).addChild(node3);
+		document.createScene().addChild(node1).addChild(node2).addChild(node3);
 
-	await document.transform(instance({ min: 2 }));
+		await document.transform(instance({ min: 2 }));
 
-	t.is(root.listNodes().length, 2, 'keeps 2/3 nodes');
+		strictEqual(root.listNodes().length, 2, 'keeps 2/3 nodes');
 
-	const [batch1, batch2] = root
-		.listNodes()
-		.map((node) => node.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing'));
+		const [batch1, batch2] = root
+			.listNodes()
+			.map((node) => node.getExtension<InstancedMesh>('EXT_mesh_gpu_instancing'));
 
-	t.is(batch, batch1, 'keeps batch 1');
-	t.truthy(batch2, 'creates batch 2');
-	t.not(batch1, batch2, 'batches are not merged');
-	t.is(batch2.getAttribute('TRANSLATION').getCount(), 2, 'batch 2 has 2 instances');
-});
+		strictEqual(batch, batch1, 'keeps batch 1');
+		ok(batch2, 'creates batch 2');
+		notStrictEqual(batch1, batch2, 'batches are not merged');
+		strictEqual(batch2.getAttribute('TRANSLATION').getCount(), 2, 'batch 2 has 2 instances');
+	});
 
-test('idempotence', async (t) => {
-	const doc = new Document().setLogger(logger);
+	test('idempotence', async () => {
+		const doc = new Document().setLogger(logger);
 
-	await doc.transform(instance());
+		await doc.transform(instance());
 
-	t.is(doc.getRoot().listExtensionsUsed().length, 0, 'does not add EXT_mesh_gpu_instancing');
+		strictEqual(doc.getRoot().listExtensionsUsed().length, 0, 'does not add EXT_mesh_gpu_instancing');
 
-	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
-	const batch = batchExtension.createInstancedMesh();
-	const node = doc.createNode();
-	node.setExtension('EXT_mesh_gpu_instancing', batch);
+		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
+		const batch = batchExtension.createInstancedMesh();
+		const node = doc.createNode();
+		node.setExtension('EXT_mesh_gpu_instancing', batch);
 
-	await doc.transform(instance());
+		await doc.transform(instance());
 
-	t.is(doc.getRoot().listExtensionsUsed().length, 1, 'does not remove EXT_mesh_gpu_instancing');
+		strictEqual(doc.getRoot().listExtensionsUsed().length, 1, 'does not remove EXT_mesh_gpu_instancing');
+	});
 });

--- a/packages/functions/test/join-primitives.test.ts
+++ b/packages/functions/test/join-primitives.test.ts
@@ -1,31 +1,33 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { type Accessor, Document, Primitive } from '@gltf-transform/core';
 import { KHRMeshPrimitiveRestart } from '@gltf-transform/extensions';
 import { joinPrimitives } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
 const { LINE_STRIP } = Primitive.Mode;
 
-test('unindexed', async (t) => {
-	const document = new Document().setLogger(logger);
-	const [primA, positionA, colorA] = createPrimA(document);
-	const [primB] = createPrimB(document);
+describe('joinPrimitives', () => {
+	test('unindexed', async () => {
+		const document = new Document().setLogger(logger);
+		const [primA, positionA, colorA] = createPrimA(document);
+		const [primB] = createPrimB(document);
 
-	const primAB = joinPrimitives([primA, primB]);
+		const primAB = joinPrimitives([primA, primB]);
 
-	t.false(primA.isDisposed(), 'primA alive');
-	t.false(primB.isDisposed(), 'primB alive');
+		strictEqual(primA.isDisposed(), false, 'primA alive');
+		strictEqual(primB.isDisposed(), false, 'primB alive');
 
-	const positionAB = primAB.getAttribute('POSITION');
-	const colorAB = primAB.getAttribute('COLOR_0');
+		const positionAB = primAB.getAttribute('POSITION');
+		const colorAB = primAB.getAttribute('COLOR_0');
 
-	t.is(positionAB.getType(), positionA.getType(), 'position.type');
-	t.is(colorAB.getType(), colorA.getType(), 'color.type');
-	t.is(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
-	t.is(colorAB.getComponentType(), colorA.getComponentType(), 'color.componentType');
+		strictEqual(positionAB.getType(), positionA.getType(), 'position.type');
+		strictEqual(colorAB.getType(), colorA.getType(), 'color.type');
+		strictEqual(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
+		strictEqual(colorAB.getComponentType(), colorA.getComponentType(), 'color.componentType');
 
-	// biome-ignore format: Readability.
-	t.deepEqual(Array.from(positionAB.getArray()), [
+		// biome-ignore format: Readability.
+		deepEqual(Array.from(positionAB.getArray()), [
 		// primA
 		0, 0, 0,
 		0, 0, 1,
@@ -38,8 +40,8 @@ test('unindexed', async (t) => {
 		10, 10, 12,
 		10, 12, 10,
 	], 'position data');
-	// biome-ignore format: Readability.
-	t.deepEqual(Array.from(colorAB.getArray()), [
+		// biome-ignore format: Readability.
+		deepEqual(Array.from(colorAB.getArray()), [
 		// primA
 		255, 0, 0, 255,
 		0, 255, 0, 255,
@@ -53,35 +55,35 @@ test('unindexed', async (t) => {
 		0, 0, 0, 0,
 	], 'position data');
 
-	t.is(primAB.getIndices(), null, 'indices data');
-});
+		strictEqual(primAB.getIndices(), null, 'indices data');
+	});
 
-test('indexed', async (t) => {
-	const document = new Document().setLogger(logger);
-	const [primA, positionA, colorA] = createPrimA(document);
-	const [primB] = createPrimB(document);
+	test('indexed', async () => {
+		const document = new Document().setLogger(logger);
+		const [primA, positionA, colorA] = createPrimA(document);
+		const [primB] = createPrimB(document);
 
-	const indicesA = document.createAccessor().setArray(new Uint16Array([0, 2, 4]));
-	const indicesB = document.createAccessor().setArray(new Uint16Array([0, 1, 2]));
+		const indicesA = document.createAccessor().setArray(new Uint16Array([0, 2, 4]));
+		const indicesB = document.createAccessor().setArray(new Uint16Array([0, 1, 2]));
 
-	primA.setIndices(indicesA);
-	primB.setIndices(indicesB);
+		primA.setIndices(indicesA);
+		primB.setIndices(indicesB);
 
-	const primAB = joinPrimitives([primA, primB]);
+		const primAB = joinPrimitives([primA, primB]);
 
-	t.false(primA.isDisposed(), 'primA alive');
-	t.false(primB.isDisposed(), 'primB alive');
+		strictEqual(primA.isDisposed(), false, 'primA alive');
+		strictEqual(primB.isDisposed(), false, 'primB alive');
 
-	const positionAB = primAB.getAttribute('POSITION');
-	const colorAB = primAB.getAttribute('COLOR_0');
+		const positionAB = primAB.getAttribute('POSITION');
+		const colorAB = primAB.getAttribute('COLOR_0');
 
-	t.is(positionAB.getType(), positionA.getType(), 'position.type');
-	t.is(colorAB.getType(), colorA.getType(), 'color.type');
-	t.is(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
-	t.is(colorAB.getComponentType(), colorA.getComponentType(), 'color.componentType');
+		strictEqual(positionAB.getType(), positionA.getType(), 'position.type');
+		strictEqual(colorAB.getType(), colorA.getType(), 'color.type');
+		strictEqual(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
+		strictEqual(colorAB.getComponentType(), colorA.getComponentType(), 'color.componentType');
 
-	// biome-ignore format: Readability.
-	t.deepEqual(Array.from(positionAB.getArray()), [
+		// biome-ignore format: Readability.
+		deepEqual(Array.from(positionAB.getArray()), [
 		// primA
 		0, 0, 0,
 		// 0, 0, 1, ❌
@@ -94,8 +96,8 @@ test('indexed', async (t) => {
 		10, 10, 12,
 		10, 12, 10,
 	], 'position data');
-	// biome-ignore format: Readability.
-	t.deepEqual(Array.from(colorAB.getArray()), [
+		// biome-ignore format: Readability.
+		deepEqual(Array.from(colorAB.getArray()), [
 		// primA
 		255, 0, 0, 255,
 		// 0, 255, 0, 255, ❌
@@ -109,29 +111,31 @@ test('indexed', async (t) => {
 		0, 0, 0, 0,
 	], 'position data');
 
-	t.deepEqual(Array.from(primAB.getIndices().getArray()), [0, 1, 2, 3, 4, 5], 'indices data');
-});
+		deepEqual(Array.from(primAB.getIndices().getArray()), [0, 1, 2, 3, 4, 5], 'indices data');
+	});
 
-test('indexed - primitive restart', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createExtension(KHRMeshPrimitiveRestart).setRequired(true);
+	test('indexed - primitive restart', async () => {
+		const document = new Document().setLogger(logger);
+		document.createExtension(KHRMeshPrimitiveRestart).setRequired(true);
 
-	const [primA, positionA] = createPrimA(document);
-	const [primB] = createPrimB(document);
+		const [primA, positionA] = createPrimA(document);
+		const [primB] = createPrimB(document);
 
-	const RESTART_U16 = 2 ** 16 - 1;
+		const RESTART_U16 = 2 ** 16 - 1;
 
-	const indicesA = document.createAccessor().setArray(new Uint16Array([0, 1, RESTART_U16, 2, 3, RESTART_U16, 4, 5]));
-	const indicesB = document.createAccessor().setArray(new Uint16Array([0, 1, RESTART_U16, 0, 2, RESTART_U16]));
+		const indicesA = document
+			.createAccessor()
+			.setArray(new Uint16Array([0, 1, RESTART_U16, 2, 3, RESTART_U16, 4, 5]));
+		const indicesB = document.createAccessor().setArray(new Uint16Array([0, 1, RESTART_U16, 0, 2, RESTART_U16]));
 
-	primA.setMode(LINE_STRIP).setIndices(indicesA);
-	primB.setMode(LINE_STRIP).setIndices(indicesB);
+		primA.setMode(LINE_STRIP).setIndices(indicesA);
+		primB.setMode(LINE_STRIP).setIndices(indicesB);
 
-	const primAB = joinPrimitives([primA, primB]);
-	const indicesAB = Array.from(primAB.getIndices().getArray());
+		const primAB = joinPrimitives([primA, primB]);
+		const indicesAB = Array.from(primAB.getIndices().getArray());
 
-	// biome-ignore format: Readability.
-	t.deepEqual(indicesAB, [
+		// biome-ignore format: Readability.
+		deepEqual(indicesAB, [
 		0, 1, RESTART_U16,
 		2, 3, RESTART_U16,
 		4, 5, RESTART_U16,
@@ -139,13 +143,13 @@ test('indexed - primitive restart', async (t) => {
 		6, 8, RESTART_U16
 	], 'indices data');
 
-	const positionAB = primAB.getAttribute('POSITION');
+		const positionAB = primAB.getAttribute('POSITION');
 
-	t.is(positionAB.getType(), positionA.getType(), 'position.type');
-	t.is(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
+		strictEqual(positionAB.getType(), positionA.getType(), 'position.type');
+		strictEqual(positionAB.getComponentType(), positionA.getComponentType(), 'position.componentType');
 
-	// biome-ignore format: Readability.
-	t.deepEqual(Array.from(positionAB.getArray()), [
+		// biome-ignore format: Readability.
+		deepEqual(Array.from(positionAB.getArray()), [
 		// primA
 		0, 0, 0,
 		0, 0, 1,
@@ -158,6 +162,7 @@ test('indexed - primitive restart', async (t) => {
 		10, 10, 12,
 		10, 12, 10,
 	], 'position data');
+	});
 });
 
 /******************************************************************************

--- a/packages/functions/test/join-primitives.test.ts
+++ b/packages/functions/test/join-primitives.test.ts
@@ -7,7 +7,7 @@ import { logger } from '@gltf-transform/test-utils';
 
 const { LINE_STRIP } = Primitive.Mode;
 
-describe('joinPrimitives', () => {
+describe('functions::joinPrimitives', () => {
 	test('unindexed', async () => {
 		const document = new Document().setLogger(logger);
 		const [primA, positionA, colorA] = createPrimA(document);

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -19,7 +19,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const { LINE_STRIP, LINE_LOOP, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-describe('join', () => {
+describe('functions::join', () => {
 	test('basic', async () => {
 		const io = await createPlatformIO();
 		const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));

--- a/packages/functions/test/join.test.ts
+++ b/packages/functions/test/join.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, getBounds, Primitive } from '@gltf-transform/core';
 import { join, quantize, transformPrimitive } from '@gltf-transform/functions';
 import {
@@ -10,7 +12,6 @@ import {
 	mat4,
 	roundBbox,
 } from '@gltf-transform/test-utils';
-import test from 'ava';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -18,78 +19,80 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const { LINE_STRIP, LINE_LOOP, TRIANGLE_STRIP, TRIANGLE_FAN } = Primitive.Mode;
 
-test('basic', async (t) => {
-	const io = await createPlatformIO();
-	const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
-	const scene = document.getRoot().getDefaultScene();
+describe('join', () => {
+	test('basic', async () => {
+		const io = await createPlatformIO();
+		const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
+		const scene = document.getRoot().getDefaultScene();
 
-	const bboxBefore = getBounds(scene);
-	await document.transform(join());
-	const bboxAfter = getBounds(scene);
+		const bboxBefore = getBounds(scene);
+		await document.transform(join());
+		const bboxAfter = getBounds(scene);
 
-	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
-	t.deepEqual(bboxAfter, bboxBefore, 'same bbox');
-});
+		strictEqual(document.getRoot().listMeshes().length, 1, '1 mesh');
+		deepEqual(bboxAfter, bboxBefore, 'same bbox');
+	});
 
-test('quantization', async (t) => {
-	const io = await createPlatformIO();
-	const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
-	const scene = document.getRoot().getDefaultScene();
+	test('quantization', async () => {
+		const io = await createPlatformIO();
+		const document = await io.read(path.join(__dirname, './in/ShapeCollection.glb'));
+		const scene = document.getRoot().getDefaultScene();
 
-	const bboxBefore = getBounds(scene);
-	await document.transform(quantize(), join());
-	const bboxAfter = roundBbox(getBounds(scene));
+		const bboxBefore = getBounds(scene);
+		await document.transform(quantize(), join());
+		const bboxAfter = roundBbox(getBounds(scene));
 
-	t.is(document.getRoot().listMeshes().length, 1, '1 mesh');
-	t.deepEqual(bboxAfter, bboxBefore, 'same bbox');
-});
+		strictEqual(document.getRoot().listMeshes().length, 1, '1 mesh');
+		deepEqual(bboxAfter, bboxBefore, 'same bbox');
+	});
 
-test('no side effects', async (t) => {
-	const document = new Document().setLogger(logger);
-	const attributeA = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([1, 2, 3]));
-	const attributeB = attributeA.clone();
-	const prim = document.createPrimitive().setAttribute('POSITION', attributeA).setAttribute('NORMAL', attributeB);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const nodeA = document.createNode('A').setMesh(mesh);
-	const nodeB = document.createNode('B');
-	document.createScene().addChild(nodeA).addChild(nodeB);
+	test('no side effects', async () => {
+		const document = new Document().setLogger(logger);
+		const attributeA = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float32Array([1, 2, 3]));
+		const attributeB = attributeA.clone();
+		const prim = document.createPrimitive().setAttribute('POSITION', attributeA).setAttribute('NORMAL', attributeB);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const nodeA = document.createNode('A').setMesh(mesh);
+		const nodeB = document.createNode('B');
+		document.createScene().addChild(nodeA).addChild(nodeB);
 
-	await document.transform(join({ cleanup: false }));
+		await document.transform(join({ cleanup: false }));
 
-	t.true(document.getRoot().listNodes().length >= 2, 'skips prune');
-	t.true(document.getRoot().listAccessors().length >= 2, 'skips dedup');
-});
+		ok(document.getRoot().listNodes().length >= 2, 'skips prune');
+		ok(document.getRoot().listAccessors().length >= 2, 'skips dedup');
+	});
 
-test('primitive modes', async (t) => {
-	const document = new Document().setLogger(logger);
-	const primLineStrip = createLineStripPrim(document);
-	const primLineLoop = createLineLoopPrim(document);
-	const primTriangleStrip = createTriangleStripPrim(document);
-	const primTriangleFan = createTriangleFanPrim(document);
-	const mesh = document
-		.createMesh()
-		.addPrimitive(primLineStrip)
-		.addPrimitive(primLineLoop)
-		.addPrimitive(primTriangleStrip)
-		.addPrimitive(primTriangleFan);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+	test('primitive modes', async () => {
+		const document = new Document().setLogger(logger);
+		const primLineStrip = createLineStripPrim(document);
+		const primLineLoop = createLineLoopPrim(document);
+		const primTriangleStrip = createTriangleStripPrim(document);
+		const primTriangleFan = createTriangleFanPrim(document);
+		const mesh = document
+			.createMesh()
+			.addPrimitive(primLineStrip)
+			.addPrimitive(primLineLoop)
+			.addPrimitive(primTriangleStrip)
+			.addPrimitive(primTriangleFan);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	transformPrimitive(primLineStrip, mat4.fromTranslation([], [-4, 0, 0]));
-	transformPrimitive(primLineLoop, mat4.fromTranslation([], [-2, 0, 0]));
-	transformPrimitive(primTriangleStrip, mat4.fromTranslation([], [2, 0, 0]));
-	transformPrimitive(primTriangleFan, mat4.fromTranslation([], [4, 0, 0]));
+		transformPrimitive(primLineStrip, mat4.fromTranslation([], [-4, 0, 0]));
+		transformPrimitive(primLineLoop, mat4.fromTranslation([], [-2, 0, 0]));
+		transformPrimitive(primTriangleStrip, mat4.fromTranslation([], [2, 0, 0]));
+		transformPrimitive(primTriangleFan, mat4.fromTranslation([], [4, 0, 0]));
 
-	await document.transform(join());
+		await document.transform(join());
 
-	t.false(mesh.isDisposed(), 'mesh not disposed');
-	t.is(mesh.listPrimitives().length, 4, 'mesh has four (4) prims');
-	t.deepEqual(
-		mesh.listPrimitives().map((prim) => prim.getMode()),
-		[LINE_STRIP, LINE_LOOP, TRIANGLE_STRIP, TRIANGLE_FAN],
-		'line strip, line loop, triangle strip, triangle fan',
-	);
+		strictEqual(mesh.isDisposed(), false, 'mesh not disposed');
+		strictEqual(mesh.listPrimitives().length, 4, 'mesh has four (4) prims');
+		deepEqual(
+			mesh.listPrimitives().map((prim) => prim.getMode()),
+			[LINE_STRIP, LINE_LOOP, TRIANGLE_STRIP, TRIANGLE_FAN],
+			'line strip, line loop, triangle strip, triangle fan',
+		);
+	});
 });

--- a/packages/functions/test/list-node-scenes.test.ts
+++ b/packages/functions/test/list-node-scenes.test.ts
@@ -1,29 +1,32 @@
+import { deepEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { listNodeScenes } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const nodeA = document.createNode('A').setTranslation([2, 0, 0]);
-	const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA);
-	const nodeC = document.createNode('C').addChild(nodeB);
-	const sceneA = document.createScene().addChild(nodeC);
-	const sceneB = document.createScene().addChild(nodeC);
+describe('listNodeScenes', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const nodeA = document.createNode('A').setTranslation([2, 0, 0]);
+		const nodeB = document.createNode('B').setScale([4, 4, 4]).addChild(nodeA);
+		const nodeC = document.createNode('C').addChild(nodeB);
+		const sceneA = document.createScene().addChild(nodeC);
+		const sceneB = document.createScene().addChild(nodeC);
 
-	t.deepEqual(listNodeScenes(nodeA), [sceneA, sceneB], 'A → Scene');
-	t.deepEqual(listNodeScenes(nodeB), [sceneA, sceneB], 'B → Scene');
-	t.deepEqual(listNodeScenes(nodeC), [sceneA, sceneB], 'C → Scene');
+		deepEqual(listNodeScenes(nodeA), [sceneA, sceneB], 'A → Scene');
+		deepEqual(listNodeScenes(nodeB), [sceneA, sceneB], 'B → Scene');
+		deepEqual(listNodeScenes(nodeC), [sceneA, sceneB], 'C → Scene');
 
-	sceneA.removeChild(nodeC);
+		sceneA.removeChild(nodeC);
 
-	t.deepEqual(listNodeScenes(nodeA), [sceneB], 'A → null');
-	t.deepEqual(listNodeScenes(nodeB), [sceneB], 'B → null');
-	t.deepEqual(listNodeScenes(nodeC), [sceneB], 'C → null');
+		deepEqual(listNodeScenes(nodeA), [sceneB], 'A → null');
+		deepEqual(listNodeScenes(nodeB), [sceneB], 'B → null');
+		deepEqual(listNodeScenes(nodeC), [sceneB], 'C → null');
 
-	sceneB.removeChild(nodeC);
+		sceneB.removeChild(nodeC);
 
-	t.deepEqual(listNodeScenes(nodeA), [], 'A → null');
-	t.deepEqual(listNodeScenes(nodeB), [], 'B → null');
-	t.deepEqual(listNodeScenes(nodeC), [], 'C → null');
+		deepEqual(listNodeScenes(nodeA), [], 'A → null');
+		deepEqual(listNodeScenes(nodeB), [], 'B → null');
+		deepEqual(listNodeScenes(nodeC), [], 'C → null');
+	});
 });

--- a/packages/functions/test/list-node-scenes.test.ts
+++ b/packages/functions/test/list-node-scenes.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { listNodeScenes } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('listNodeScenes', () => {
+describe('functions::listNodeScenes', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const nodeA = document.createNode('A').setTranslation([2, 0, 0]);

--- a/packages/functions/test/list-texture-channels.test.ts
+++ b/packages/functions/test/list-texture-channels.test.ts
@@ -1,50 +1,53 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, TextureChannel } from '@gltf-transform/core';
 import { KHRMaterialsSheen } from '@gltf-transform/extensions';
 import { getTextureChannelMask, listTextureChannels } from '@gltf-transform/functions';
-import test from 'ava';
 
 const { R, G, B, A } = TextureChannel;
 
-test('listTextureChannels', (t) => {
-	const document = new Document();
-	const textureA = document.createTexture();
-	const textureB = document.createTexture();
-	const sheenExtension = document.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureB);
-	const material = document
-		.createMaterial()
-		.setAlphaMode('BLEND')
-		.setBaseColorTexture(textureA)
-		.setExtension('KHR_materials_sheen', sheen);
+describe('listTextureChannels', () => {
+	test('listTextureChannels', () => {
+		const document = new Document();
+		const textureA = document.createTexture();
+		const textureB = document.createTexture();
+		const sheenExtension = document.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureB);
+		const material = document
+			.createMaterial()
+			.setAlphaMode('BLEND')
+			.setBaseColorTexture(textureA)
+			.setExtension('KHR_materials_sheen', sheen);
 
-	t.deepEqual(listTextureChannels(textureA), [R, G, B, A], 'baseColorTexture RGBA');
-	t.deepEqual(listTextureChannels(textureB), [A], 'sheenColorTexture A');
+		deepEqual(listTextureChannels(textureA), [R, G, B, A], 'baseColorTexture RGBA');
+		deepEqual(listTextureChannels(textureB), [A], 'sheenColorTexture A');
 
-	material.setAlphaMode('OPAQUE');
-	t.deepEqual(listTextureChannels(textureA), [R, G, B], 'baseColorTexture RGB');
+		material.setAlphaMode('OPAQUE');
+		deepEqual(listTextureChannels(textureA), [R, G, B], 'baseColorTexture RGB');
 
-	sheen.setSheenColorTexture(textureB);
-	t.deepEqual(listTextureChannels(textureB), [R, G, B, A], 'sheenColorTexture RGBA');
-});
+		sheen.setSheenColorTexture(textureB);
+		deepEqual(listTextureChannels(textureB), [R, G, B, A], 'sheenColorTexture RGBA');
+	});
 
-test('getTextureChannelMask', (t) => {
-	const document = new Document();
-	const textureA = document.createTexture();
-	const textureB = document.createTexture();
-	const sheenExtension = document.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureB);
-	const material = document
-		.createMaterial()
-		.setAlphaMode('BLEND')
-		.setBaseColorTexture(textureA)
-		.setExtension('KHR_materials_sheen', sheen);
+	test('getTextureChannelMask', () => {
+		const document = new Document();
+		const textureA = document.createTexture();
+		const textureB = document.createTexture();
+		const sheenExtension = document.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureB);
+		const material = document
+			.createMaterial()
+			.setAlphaMode('BLEND')
+			.setBaseColorTexture(textureA)
+			.setExtension('KHR_materials_sheen', sheen);
 
-	t.is(getTextureChannelMask(textureA), R | G | B | A, 'baseColorTexture RGBA');
-	t.is(getTextureChannelMask(textureB), A, 'sheenColorTexture A');
+		strictEqual(getTextureChannelMask(textureA), R | G | B | A, 'baseColorTexture RGBA');
+		strictEqual(getTextureChannelMask(textureB), A, 'sheenColorTexture A');
 
-	material.setAlphaMode('OPAQUE');
-	t.is(getTextureChannelMask(textureA), R | G | B, 'baseColorTexture RGB');
+		material.setAlphaMode('OPAQUE');
+		strictEqual(getTextureChannelMask(textureA), R | G | B, 'baseColorTexture RGB');
 
-	sheen.setSheenColorTexture(textureB);
-	t.is(getTextureChannelMask(textureB), R | G | B | A, 'sheenColorTexture RGBA');
+		sheen.setSheenColorTexture(textureB);
+		strictEqual(getTextureChannelMask(textureB), R | G | B | A, 'sheenColorTexture RGBA');
+	});
 });

--- a/packages/functions/test/list-texture-channels.test.ts
+++ b/packages/functions/test/list-texture-channels.test.ts
@@ -6,7 +6,7 @@ import { getTextureChannelMask, listTextureChannels } from '@gltf-transform/func
 
 const { R, G, B, A } = TextureChannel;
 
-describe('listTextureChannels', () => {
+describe('functions::listTextureChannels', () => {
 	test('listTextureChannels', () => {
 		const document = new Document();
 		const textureA = document.createTexture();

--- a/packages/functions/test/list-texture-info.test.ts
+++ b/packages/functions/test/list-texture-info.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { KHRMaterialsSheen, KHRMaterialsVolume } from '@gltf-transform/extensions';
 import { listTextureInfo, listTextureInfoByMaterial } from '@gltf-transform/functions';
 
-describe('listTextureInfo', () => {
+describe('functions::listTextureInfo', () => {
 	test('listTextureInfo', () => {
 		const document = new Document();
 		const textureA = document.createTexture();

--- a/packages/functions/test/list-texture-info.test.ts
+++ b/packages/functions/test/list-texture-info.test.ts
@@ -1,55 +1,58 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { KHRMaterialsSheen, KHRMaterialsVolume } from '@gltf-transform/extensions';
 import { listTextureInfo, listTextureInfoByMaterial } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('listTextureInfo', (t) => {
-	const document = new Document();
-	const textureA = document.createTexture();
-	const textureB = document.createTexture();
+describe('listTextureInfo', () => {
+	test('listTextureInfo', () => {
+		const document = new Document();
+		const textureA = document.createTexture();
+		const textureB = document.createTexture();
 
-	const sheenExtension = document.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureA);
+		const sheenExtension = document.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension.createSheen().setSheenRoughnessTexture(textureA);
 
-	document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);
-	document.createMaterial().setOcclusionTexture(textureB).setMetallicRoughnessTexture(textureB);
+		document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);
+		document.createMaterial().setOcclusionTexture(textureB).setMetallicRoughnessTexture(textureB);
 
-	t.deepEqual(
-		listTextureInfo(textureA)
-			.map((info) => info.getName())
-			.sort(),
-		['baseColorTextureInfo', 'sheenRoughnessTextureInfo'],
-		'texture A',
-	);
-	t.deepEqual(
-		listTextureInfo(textureB)
-			.map((info) => info.getName())
-			.sort(),
-		['metallicRoughnessTextureInfo', 'occlusionTextureInfo'],
-		'texture B',
-	);
-});
+		deepEqual(
+			listTextureInfo(textureA)
+				.map((info) => info.getName())
+				.sort(),
+			['baseColorTextureInfo', 'sheenRoughnessTextureInfo'],
+			'texture A',
+		);
+		deepEqual(
+			listTextureInfo(textureB)
+				.map((info) => info.getName())
+				.sort(),
+			['metallicRoughnessTextureInfo', 'occlusionTextureInfo'],
+			'texture B',
+		);
+	});
 
-test('listTextureInfoByMaterial', (t) => {
-	const document = new Document();
-	const textureA = document.createTexture();
-	const textureB = document.createTexture();
-	const textureC = document.createTexture();
-	const volumeExtension = document.createExtension(KHRMaterialsVolume);
-	const volume = volumeExtension.createVolume().setThicknessTexture(textureC);
-	const materialA = document
-		.createMaterial()
-		.setBaseColorTexture(textureA)
-		.setNormalTexture(textureB)
-		.setExtension('KHR_materials_volume', volume);
-	const materialB = document.createMaterial().setBaseColorTexture(textureA);
+	test('listTextureInfoByMaterial', () => {
+		const document = new Document();
+		const textureA = document.createTexture();
+		const textureB = document.createTexture();
+		const textureC = document.createTexture();
+		const volumeExtension = document.createExtension(KHRMaterialsVolume);
+		const volume = volumeExtension.createVolume().setThicknessTexture(textureC);
+		const materialA = document
+			.createMaterial()
+			.setBaseColorTexture(textureA)
+			.setNormalTexture(textureB)
+			.setExtension('KHR_materials_volume', volume);
+		const materialB = document.createMaterial().setBaseColorTexture(textureA);
 
-	let textureInfo = new Set(listTextureInfoByMaterial(materialA));
-	t.is(textureInfo.size, 3, 'finds TextureInfo x 3');
-	t.true(textureInfo.has(materialA.getBaseColorTextureInfo()), 'finds material.baseColorTextureInfo');
-	t.true(textureInfo.has(materialA.getNormalTextureInfo()), 'finds material.normalTextureInfo');
-	t.true(textureInfo.has(volume.getThicknessTextureInfo()), 'finds material.volume.thicknessTextureInfo');
+		let textureInfo = new Set(listTextureInfoByMaterial(materialA));
+		strictEqual(textureInfo.size, 3, 'finds TextureInfo x 3');
+		ok(textureInfo.has(materialA.getBaseColorTextureInfo()), 'finds material.baseColorTextureInfo');
+		ok(textureInfo.has(materialA.getNormalTextureInfo()), 'finds material.normalTextureInfo');
+		ok(textureInfo.has(volume.getThicknessTextureInfo()), 'finds material.volume.thicknessTextureInfo');
 
-	textureInfo = new Set(listTextureInfoByMaterial(materialB));
-	t.is(textureInfo.size, 1, 'finds TextureInfo x 1');
+		textureInfo = new Set(listTextureInfoByMaterial(materialB));
+		strictEqual(textureInfo.size, 1, 'finds TextureInfo x 1');
+	});
 });

--- a/packages/functions/test/list-texture-slots.test.ts
+++ b/packages/functions/test/list-texture-slots.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { KHRMaterialsSheen } from '@gltf-transform/extensions';
 import { listTextureSlots } from '@gltf-transform/functions';
 
-describe('listTextureSlots', () => {
+describe('functions::listTextureSlots', () => {
 	test('basic', () => {
 		const document = new Document();
 		const textureA = document.createTexture();

--- a/packages/functions/test/list-texture-slots.test.ts
+++ b/packages/functions/test/list-texture-slots.test.ts
@@ -1,15 +1,18 @@
+import { deepEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { KHRMaterialsSheen } from '@gltf-transform/extensions';
 import { listTextureSlots } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', (t) => {
-	const document = new Document();
-	const textureA = document.createTexture();
-	const textureB = document.createTexture();
-	const sheenExtension = document.createExtension(KHRMaterialsSheen);
-	const sheen = sheenExtension.createSheen().setSheenColorTexture(textureB);
-	document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);
-	t.deepEqual(listTextureSlots(textureA), ['baseColorTexture'], 'baseColorTexture');
-	t.deepEqual(listTextureSlots(textureB), ['sheenColorTexture'], 'sheenColorTexture');
+describe('listTextureSlots', () => {
+	test('basic', () => {
+		const document = new Document();
+		const textureA = document.createTexture();
+		const textureB = document.createTexture();
+		const sheenExtension = document.createExtension(KHRMaterialsSheen);
+		const sheen = sheenExtension.createSheen().setSheenColorTexture(textureB);
+		document.createMaterial().setBaseColorTexture(textureA).setExtension('KHR_materials_sheen', sheen);
+		deepEqual(listTextureSlots(textureA), ['baseColorTexture'], 'baseColorTexture');
+		deepEqual(listTextureSlots(textureB), ['sheenColorTexture'], 'sheenColorTexture');
+	});
 });

--- a/packages/functions/test/meshopt.test.ts
+++ b/packages/functions/test/meshopt.test.ts
@@ -1,23 +1,26 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { meshopt } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import { MeshoptEncoder } from 'meshoptimizer';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createMesh().addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 6 }));
+describe('meshopt', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		document.createMesh().addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 6 }));
 
-	await document.transform(meshopt({ encoder: MeshoptEncoder }));
+		await document.transform(meshopt({ encoder: MeshoptEncoder }));
 
-	t.true(hasMeshopt(document), 'adds extension');
-});
+		ok(hasMeshopt(document), 'adds extension');
+	});
 
-test('noop', async (t) => {
-	const document = new Document().setLogger(logger);
-	await document.transform(meshopt({ encoder: MeshoptEncoder }));
+	test('noop', async () => {
+		const document = new Document().setLogger(logger);
+		await document.transform(meshopt({ encoder: MeshoptEncoder }));
 
-	t.false(hasMeshopt(document), 'skips extension if no accessors found');
+		strictEqual(hasMeshopt(document), false, 'skips extension if no accessors found');
+	});
 });
 
 const hasMeshopt = (document: Document): boolean =>

--- a/packages/functions/test/meshopt.test.ts
+++ b/packages/functions/test/meshopt.test.ts
@@ -5,7 +5,7 @@ import { meshopt } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
 import { MeshoptEncoder } from 'meshoptimizer';
 
-describe('meshopt', () => {
+describe('functions::meshopt', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		document.createMesh().addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 6 }));

--- a/packages/functions/test/metal-rough.test.ts
+++ b/packages/functions/test/metal-rough.test.ts
@@ -23,7 +23,7 @@ const SPEC = ndarray(new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 
 // orm.G = 1 - specGloss.A * glossFactor
 const ROUGH = ndarray(new Uint8Array([0, 255, 0, 255, 0, 223, 0, 255, 0, 191, 0, 255, 0, 127, 0, 255]), [1, 4, 4]);
 
-describe('metalRough', () => {
+describe('functions::metalRough', () => {
 	test('textures', async () => {
 		const doc = new Document();
 		const baseColorTex = doc

--- a/packages/functions/test/metal-rough.test.ts
+++ b/packages/functions/test/metal-rough.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import {
 	type IOR,
@@ -7,7 +9,6 @@ import {
 	type Specular,
 } from '@gltf-transform/extensions';
 import { metalRough } from '@gltf-transform/functions';
-import test from 'ava';
 import ndarray from 'ndarray';
 import { getPixels, savePixels } from 'ndarray-pixels';
 
@@ -22,114 +23,116 @@ const SPEC = ndarray(new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 
 // orm.G = 1 - specGloss.A * glossFactor
 const ROUGH = ndarray(new Uint8Array([0, 255, 0, 255, 0, 223, 0, 255, 0, 191, 0, 255, 0, 127, 0, 255]), [1, 4, 4]);
 
-test('textures', async (t) => {
-	const doc = new Document();
-	const baseColorTex = doc
-		.createTexture()
-		.setImage(await savePixels(ZEROS, 'image/png'))
-		.setMimeType('image/png');
-	const metalRoughTex = doc
-		.createTexture()
-		.setImage(await savePixels(ZEROS, 'image/png'))
-		.setMimeType('image/png');
-	const diffuseTex = doc
-		.createTexture()
-		.setImage(await savePixels(DIFFUSE, 'image/png'))
-		.setMimeType('image/png');
-	const specGlossTex = doc
-		.createTexture()
-		.setImage(await savePixels(SPEC_GLOSS, 'image/png'))
-		.setMimeType('image/png');
-	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
-	const specGloss = specGlossExtension
-		.createPBRSpecularGlossiness()
-		.setDiffuseTexture(diffuseTex)
-		.setSpecularGlossinessTexture(specGlossTex)
-		.setGlossinessFactor(0.5);
-	const mat = doc
-		.createMaterial()
-		.setBaseColorTexture(baseColorTex)
-		.setMetallicRoughnessTexture(metalRoughTex)
-		.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
+describe('metalRough', () => {
+	test('textures', async () => {
+		const doc = new Document();
+		const baseColorTex = doc
+			.createTexture()
+			.setImage(await savePixels(ZEROS, 'image/png'))
+			.setMimeType('image/png');
+		const metalRoughTex = doc
+			.createTexture()
+			.setImage(await savePixels(ZEROS, 'image/png'))
+			.setMimeType('image/png');
+		const diffuseTex = doc
+			.createTexture()
+			.setImage(await savePixels(DIFFUSE, 'image/png'))
+			.setMimeType('image/png');
+		const specGlossTex = doc
+			.createTexture()
+			.setImage(await savePixels(SPEC_GLOSS, 'image/png'))
+			.setMimeType('image/png');
+		const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
+		const specGloss = specGlossExtension
+			.createPBRSpecularGlossiness()
+			.setDiffuseTexture(diffuseTex)
+			.setSpecularGlossinessTexture(specGlossTex)
+			.setGlossinessFactor(0.5);
+		const mat = doc
+			.createMaterial()
+			.setBaseColorTexture(baseColorTex)
+			.setMetallicRoughnessTexture(metalRoughTex)
+			.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 
-	await doc.transform(metalRough());
+		await doc.transform(metalRough());
 
-	const specularExtension = mat.getExtension<Specular>('KHR_materials_specular');
-	const extensionsUsed = doc
-		.getRoot()
-		.listExtensionsUsed()
-		.map((e) => e.extensionName)
-		.sort();
+		const specularExtension = mat.getExtension<Specular>('KHR_materials_specular');
+		const extensionsUsed = doc
+			.getRoot()
+			.listExtensionsUsed()
+			.map((e) => e.extensionName)
+			.sort();
 
-	t.deepEqual(
-		extensionsUsed,
-		[KHRMaterialsIOR.EXTENSION_NAME, KHRMaterialsSpecular.EXTENSION_NAME],
-		'uses KHR_materials_ior and KHR_materials_specular',
-	);
-	t.truthy(specGloss.isDisposed(), 'disposes PBRSpecularGlossiness');
-	t.truthy(baseColorTex.isDisposed(), 'disposes baseColorTexture');
-	t.truthy(metalRoughTex.isDisposed(), 'disposes metalRoughTexture');
-	t.truthy(specGlossTex.isDisposed(), 'disposes specGlossTexture');
-	t.deepEqual(
-		Array.from((await getPixels(mat.getBaseColorTexture().getImage(), 'image/png')).data as Uint8Array),
-		Array.from(DIFFUSE.data),
-		'diffuse -> baseColor',
-	);
-	t.deepEqual(
-		Array.from((await getPixels(mat.getMetallicRoughnessTexture().getImage(), 'image/png')).data as Uint8Array),
-		Array.from(ROUGH.data),
-		'spec -> rough',
-	);
-	t.deepEqual(
-		Array.from(
-			(await getPixels(specularExtension.getSpecularTexture().getImage(), 'image/png')).data as Uint8Array,
-		),
-		Array.from(SPEC.data),
-		'spec -> spec',
-	);
-	t.is(mat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1000, 'ior = 1000');
-	t.is(mat.getRoughnessFactor(), 1, 'roughnessFactor = 1');
-	t.is(mat.getMetallicFactor(), 0, 'metallicFactor = 0');
-	t.is(doc.getRoot().listTextures().length, 3, 'correct texture count');
-});
+		deepEqual(
+			extensionsUsed,
+			[KHRMaterialsIOR.EXTENSION_NAME, KHRMaterialsSpecular.EXTENSION_NAME],
+			'uses KHR_materials_ior and KHR_materials_specular',
+		);
+		ok(specGloss.isDisposed(), 'disposes PBRSpecularGlossiness');
+		ok(baseColorTex.isDisposed(), 'disposes baseColorTexture');
+		ok(metalRoughTex.isDisposed(), 'disposes metalRoughTexture');
+		ok(specGlossTex.isDisposed(), 'disposes specGlossTexture');
+		deepEqual(
+			Array.from((await getPixels(mat.getBaseColorTexture().getImage(), 'image/png')).data as Uint8Array),
+			Array.from(DIFFUSE.data),
+			'diffuse -> baseColor',
+		);
+		deepEqual(
+			Array.from((await getPixels(mat.getMetallicRoughnessTexture().getImage(), 'image/png')).data as Uint8Array),
+			Array.from(ROUGH.data),
+			'spec -> rough',
+		);
+		deepEqual(
+			Array.from(
+				(await getPixels(specularExtension.getSpecularTexture().getImage(), 'image/png')).data as Uint8Array,
+			),
+			Array.from(SPEC.data),
+			'spec -> spec',
+		);
+		strictEqual(mat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1000, 'ior = 1000');
+		strictEqual(mat.getRoughnessFactor(), 1, 'roughnessFactor = 1');
+		strictEqual(mat.getMetallicFactor(), 0, 'metallicFactor = 0');
+		strictEqual(doc.getRoot().listTextures().length, 3, 'correct texture count');
+	});
 
-test('factors', async (t) => {
-	const doc = new Document();
-	const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
-	const specGloss = specGlossExtension
-		.createPBRSpecularGlossiness()
-		.setDiffuseFactor([0, 1, 0, 0.5])
-		.setSpecularFactor([1, 0.5, 0.5])
-		.setGlossinessFactor(0.9);
-	const mat = doc
-		.createMaterial()
-		.setBaseColorFactor([1, 0, 0, 1])
-		.setMetallicFactor(0.25)
-		.setRoughnessFactor(0.75)
-		.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
+	test('factors', async () => {
+		const doc = new Document();
+		const specGlossExtension = doc.createExtension(KHRMaterialsPBRSpecularGlossiness);
+		const specGloss = specGlossExtension
+			.createPBRSpecularGlossiness()
+			.setDiffuseFactor([0, 1, 0, 0.5])
+			.setSpecularFactor([1, 0.5, 0.5])
+			.setGlossinessFactor(0.9);
+		const mat = doc
+			.createMaterial()
+			.setBaseColorFactor([1, 0, 0, 1])
+			.setMetallicFactor(0.25)
+			.setRoughnessFactor(0.75)
+			.setExtension('KHR_materials_pbrSpecularGlossiness', specGloss);
 
-	await doc.transform(metalRough());
+		await doc.transform(metalRough());
 
-	const extensionsUsed = doc
-		.getRoot()
-		.listExtensionsUsed()
-		.map((e) => e.extensionName)
-		.sort();
+		const extensionsUsed = doc
+			.getRoot()
+			.listExtensionsUsed()
+			.map((e) => e.extensionName)
+			.sort();
 
-	t.deepEqual(
-		extensionsUsed,
-		[KHRMaterialsIOR.EXTENSION_NAME, KHRMaterialsSpecular.EXTENSION_NAME],
-		'uses KHR_materials_ior and KHR_materials_specular',
-	);
-	t.deepEqual(mat.getBaseColorFactor(), [0, 1, 0, 0.5], 'baseColorFactor = diffuseFactor');
-	t.is(mat.getExtension<Specular>('KHR_materials_specular').getSpecularFactor(), 1, 'specularFactor = 1');
-	t.deepEqual(
-		mat.getExtension<Specular>('KHR_materials_specular').getSpecularColorFactor(),
-		[1, 0.5, 0.5],
-		'specularColorFactor = specularFactor',
-	);
-	t.is(mat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1000, 'ior = 1000');
-	t.is(mat.getRoughnessFactor().toFixed(3), '0.100', 'roughnessFactor = 1 - glossFactor');
-	t.is(mat.getMetallicFactor(), 0, 'metallicFactor = 0');
-	t.is(doc.getRoot().listTextures().length, 0, 'no textures');
+		deepEqual(
+			extensionsUsed,
+			[KHRMaterialsIOR.EXTENSION_NAME, KHRMaterialsSpecular.EXTENSION_NAME],
+			'uses KHR_materials_ior and KHR_materials_specular',
+		);
+		deepEqual(mat.getBaseColorFactor(), [0, 1, 0, 0.5], 'baseColorFactor = diffuseFactor');
+		strictEqual(mat.getExtension<Specular>('KHR_materials_specular').getSpecularFactor(), 1, 'specularFactor = 1');
+		deepEqual(
+			mat.getExtension<Specular>('KHR_materials_specular').getSpecularColorFactor(),
+			[1, 0.5, 0.5],
+			'specularColorFactor = specularFactor',
+		);
+		strictEqual(mat.getExtension<IOR>('KHR_materials_ior').getIOR(), 1000, 'ior = 1000');
+		strictEqual(mat.getRoughnessFactor().toFixed(3), '0.100', 'roughnessFactor = 1 - glossFactor');
+		strictEqual(mat.getMetallicFactor(), 0, 'metallicFactor = 0');
+		strictEqual(doc.getRoot().listTextures().length, 0, 'no textures');
+	});
 });

--- a/packages/functions/test/normals.test.ts
+++ b/packages/functions/test/normals.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { normals } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('normals', () => {
+describe('functions::normals', () => {
 	test('basic', async () => {
 		const doc = new Document().setLogger(logger);
 		const indicesArray = new Uint16Array([0, 1, 2]);

--- a/packages/functions/test/normals.test.ts
+++ b/packages/functions/test/normals.test.ts
@@ -1,29 +1,32 @@
+import { deepEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { normals } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const indicesArray = new Uint16Array([0, 1, 2]);
-	const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 1, 0, 0]);
-	const normalArray = new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0]);
-	const resultArray = new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0]);
-	const indices = doc.createAccessor().setType('SCALAR').setArray(indicesArray);
-	const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
-	const normal = doc.createAccessor().setType('VEC3').setArray(normalArray);
-	const prim = doc
-		.createPrimitive()
-		.setIndices(indices)
-		.setAttribute('POSITION', position)
-		.setAttribute('NORMAL', normal);
-	doc.createMesh().addPrimitive(prim);
+describe('normals', () => {
+	test('basic', async () => {
+		const doc = new Document().setLogger(logger);
+		const indicesArray = new Uint16Array([0, 1, 2]);
+		const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 1, 0, 0]);
+		const normalArray = new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0]);
+		const resultArray = new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0]);
+		const indices = doc.createAccessor().setType('SCALAR').setArray(indicesArray);
+		const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
+		const normal = doc.createAccessor().setType('VEC3').setArray(normalArray);
+		const prim = doc
+			.createPrimitive()
+			.setIndices(indices)
+			.setAttribute('POSITION', position)
+			.setAttribute('NORMAL', normal);
+		doc.createMesh().addPrimitive(prim);
 
-	await doc.transform(normals({ overwrite: false }));
+		await doc.transform(normals({ overwrite: false }));
 
-	t.deepEqual(prim.getAttribute('NORMAL').getArray(), normalArray, 'skips normals');
+		deepEqual(prim.getAttribute('NORMAL').getArray(), normalArray, 'skips normals');
 
-	await doc.transform(normals({ overwrite: true }));
+		await doc.transform(normals({ overwrite: true }));
 
-	t.deepEqual(prim.getAttribute('NORMAL').getArray(), resultArray, 'overwrites normals');
+		deepEqual(prim.getAttribute('NORMAL').getArray(), resultArray, 'overwrites normals');
+	});
 });

--- a/packages/functions/test/palette.test.ts
+++ b/packages/functions/test/palette.test.ts
@@ -1,159 +1,161 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, type GLTF, type Material, type vec4 } from '@gltf-transform/core';
 import { KHRMaterialsSpecular } from '@gltf-transform/extensions';
 import { palette } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import { getPixels } from 'ndarray-pixels';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const [materialA, materialB, materialC, materialD, materialE] = createMaterials(
-		document,
-		['A', 'B', 'C', 'D', 'E'],
-		[
-			[1, 0, 0, 1],
-			[0, 1, 0, 1],
-			[0, 0, 1, 1],
-			[0, 1, 0, 1],
-			[1, 0, 0, 1],
-		],
-		[1.0, 1.0, 1.0, 0.0, 1.0],
-		['OPAQUE', 'OPAQUE', 'OPAQUE', 'OPAQUE', 'BLEND'],
-	);
+describe('palette', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const [materialA, materialB, materialC, materialD, materialE] = createMaterials(
+			document,
+			['A', 'B', 'C', 'D', 'E'],
+			[
+				[1, 0, 0, 1],
+				[0, 1, 0, 1],
+				[0, 0, 1, 1],
+				[0, 1, 0, 1],
+				[1, 0, 0, 1],
+			],
+			[1.0, 1.0, 1.0, 0.0, 1.0],
+			['OPAQUE', 'OPAQUE', 'OPAQUE', 'OPAQUE', 'BLEND'],
+		);
 
-	await document.transform(palette({ min: 2 }));
+		await document.transform(palette({ min: 2 }));
 
-	t.true(materialA.isDisposed(), 'disposed material A');
-	t.true(materialB.isDisposed(), 'disposed material B');
-	t.true(materialC.isDisposed(), 'disposed material C');
-	t.true(materialD.isDisposed(), 'disposed material D');
-	t.true(materialE.isDisposed(), 'disposed material E');
-	t.is(document.getRoot().listMaterials().length, 2, 'separate opaque and blend materials');
+		ok(materialA.isDisposed(), 'disposed material A');
+		ok(materialB.isDisposed(), 'disposed material B');
+		ok(materialC.isDisposed(), 'disposed material C');
+		ok(materialD.isDisposed(), 'disposed material D');
+		ok(materialE.isDisposed(), 'disposed material E');
+		strictEqual(document.getRoot().listMaterials().length, 2, 'separate opaque and blend materials');
 
-	const [opaquePaletteMaterial, blendPaletteMaterial] = document.getRoot().listMaterials();
+		const [opaquePaletteMaterial, blendPaletteMaterial] = document.getRoot().listMaterials();
 
-	t.is(opaquePaletteMaterial.getName(), 'PaletteMaterial001', 'creates opaque palette material');
-	t.is(opaquePaletteMaterial.getAlphaMode(), 'OPAQUE', 'material.alphaMode === "OPAQUE"');
+		strictEqual(opaquePaletteMaterial.getName(), 'PaletteMaterial001', 'creates opaque palette material');
+		strictEqual(opaquePaletteMaterial.getAlphaMode(), 'OPAQUE', 'material.alphaMode === "OPAQUE"');
 
-	t.is(blendPaletteMaterial.getName(), 'PaletteMaterial002', 'creates blend palette material');
-	t.is(blendPaletteMaterial.getAlphaMode(), 'BLEND', 'material.alphaMode === "BLEND"');
-});
+		strictEqual(blendPaletteMaterial.getName(), 'PaletteMaterial002', 'creates blend palette material');
+		strictEqual(blendPaletteMaterial.getAlphaMode(), 'BLEND', 'material.alphaMode === "BLEND"');
+	});
 
-test('options.blockSize', async (t) => {
-	const document = new Document().setLogger(logger);
-	createMaterials(
-		document,
-		['A', 'B', 'C', 'D', 'E'],
-		[
-			[1, 0, 0, 1],
-			[0, 1, 0, 1],
-			[0, 0, 1, 1],
-			[0, 1, 0, 1],
-			[1, 0, 0, 1],
-		],
-		new Array(5).fill(1.0),
-		new Array(5).fill('OPAQUE'),
-	);
+	test('options.blockSize', async () => {
+		const document = new Document().setLogger(logger);
+		createMaterials(
+			document,
+			['A', 'B', 'C', 'D', 'E'],
+			[
+				[1, 0, 0, 1],
+				[0, 1, 0, 1],
+				[0, 0, 1, 1],
+				[0, 1, 0, 1],
+				[1, 0, 0, 1],
+			],
+			new Array(5).fill(1.0),
+			new Array(5).fill('OPAQUE'),
+		);
 
-	await document.transform(palette({ min: 2, blockSize: 10 }));
+		await document.transform(palette({ min: 2, blockSize: 10 }));
 
-	t.is(document.getRoot().listMaterials().length, 1, 'only palette material remains');
+		strictEqual(document.getRoot().listMaterials().length, 1, 'only palette material remains');
 
-	const material = document.getRoot().listMaterials()[0]!;
+		const material = document.getRoot().listMaterials()[0]!;
 
-	t.truthy(material.getBaseColorTexture(), 'baseColorTexture = Texture');
-	t.is(material.getEmissiveTexture(), null, 'emissiveTexture = null');
-	t.is(material.getMetallicRoughnessTexture(), null, 'metallicRoughnessTexture = null');
+		ok(material.getBaseColorTexture(), 'baseColorTexture = Texture');
+		strictEqual(material.getEmissiveTexture(), null, 'emissiveTexture = null');
+		strictEqual(material.getMetallicRoughnessTexture(), null, 'metallicRoughnessTexture = null');
 
-	const baseColorPixels = await getPixels(material.getBaseColorTexture().getImage(), 'image/png');
-	t.deepEqual(baseColorPixels.shape, [32, 16, 4], 'dimensions');
-});
+		const baseColorPixels = await getPixels(material.getBaseColorTexture().getImage(), 'image/png');
+		deepEqual(baseColorPixels.shape, [32, 16, 4], 'dimensions');
+	});
 
-test('options.min', async (t) => {
-	const document = new Document().setLogger(logger);
-	createMaterials(
-		document,
-		['A', 'B', 'C', 'D', 'E'],
-		[
-			[1, 0, 0, 1],
-			[0, 1, 0, 1],
-			[0, 0, 1, 1],
-			[0, 1, 0, 1],
-			[1, 0, 0, 1],
-		],
-		new Array(5).fill(1.0),
-		new Array(5).fill('OPAQUE'),
-	);
+	test('options.min', async () => {
+		const document = new Document().setLogger(logger);
+		createMaterials(
+			document,
+			['A', 'B', 'C', 'D', 'E'],
+			[
+				[1, 0, 0, 1],
+				[0, 1, 0, 1],
+				[0, 0, 1, 1],
+				[0, 1, 0, 1],
+				[1, 0, 0, 1],
+			],
+			new Array(5).fill(1.0),
+			new Array(5).fill('OPAQUE'),
+		);
 
-	t.is(document.getRoot().listMaterials().length, 5, 'initial');
+		strictEqual(document.getRoot().listMaterials().length, 5, 'initial');
 
-	await document.transform(palette({ min: 4 }));
+		await document.transform(palette({ min: 4 }));
 
-	t.is(document.getRoot().listMaterials().length, 5, 'min = 4, palette = no');
+		strictEqual(document.getRoot().listMaterials().length, 5, 'min = 4, palette = no');
 
-	await document.transform(palette({ min: 3 }));
+		await document.transform(palette({ min: 3 }));
 
-	t.is(document.getRoot().listMaterials().length, 1, 'min = 3, palette = yes');
-});
+		strictEqual(document.getRoot().listMaterials().length, 1, 'min = 3, palette = yes');
+	});
 
-test('preserve extensions', async (t) => {
-	const document = new Document().setLogger(logger);
-	const [material] = createMaterials(
-		document,
-		['A', 'B', 'C', 'D', 'E'],
-		[
-			[1, 0, 0, 1],
-			[0, 1, 0, 1],
-			[0, 0, 1, 1],
-			[0, 1, 0, 1],
-			[1, 0, 0, 1],
-		],
-		new Array(5).fill(1.0),
-		new Array(5).fill('OPAQUE'),
-	);
+	test('preserve extensions', async () => {
+		const document = new Document().setLogger(logger);
+		const [material] = createMaterials(
+			document,
+			['A', 'B', 'C', 'D', 'E'],
+			[
+				[1, 0, 0, 1],
+				[0, 1, 0, 1],
+				[0, 0, 1, 1],
+				[0, 1, 0, 1],
+				[1, 0, 0, 1],
+			],
+			new Array(5).fill(1.0),
+			new Array(5).fill('OPAQUE'),
+		);
 
-	const specular = document
-		.createExtension(KHRMaterialsSpecular)
-		.createSpecular()
-		.setSpecularColorFactor([0.5, 0.5, 0.5]);
-	material.setExtension('KHR_materials_specular', specular);
+		const specular = document
+			.createExtension(KHRMaterialsSpecular)
+			.createSpecular()
+			.setSpecularColorFactor([0.5, 0.5, 0.5]);
+		material.setExtension('KHR_materials_specular', specular);
 
-	await document.transform(palette({ min: 2 }));
+		await document.transform(palette({ min: 2 }));
 
-	t.is(document.getRoot().listMaterials().length, 2, 'specular + non-specular palette materials');
+		strictEqual(document.getRoot().listMaterials().length, 2, 'specular + non-specular palette materials');
 
-	const [materialA, materialB] = document.getRoot().listMaterials();
+		const [materialA, materialB] = document.getRoot().listMaterials();
 
-	t.is(materialA.getName(), 'PaletteMaterial001', 'palette material #1 - name');
-	t.is(materialB.getName(), 'PaletteMaterial002', 'palette material #2 - name');
-	t.truthy(materialA.getExtension('KHR_materials_specular'), 'palette material #1 - spec');
-	t.is(materialB.getExtension('KHR_materials_specular'), null, 'palette material #1 - nonspec');
-});
+		strictEqual(materialA.getName(), 'PaletteMaterial001', 'palette material #1 - name');
+		strictEqual(materialB.getName(), 'PaletteMaterial002', 'palette material #2 - name');
+		ok(materialA.getExtension('KHR_materials_specular'), 'palette material #1 - spec');
+		strictEqual(materialB.getExtension('KHR_materials_specular'), null, 'palette material #1 - nonspec');
+	});
 
-test('pixel values', async (t) => {
-	const document = new Document().setLogger(logger);
-	createMaterials(
-		document,
-		['A', 'B', 'C'],
-		[
-			[0.218, 0.218, 0.218, 1],
-			[0, 0, 0.218, 1],
-			[0.218, 0, 0, 1],
-		],
-		new Array(3).fill(1.0),
-		new Array(3).fill('OPAQUE'),
-	);
+	test('pixel values', async () => {
+		const document = new Document().setLogger(logger);
+		createMaterials(
+			document,
+			['A', 'B', 'C'],
+			[
+				[0.218, 0.218, 0.218, 1],
+				[0, 0, 0.218, 1],
+				[0.218, 0, 0, 1],
+			],
+			new Array(3).fill(1.0),
+			new Array(3).fill('OPAQUE'),
+		);
 
-	await document.transform(palette({ min: 2, blockSize: 2 }));
+		await document.transform(palette({ min: 2, blockSize: 2 }));
 
-	const material = document.getRoot().listMaterials()[0];
-	const baseColorPixels = await getPixels(material.getBaseColorTexture().getImage(), 'image/png');
+		const material = document.getRoot().listMaterials()[0];
+		const baseColorPixels = await getPixels(material.getBaseColorTexture().getImage(), 'image/png');
 
-	t.deepEqual(baseColorPixels.shape, [8, 2, 4], 'dimensions');
-	t.deepEqual(
-		Array.from(baseColorPixels.data as Uint8Array),
-		// biome-ignore format: Readability.
-		[
+		deepEqual(baseColorPixels.shape, [8, 2, 4], 'dimensions');
+		deepEqual(
+			Array.from(baseColorPixels.data as Uint8Array),
+			// biome-ignore format: Readability.
+			[
 			// row 1
 			128, 128, 128, 255,
 			128, 128, 128, 255,
@@ -173,41 +175,42 @@ test('pixel values', async (t) => {
 			0, 0, 0, 0,
 			0, 0, 0, 0,
 		],
-		'pixel values',
-	);
-});
+			'pixel values',
+		);
+	});
 
-test('preserve UVs', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('preserve UVs', async () => {
+		const document = new Document().setLogger(logger);
 
-	const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
-	const uv = document.createAccessor().setType('VEC2').setArray(new Uint8Array(6));
+		const position = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+		const uv = document.createAccessor().setType('VEC2').setArray(new Uint8Array(6));
 
-	const materialA = document.createMaterial('A').setBaseColorFactor([1, 0, 0, 1]);
-	const materialB = document.createMaterial('B').setBaseColorFactor([0, 1, 0, 1]);
-	const materialC = document.createMaterial('C').setBaseColorFactor([0, 0, 1, 1]);
+		const materialA = document.createMaterial('A').setBaseColorFactor([1, 0, 0, 1]);
+		const materialB = document.createMaterial('B').setBaseColorFactor([0, 1, 0, 1]);
+		const materialC = document.createMaterial('C').setBaseColorFactor([0, 0, 1, 1]);
 
-	const primA = document.createPrimitive().setMaterial(materialA).setAttribute('POSITION', position);
-	const primB = document.createPrimitive().setMaterial(materialB).setAttribute('POSITION', position);
-	const primC = document
-		.createPrimitive()
-		.setMaterial(materialC)
-		.setAttribute('POSITION', position)
-		.setAttribute('TEXCOORD_0', uv);
+		const primA = document.createPrimitive().setMaterial(materialA).setAttribute('POSITION', position);
+		const primB = document.createPrimitive().setMaterial(materialB).setAttribute('POSITION', position);
+		const primC = document
+			.createPrimitive()
+			.setMaterial(materialC)
+			.setAttribute('POSITION', position)
+			.setAttribute('TEXCOORD_0', uv);
 
-	document.createMesh().addPrimitive(primA).addPrimitive(primB).addPrimitive(primC);
+		document.createMesh().addPrimitive(primA).addPrimitive(primB).addPrimitive(primC);
 
-	await document.transform(palette({ min: 2 }));
+		await document.transform(palette({ min: 2 }));
 
-	t.is(document.getRoot().listMaterials().length, 2, 'one material per texCoord index');
+		strictEqual(document.getRoot().listMaterials().length, 2, 'one material per texCoord index');
 
-	const paletteMaterials = document.getRoot().listMaterials();
-	const paletteMaterialA = paletteMaterials[0];
-	const paletteMaterialB = paletteMaterials[1];
+		const paletteMaterials = document.getRoot().listMaterials();
+		const paletteMaterialA = paletteMaterials[0];
+		const paletteMaterialB = paletteMaterials[1];
 
-	t.is(paletteMaterialA.getBaseColorTextureInfo().getTexCoord(), 0, 'texCoord = 0');
-	t.is(paletteMaterialB.getBaseColorTextureInfo().getTexCoord(), 1, 'texCoord = 1');
-	t.is(paletteMaterialA.getBaseColorTexture(), paletteMaterialB.getBaseColorTexture(), 'same texture');
+		strictEqual(paletteMaterialA.getBaseColorTextureInfo().getTexCoord(), 0, 'texCoord = 0');
+		strictEqual(paletteMaterialB.getBaseColorTextureInfo().getTexCoord(), 1, 'texCoord = 1');
+		strictEqual(paletteMaterialA.getBaseColorTexture(), paletteMaterialB.getBaseColorTexture(), 'same texture');
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/palette.test.ts
+++ b/packages/functions/test/palette.test.ts
@@ -6,7 +6,7 @@ import { palette } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 import { getPixels } from 'ndarray-pixels';
 
-describe('palette', () => {
+describe('functions::palette', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const [materialA, materialB, materialC, materialD, materialE] = createMaterials(

--- a/packages/functions/test/partition.test.ts
+++ b/packages/functions/test/partition.test.ts
@@ -1,55 +1,58 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, NodeIO } from '@gltf-transform/core';
 import { partition } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import path from 'path';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-test('basic', async (t) => {
-	const io = new NodeIO().setLogger(logger);
-	const document = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));
-	document.setLogger(logger);
-	t.is(document.getRoot().listBuffers().length, 1, 'initialized with one buffer');
+describe('partition', () => {
+	test('basic', async () => {
+		const io = new NodeIO().setLogger(logger);
+		const document = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));
+		document.setLogger(logger);
+		strictEqual(document.getRoot().listBuffers().length, 1, 'initialized with one buffer');
 
-	await document.transform(partition({ meshes: [] }));
-	await document.transform(partition({ meshes: false }));
+		await document.transform(partition({ meshes: [] }));
+		await document.transform(partition({ meshes: false }));
 
-	t.is(document.getRoot().listBuffers().length, 1, 'has no effect when disabled');
+		strictEqual(document.getRoot().listBuffers().length, 1, 'has no effect when disabled');
 
-	await document.transform(partition({ meshes: ['CubeA', 'CubeB'] }));
+		await document.transform(partition({ meshes: ['CubeA', 'CubeB'] }));
 
-	const jsonDoc = await io.writeJSON(document, { basename: 'partition-test' });
-	t.deepEqual(
-		jsonDoc.json.buffers,
-		[
-			{ uri: 'CubeA.bin', byteLength: 324, name: 'CubeA' },
-			{ uri: 'CubeB.bin', byteLength: 324, name: 'CubeB' },
-		],
-		'partitions into two buffers',
-	);
+		const jsonDoc = await io.writeJSON(document, { basename: 'partition-test' });
+		deepEqual(
+			jsonDoc.json.buffers,
+			[
+				{ uri: 'CubeA.bin', byteLength: 324, name: 'CubeA' },
+				{ uri: 'CubeB.bin', byteLength: 324, name: 'CubeB' },
+			],
+			'partitions into two buffers',
+		);
 
-	const bufferReferences = jsonDoc.json.bufferViews.map((b) => b.buffer);
-	t.deepEqual(bufferReferences, [0, 0, 1, 1], 'creates four buffer views');
-});
+		const bufferReferences = jsonDoc.json.bufferViews.map((b) => b.buffer);
+		deepEqual(bufferReferences, [0, 0, 1, 1], 'creates four buffer views');
+	});
 
-test('valid and unique URIs', async (t) => {
-	const io = new NodeIO().setLogger(logger);
-	const document = new Document().setLogger(logger);
-	document.createMesh('../%$mesh-001!').addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 12 }));
-	document.createMesh('../%$mesh-002!').addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 12 }));
-	document.createMesh('../%$mesh-002!').addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 12 }));
+	test('valid and unique URIs', async () => {
+		const io = new NodeIO().setLogger(logger);
+		const document = new Document().setLogger(logger);
+		document.createMesh('../%$mesh-001!').addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 12 }));
+		document.createMesh('../%$mesh-002!').addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 12 }));
+		document.createMesh('../%$mesh-002!').addPrimitive(createTorusKnotPrimitive(document, { tubularSegments: 12 }));
 
-	await document.transform(partition({ meshes: true }));
+		await document.transform(partition({ meshes: true }));
 
-	const jsonDocument = await io.writeJSON(document, { basename: 'partition-test' });
-	t.deepEqual(
-		jsonDocument.json.buffers,
-		[
-			{ uri: 'mesh-001.bin', byteLength: 6048, name: '../%$mesh-001!' },
-			{ uri: 'mesh-002.bin', byteLength: 6048, name: '../%$mesh-002!' },
-			{ uri: 'mesh-002_1.bin', byteLength: 6048, name: '../%$mesh-002!' },
-		],
-		'partitions into three buffers',
-	);
+		const jsonDocument = await io.writeJSON(document, { basename: 'partition-test' });
+		deepEqual(
+			jsonDocument.json.buffers,
+			[
+				{ uri: 'mesh-001.bin', byteLength: 6048, name: '../%$mesh-001!' },
+				{ uri: 'mesh-002.bin', byteLength: 6048, name: '../%$mesh-002!' },
+				{ uri: 'mesh-002_1.bin', byteLength: 6048, name: '../%$mesh-002!' },
+			],
+			'partitions into three buffers',
+		);
+	});
 });

--- a/packages/functions/test/partition.test.ts
+++ b/packages/functions/test/partition.test.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 const __dirname = path.dirname(new URL(import.meta.url).pathname);
 
-describe('partition', () => {
+describe('functions::partition', () => {
 	test('basic', async () => {
 		const io = new NodeIO().setLogger(logger);
 		const document = await io.read(path.join(__dirname, 'in/TwoCubes.glb'));

--- a/packages/functions/test/prune.test.ts
+++ b/packages/functions/test/prune.test.ts
@@ -1,314 +1,319 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { type Accessor, Document, Primitive, PropertyType } from '@gltf-transform/core';
 import { KHRMaterialsUnlit } from '@gltf-transform/extensions';
 import { prune } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import ndarray from 'ndarray';
 import { savePixels } from 'ndarray-pixels';
 
 const PIXELS_SOLID = ndarray(new Uint8Array([128, 128, 192, 1]), [1, 1, 4]);
 const PIXELS_NON_SOLID = ndarray(new Uint8Array([64, 64, 128, 1, 32, 32, 128, 1]), [1, 2, 4]);
 
-test('properties', async (t) => {
-	const doc = new Document().setLogger(logger);
+describe('prune', () => {
+	test('properties', async () => {
+		const doc = new Document().setLogger(logger);
 
-	// Create used resources.
-	const prim = doc.createPrimitive();
-	const mesh = doc.createMesh().addPrimitive(prim);
-	const node = doc.createNode().setMesh(mesh);
-	const scene = doc.createScene().addChild(node);
-	const chan = doc.createAnimationChannel().setTargetNode(node);
-	const samp = doc.createAnimationSampler();
-	const anim = doc.createAnimation().addChannel(chan).addSampler(samp);
+		// Create used resources.
+		const prim = doc.createPrimitive();
+		const mesh = doc.createMesh().addPrimitive(prim);
+		const node = doc.createNode().setMesh(mesh);
+		const scene = doc.createScene().addChild(node);
+		const chan = doc.createAnimationChannel().setTargetNode(node);
+		const samp = doc.createAnimationSampler();
+		const anim = doc.createAnimation().addChannel(chan).addSampler(samp);
 
-	// Create unused resources.
-	const mesh2 = doc.createMesh().addPrimitive(prim);
-	const node2 = doc.createNode().setMesh(mesh2);
-	const chan2 = doc.createAnimationChannel().setTargetNode(node2);
-	const samp2 = doc.createAnimationSampler();
-	const anim2 = doc.createAnimation().addChannel(chan2).addSampler(samp2);
+		// Create unused resources.
+		const mesh2 = doc.createMesh().addPrimitive(prim);
+		const node2 = doc.createNode().setMesh(mesh2);
+		const chan2 = doc.createAnimationChannel().setTargetNode(node2);
+		const samp2 = doc.createAnimationSampler();
+		const anim2 = doc.createAnimation().addChannel(chan2).addSampler(samp2);
 
-	const mesh3 = doc.createMesh();
-	const node3 = doc.createNode().setMesh(mesh3);
-	scene.addChild(node3);
+		const mesh3 = doc.createMesh();
+		const node3 = doc.createNode().setMesh(mesh3);
+		scene.addChild(node3);
 
-	await doc.transform(prune());
+		await doc.transform(prune());
 
-	t.false(scene.isDisposed(), 'referenced scene');
-	t.false(mesh.isDisposed(), 'referenced mesh');
-	t.false(node.isDisposed(), 'referenced node');
-	t.false(anim.isDisposed(), 'referenced animation');
-	t.false(samp.isDisposed(), 'referenced sampler');
-	t.false(chan.isDisposed(), 'referenced channel');
+		strictEqual(scene.isDisposed(), false, 'referenced scene');
+		strictEqual(mesh.isDisposed(), false, 'referenced mesh');
+		strictEqual(node.isDisposed(), false, 'referenced node');
+		strictEqual(anim.isDisposed(), false, 'referenced animation');
+		strictEqual(samp.isDisposed(), false, 'referenced sampler');
+		strictEqual(chan.isDisposed(), false, 'referenced channel');
 
-	t.true(mesh2.isDisposed(), 'unreferenced mesh');
-	t.true(node2.isDisposed(), 'unreferenced node');
-	t.true(anim2.isDisposed(), 'unreferenced animation');
-	t.true(samp2.isDisposed(), 'unreferenced sampler');
-	t.true(chan2.isDisposed(), 'unreferenced channel');
+		ok(mesh2.isDisposed(), 'unreferenced mesh');
+		ok(node2.isDisposed(), 'unreferenced node');
+		ok(anim2.isDisposed(), 'unreferenced animation');
+		ok(samp2.isDisposed(), 'unreferenced sampler');
+		ok(chan2.isDisposed(), 'unreferenced channel');
 
-	t.true(mesh3.isDisposed(), 'empty mesh');
-});
+		ok(mesh3.isDisposed(), 'empty mesh');
+	});
 
-test('leaf nodes', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('leaf nodes', async () => {
+		const document = new Document().setLogger(logger);
 
-	const prim = document.createPrimitive();
-	const mesh = document.createMesh().addPrimitive(prim);
-	const skin = document.createSkin();
-	const nodeC = document.createNode('C').setMesh(mesh);
-	const nodeB = document.createNode('B').addChild(nodeC);
-	const nodeA = document.createNode('A').addChild(nodeB).setSkin(skin);
-	const scene = document.createScene().addChild(nodeA);
+		const prim = document.createPrimitive();
+		const mesh = document.createMesh().addPrimitive(prim);
+		const skin = document.createSkin();
+		const nodeC = document.createNode('C').setMesh(mesh);
+		const nodeB = document.createNode('B').addChild(nodeC);
+		const nodeA = document.createNode('A').addChild(nodeB).setSkin(skin);
+		const scene = document.createScene().addChild(nodeA);
 
-	await document.transform(prune({ keepLeaves: true }));
+		await document.transform(prune({ keepLeaves: true }));
 
-	t.falsy(scene.isDisposed(), 'scene in tree');
-	t.falsy(nodeA.isDisposed(), 'nodeA in tree');
-	t.falsy(nodeB.isDisposed(), 'nodeB in tree');
-	t.falsy(nodeC.isDisposed(), 'nodeC in tree');
-	t.falsy(mesh.isDisposed(), 'mesh in tree');
-	t.falsy(skin.isDisposed(), 'skin in tree');
+		strictEqual(scene.isDisposed(), false, 'scene in tree');
+		strictEqual(nodeA.isDisposed(), false, 'nodeA in tree');
+		strictEqual(nodeB.isDisposed(), false, 'nodeB in tree');
+		strictEqual(nodeC.isDisposed(), false, 'nodeC in tree');
+		strictEqual(mesh.isDisposed(), false, 'mesh in tree');
+		strictEqual(skin.isDisposed(), false, 'skin in tree');
 
-	mesh.dispose();
-	await document.transform(prune());
+		mesh.dispose();
+		await document.transform(prune());
 
-	t.falsy(scene.isDisposed(), 'scene in tree');
-	t.falsy(nodeA.isDisposed(), 'nodeA in tree');
-	t.truthy(nodeB.isDisposed(), 'nodeB disposed');
-	t.truthy(nodeC.isDisposed(), 'nodeC disposed');
+		strictEqual(scene.isDisposed(), false, 'scene in tree');
+		strictEqual(nodeA.isDisposed(), false, 'nodeA in tree');
+		ok(nodeB.isDisposed(), 'nodeB disposed');
+		ok(nodeC.isDisposed(), 'nodeC disposed');
 
-	skin.dispose();
-	await document.transform(prune({ keepLeaves: false, propertyTypes: [] }));
+		skin.dispose();
+		await document.transform(prune({ keepLeaves: false, propertyTypes: [] }));
 
-	t.falsy(scene.isDisposed(), 'scene in tree');
-	t.falsy(nodeA.isDisposed(), 'nodeA disposed');
+		strictEqual(scene.isDisposed(), false, 'scene in tree');
+		strictEqual(nodeA.isDisposed(), false, 'nodeA disposed');
 
-	await document.transform(prune({ keepLeaves: false, propertyTypes: [PropertyType.NODE] }));
+		await document.transform(prune({ keepLeaves: false, propertyTypes: [PropertyType.NODE] }));
 
-	t.falsy(scene.isDisposed(), 'scene in tree');
-	t.truthy(nodeA.isDisposed(), 'nodeA disposed');
-});
+		strictEqual(scene.isDisposed(), false, 'scene in tree');
+		ok(nodeA.isDisposed(), 'nodeA disposed');
+	});
 
-test('leaf nodes - extras', async (t) => {
-	const document = new Document().setLogger(logger);
-	const node = document.createNode('CustomNode');
-	node.setExtras({ customData: 'test' });
-	document.createScene().addChild(node);
+	test('leaf nodes - extras', async () => {
+		const document = new Document().setLogger(logger);
+		const node = document.createNode('CustomNode');
+		node.setExtras({ customData: 'test' });
+		document.createScene().addChild(node);
 
-	await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false, keepExtras: true }));
+		await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false, keepExtras: true }));
 
-	t.is(document.getRoot().listNodes().length, 1, '1 nodes');
+		strictEqual(document.getRoot().listNodes().length, 1, '1 nodes');
 
-	await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false, keepExtras: false }));
+		await document.transform(prune({ propertyTypes: [PropertyType.NODE], keepLeaves: false, keepExtras: false }));
 
-	t.is(document.getRoot().listNodes().length, 0, '0 nodes');
-});
+		strictEqual(document.getRoot().listNodes().length, 0, '0 nodes');
+	});
 
-test('attributes', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('attributes', async () => {
+		const document = new Document().setLogger(logger);
 
-	const position = document.createAccessor('POSITION');
-	const tangent = document.createAccessor('TANGENT');
-	const texcoord0 = document.createAccessor('TEXCOORD_0');
-	const texcoord1 = document.createAccessor('TEXCOORD_1');
-	const color0 = document.createAccessor('COLOR_0');
-	const color1 = document.createAccessor('COLOR_1');
-	const texture = document.createTexture();
-	const material = document
-		.createMaterial()
-		.setRoughnessFactor(1)
-		.setBaseColorTexture(texture)
-		.setNormalTexture(texture);
-	material.getBaseColorTextureInfo().setTexCoord(0);
-	material.getNormalTextureInfo().setTexCoord(1);
-	const prim = document
-		.createPrimitive()
-		.setMaterial(material)
-		.setAttribute('POSITION', position)
-		.setAttribute('TANGENT', tangent)
-		.setAttribute('TEXCOORD_0', texcoord0)
-		.setAttribute('TEXCOORD_1', texcoord1)
-		.setAttribute('COLOR_0', color0)
-		.setAttribute('COLOR_1', color1);
-	document.createMesh().addPrimitive(prim);
+		const position = document.createAccessor('POSITION');
+		const tangent = document.createAccessor('TANGENT');
+		const texcoord0 = document.createAccessor('TEXCOORD_0');
+		const texcoord1 = document.createAccessor('TEXCOORD_1');
+		const color0 = document.createAccessor('COLOR_0');
+		const color1 = document.createAccessor('COLOR_1');
+		const texture = document.createTexture();
+		const material = document
+			.createMaterial()
+			.setRoughnessFactor(1)
+			.setBaseColorTexture(texture)
+			.setNormalTexture(texture);
+		material.getBaseColorTextureInfo().setTexCoord(0);
+		material.getNormalTextureInfo().setTexCoord(1);
+		const prim = document
+			.createPrimitive()
+			.setMaterial(material)
+			.setAttribute('POSITION', position)
+			.setAttribute('TANGENT', tangent)
+			.setAttribute('TEXCOORD_0', texcoord0)
+			.setAttribute('TEXCOORD_1', texcoord1)
+			.setAttribute('COLOR_0', color0)
+			.setAttribute('COLOR_1', color1);
+		document.createMesh().addPrimitive(prim);
 
-	await document.transform(
-		prune({
-			propertyTypes: [PropertyType.ACCESSOR],
-			keepAttributes: true,
-		}),
-	);
+		await document.transform(
+			prune({
+				propertyTypes: [PropertyType.ACCESSOR],
+				keepAttributes: true,
+			}),
+		);
 
-	t.deepEqual(
-		[position, tangent, texcoord0, texcoord1, color0, color1].map((a) => a.isDisposed()),
-		new Array(6).fill(false),
-		'keeps required attributes (1/3)',
-	);
+		deepEqual(
+			[position, tangent, texcoord0, texcoord1, color0, color1].map((a) => a.isDisposed()),
+			new Array(6).fill(false),
+			'keeps required attributes (1/3)',
+		);
 
-	await document.transform(
-		prune({
-			propertyTypes: [PropertyType.ACCESSOR],
-			keepAttributes: false,
-		}),
-	);
+		await document.transform(
+			prune({
+				propertyTypes: [PropertyType.ACCESSOR],
+				keepAttributes: false,
+			}),
+		);
 
-	t.deepEqual(
-		[position, tangent, texcoord0, texcoord1, color0].map((a) => a.isDisposed()),
-		new Array(5).fill(false),
-		'keeps required attributes (2/3)',
-	);
-	t.is(color1.isDisposed(), true, 'discards COLOR_1');
+		deepEqual(
+			[position, tangent, texcoord0, texcoord1, color0].map((a) => a.isDisposed()),
+			new Array(5).fill(false),
+			'keeps required attributes (2/3)',
+		);
+		strictEqual(color1.isDisposed(), true, 'discards COLOR_1');
 
-	material.setNormalTexture(null);
+		material.setNormalTexture(null);
 
-	await document.transform(
-		prune({
-			propertyTypes: [PropertyType.ACCESSOR],
-			keepAttributes: false,
-		}),
-	);
+		await document.transform(
+			prune({
+				propertyTypes: [PropertyType.ACCESSOR],
+				keepAttributes: false,
+			}),
+		);
 
-	t.deepEqual(
-		[position, texcoord0, color0].map((a) => a.isDisposed()),
-		[false, false, false],
-		'keeps required attributes (3/3)',
-	);
-	t.deepEqual(
-		[tangent, texcoord1].map((a) => a.isDisposed()),
-		[true, true],
-		'discards TANGENT, TEXCOORD_1',
-	);
-});
+		deepEqual(
+			[position, texcoord0, color0].map((a) => a.isDisposed()),
+			[false, false, false],
+			'keeps required attributes (3/3)',
+		);
+		deepEqual(
+			[tangent, texcoord1].map((a) => a.isDisposed()),
+			[true, true],
+			'discards TANGENT, TEXCOORD_1',
+		);
+	});
 
-test('attributes - texcoords', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('attributes - texcoords', async () => {
+		const document = new Document().setLogger(logger);
 
-	// Material.
-	const texture1 = document.createTexture();
-	const texture3 = document.createTexture();
-	const material = document.createMaterial();
-	material.setBaseColorTexture(texture1).getBaseColorTextureInfo().setTexCoord(1);
-	material.setNormalTexture(texture3).getNormalTextureInfo().setTexCoord(3);
+		// Material.
+		const texture1 = document.createTexture();
+		const texture3 = document.createTexture();
+		const material = document.createMaterial();
+		material.setBaseColorTexture(texture1).getBaseColorTextureInfo().setTexCoord(1);
+		material.setNormalTexture(texture3).getNormalTextureInfo().setTexCoord(3);
 
-	// Primitives.
-	const uvs: Accessor[] = [];
-	const primA = document
-		.createPrimitive()
-		.setMaterial(material)
-		.setAttribute('POSITION', document.createAccessor())
-		.setAttribute('TEXCOORD_0', (uvs[0] = document.createAccessor())) // unused
-		.setAttribute('TEXCOORD_1', (uvs[1] = document.createAccessor()))
-		.setAttribute('TEXCOORD_2', (uvs[2] = document.createAccessor())) // unused
-		.setAttribute('TEXCOORD_3', (uvs[3] = document.createAccessor()));
-	const primB = primA
-		.clone()
-		.setAttribute('TEXCOORD_4', (uvs[4] = document.createAccessor())) // unused
-		.setAttribute('TEXCOORD_5', (uvs[5] = document.createAccessor())); // unused
-	document.createMesh().addPrimitive(primA).addPrimitive(primB);
+		// Primitives.
+		const uvs: Accessor[] = [];
+		const primA = document
+			.createPrimitive()
+			.setMaterial(material)
+			.setAttribute('POSITION', document.createAccessor())
+			.setAttribute('TEXCOORD_0', (uvs[0] = document.createAccessor())) // unused
+			.setAttribute('TEXCOORD_1', (uvs[1] = document.createAccessor()))
+			.setAttribute('TEXCOORD_2', (uvs[2] = document.createAccessor())) // unused
+			.setAttribute('TEXCOORD_3', (uvs[3] = document.createAccessor()));
+		const primB = primA
+			.clone()
+			.setAttribute('TEXCOORD_4', (uvs[4] = document.createAccessor())) // unused
+			.setAttribute('TEXCOORD_5', (uvs[5] = document.createAccessor())); // unused
+		document.createMesh().addPrimitive(primA).addPrimitive(primB);
 
-	await document.transform(prune({ keepAttributes: true, propertyTypes: [PropertyType.ACCESSOR] }));
+		await document.transform(prune({ keepAttributes: true, propertyTypes: [PropertyType.ACCESSOR] }));
 
-	t.deepEqual(
-		uvs.map((a) => a.isDisposed()),
-		[false, false, false, false, false, false],
-		'keeps all texcoords',
-	);
+		deepEqual(
+			uvs.map((a) => a.isDisposed()),
+			[false, false, false, false, false, false],
+			'keeps all texcoords',
+		);
 
-	await document.transform(prune({ keepAttributes: false, propertyTypes: [PropertyType.ACCESSOR] }));
+		await document.transform(prune({ keepAttributes: false, propertyTypes: [PropertyType.ACCESSOR] }));
 
-	t.deepEqual(
-		uvs.map((a) => a.isDisposed()),
-		[true, false, true, false, true, true],
-		'disposes TEXCOORD_0, TEXCOORD_2, TEXCOORD_4, and TEXCOORD_5',
-	);
+		deepEqual(
+			uvs.map((a) => a.isDisposed()),
+			[true, false, true, false, true, true],
+			'disposes TEXCOORD_0, TEXCOORD_2, TEXCOORD_4, and TEXCOORD_5',
+		);
 
-	t.true(primA.getAttribute('TEXCOORD_0') === uvs[1], 'primA.TEXCOORD_0');
-	t.true(primA.getAttribute('TEXCOORD_1') === uvs[3], 'primA.TEXCOORD_1');
-	t.true(primA.getAttribute('TEXCOORD_2') === null, 'primA.TEXCOORD_2 → null');
-	t.true(primA.getAttribute('TEXCOORD_3') === null, 'primA.TEXCOORD_3 → null');
+		ok(primA.getAttribute('TEXCOORD_0') === uvs[1], 'primA.TEXCOORD_0');
+		ok(primA.getAttribute('TEXCOORD_1') === uvs[3], 'primA.TEXCOORD_1');
+		ok(primA.getAttribute('TEXCOORD_2') === null, 'primA.TEXCOORD_2 → null');
+		ok(primA.getAttribute('TEXCOORD_3') === null, 'primA.TEXCOORD_3 → null');
 
-	t.true(primB.getAttribute('TEXCOORD_0') === uvs[1], 'primB.TEXCOORD_0');
-	t.true(primB.getAttribute('TEXCOORD_1') === uvs[3], 'primB.TEXCOORD_1');
-	t.true(primB.getAttribute('TEXCOORD_2') === null, 'primB.TEXCOORD_2 → null');
-	t.true(primB.getAttribute('TEXCOORD_3') === null, 'primB.TEXCOORD_3 → null');
-	t.true(primB.getAttribute('TEXCOORD_4') === null, 'primB.TEXCOORD_4 → null');
-	t.true(primB.getAttribute('TEXCOORD_5') === null, 'primB.TEXCOORD_5 → null');
+		ok(primB.getAttribute('TEXCOORD_0') === uvs[1], 'primB.TEXCOORD_0');
+		ok(primB.getAttribute('TEXCOORD_1') === uvs[3], 'primB.TEXCOORD_1');
+		ok(primB.getAttribute('TEXCOORD_2') === null, 'primB.TEXCOORD_2 → null');
+		ok(primB.getAttribute('TEXCOORD_3') === null, 'primB.TEXCOORD_3 → null');
+		ok(primB.getAttribute('TEXCOORD_4') === null, 'primB.TEXCOORD_4 → null');
+		ok(primB.getAttribute('TEXCOORD_5') === null, 'primB.TEXCOORD_5 → null');
 
-	t.is(material.getBaseColorTextureInfo().getTexCoord(), 0, 'material.baseColorTexture.texCoord = 0');
-	t.is(material.getNormalTextureInfo().getTexCoord(), 1, 'material.normalTexture.texCoord → 1');
-});
+		strictEqual(material.getBaseColorTextureInfo().getTexCoord(), 0, 'material.baseColorTexture.texCoord = 0');
+		strictEqual(material.getNormalTextureInfo().getTexCoord(), 1, 'material.normalTexture.texCoord → 1');
+	});
 
-test('attributes - normals', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('attributes - normals', async () => {
+		const document = new Document().setLogger(logger);
 
-	const unlitExtension = document.createExtension<KHRMaterialsUnlit>(KHRMaterialsUnlit);
-	const material = document.createMaterial();
-	const materialUnlit = document.createMaterial().setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
+		const unlitExtension = document.createExtension<KHRMaterialsUnlit>(KHRMaterialsUnlit);
+		const material = document.createMaterial();
+		const materialUnlit = document
+			.createMaterial()
+			.setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
 
-	const attribute = document.createAccessor().setArray(new Float32Array(12));
-	const primTriangles = document
-		.createPrimitive()
-		.setMaterial(material)
-		.setAttribute('POSITION', attribute)
-		.setAttribute('NORMAL', attribute)
-		.setMode(Primitive.Mode.TRIANGLES);
-	const primPoints = primTriangles.clone().setMode(Primitive.Mode.POINTS);
-	const primUnlit = primTriangles.clone().setMaterial(materialUnlit);
-	const mesh = document.createMesh().addPrimitive(primTriangles).addPrimitive(primPoints).addPrimitive(primUnlit);
-	const node = document.createNode().setMesh(mesh);
-	document.createScene().addChild(node);
+		const attribute = document.createAccessor().setArray(new Float32Array(12));
+		const primTriangles = document
+			.createPrimitive()
+			.setMaterial(material)
+			.setAttribute('POSITION', attribute)
+			.setAttribute('NORMAL', attribute)
+			.setMode(Primitive.Mode.TRIANGLES);
+		const primPoints = primTriangles.clone().setMode(Primitive.Mode.POINTS);
+		const primUnlit = primTriangles.clone().setMaterial(materialUnlit);
+		const mesh = document.createMesh().addPrimitive(primTriangles).addPrimitive(primPoints).addPrimitive(primUnlit);
+		const node = document.createNode().setMesh(mesh);
+		document.createScene().addChild(node);
 
-	await document.transform(prune({ keepAttributes: true, propertyTypes: [PropertyType.ACCESSOR] }));
+		await document.transform(prune({ keepAttributes: true, propertyTypes: [PropertyType.ACCESSOR] }));
 
-	t.deepEqual(primTriangles.listSemantics(), ['POSITION', 'NORMAL'], 'triangles, keepAttributes=true');
-	t.deepEqual(primPoints.listSemantics(), ['POSITION', 'NORMAL'], 'points, keepAttributes=true');
-	t.deepEqual(primUnlit.listSemantics(), ['POSITION', 'NORMAL'], 'unlit, keepAttributes=true');
+		deepEqual(primTriangles.listSemantics(), ['POSITION', 'NORMAL'], 'triangles, keepAttributes=true');
+		deepEqual(primPoints.listSemantics(), ['POSITION', 'NORMAL'], 'points, keepAttributes=true');
+		deepEqual(primUnlit.listSemantics(), ['POSITION', 'NORMAL'], 'unlit, keepAttributes=true');
 
-	await document.transform(prune({ keepAttributes: false, propertyTypes: [PropertyType.ACCESSOR] }));
+		await document.transform(prune({ keepAttributes: false, propertyTypes: [PropertyType.ACCESSOR] }));
 
-	t.deepEqual(primTriangles.listSemantics(), ['POSITION', 'NORMAL'], 'triangles, keepAttributes=false');
-	t.deepEqual(primPoints.listSemantics(), ['POSITION'], 'points, keepAttributes=false');
-	t.deepEqual(primUnlit.listSemantics(), ['POSITION'], 'unlit, keepAttributes=false');
-});
+		deepEqual(primTriangles.listSemantics(), ['POSITION', 'NORMAL'], 'triangles, keepAttributes=false');
+		deepEqual(primPoints.listSemantics(), ['POSITION'], 'points, keepAttributes=false');
+		deepEqual(primUnlit.listSemantics(), ['POSITION'], 'unlit, keepAttributes=false');
+	});
 
-test('solid textures', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('solid textures', async () => {
+		const document = new Document().setLogger(logger);
 
-	const textureNonSolid = document
-		.createTexture()
-		.setImage(await savePixels(PIXELS_NON_SOLID, 'image/png'))
-		.setMimeType('image/png');
-	const textureSolid = document
-		.createTexture()
-		.setImage(await savePixels(PIXELS_SOLID, 'image/png'))
-		.setMimeType('image/png');
-	const textureUnknown = document.createTexture().setImage(new Uint8Array(1)).setMimeType('image/png');
-	const material = document
-		.createMaterial()
-		.setBaseColorTexture(textureNonSolid)
-		.setMetallicRoughnessTexture(textureSolid)
-		.setEmissiveTexture(textureUnknown);
-	const prim = document.createPrimitive().setMaterial(material);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode('A').setMesh(mesh);
-	document.createScene().addChild(node);
+		const textureNonSolid = document
+			.createTexture()
+			.setImage(await savePixels(PIXELS_NON_SOLID, 'image/png'))
+			.setMimeType('image/png');
+		const textureSolid = document
+			.createTexture()
+			.setImage(await savePixels(PIXELS_SOLID, 'image/png'))
+			.setMimeType('image/png');
+		const textureUnknown = document.createTexture().setImage(new Uint8Array(1)).setMimeType('image/png');
+		const material = document
+			.createMaterial()
+			.setBaseColorTexture(textureNonSolid)
+			.setMetallicRoughnessTexture(textureSolid)
+			.setEmissiveTexture(textureUnknown);
+		const prim = document.createPrimitive().setMaterial(material);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode('A').setMesh(mesh);
+		document.createScene().addChild(node);
 
-	await document.transform(prune({ keepSolidTextures: true }));
+		await document.transform(prune({ keepSolidTextures: true }));
 
-	t.false(textureSolid.isDisposed());
-	t.false(textureNonSolid.isDisposed());
-	t.false(textureUnknown.isDisposed());
+		strictEqual(textureSolid.isDisposed(), false);
+		strictEqual(textureNonSolid.isDisposed(), false);
+		strictEqual(textureUnknown.isDisposed(), false);
 
-	await document.transform(prune({ keepSolidTextures: false }));
+		await document.transform(prune({ keepSolidTextures: false }));
 
-	t.true(textureSolid.isDisposed());
-	t.false(textureNonSolid.isDisposed());
-	t.false(textureUnknown.isDisposed());
+		ok(textureSolid.isDisposed());
+		strictEqual(textureNonSolid.isDisposed(), false);
+		strictEqual(textureUnknown.isDisposed(), false);
 
-	t.deepEqual(material.getBaseColorFactor(), [1, 1, 1, 1], 'baseColorFactor');
-	t.deepEqual(material.getEmissiveFactor(), [0, 0, 0], 'baseColorFactor');
-	t.is(material.getRoughnessFactor().toFixed(2), '0.50', 'roughnessFactor');
-	t.is(material.getMetallicFactor().toFixed(2), '0.75', 'metallicFactor');
-	t.is(material.getMetallicRoughnessTexture(), null, 'metallicRoughnessTexture');
+		deepEqual(material.getBaseColorFactor(), [1, 1, 1, 1], 'baseColorFactor');
+		deepEqual(material.getEmissiveFactor(), [0, 0, 0], 'baseColorFactor');
+		strictEqual(material.getRoughnessFactor().toFixed(2), '0.50', 'roughnessFactor');
+		strictEqual(material.getMetallicFactor().toFixed(2), '0.75', 'metallicFactor');
+		strictEqual(material.getMetallicRoughnessTexture(), null, 'metallicRoughnessTexture');
+	});
 });

--- a/packages/functions/test/prune.test.ts
+++ b/packages/functions/test/prune.test.ts
@@ -10,7 +10,7 @@ import { savePixels } from 'ndarray-pixels';
 const PIXELS_SOLID = ndarray(new Uint8Array([128, 128, 192, 1]), [1, 1, 4]);
 const PIXELS_NON_SOLID = ndarray(new Uint8Array([64, 64, 128, 1, 32, 32, 128, 1]), [1, 2, 4]);
 
-describe('prune', () => {
+describe('functions::prune', () => {
 	test('properties', async () => {
 		const doc = new Document().setLogger(logger);
 

--- a/packages/functions/test/quantize.test.ts
+++ b/packages/functions/test/quantize.test.ts
@@ -17,7 +17,7 @@ import { EXTMeshGPUInstancing, KHRMaterialsVolume, type Volume } from '@gltf-tra
 import { quantize } from '@gltf-transform/functions';
 import { logger, round, roundBbox } from '@gltf-transform/test-utils';
 
-describe('quantize', () => {
+describe('functions::quantize', () => {
 	test('noop', async () => {
 		const document = new Document().setLogger(logger);
 		await document.transform(quantize());

--- a/packages/functions/test/quantize.test.ts
+++ b/packages/functions/test/quantize.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, fail, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import {
 	type Accessor,
 	type AnimationChannel,
@@ -14,414 +16,421 @@ import {
 import { EXTMeshGPUInstancing, KHRMaterialsVolume, type Volume } from '@gltf-transform/extensions';
 import { quantize } from '@gltf-transform/functions';
 import { logger, round, roundBbox } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('noop', async (t) => {
-	const document = new Document().setLogger(logger);
-	await document.transform(quantize());
+describe('quantize', () => {
+	test('noop', async () => {
+		const document = new Document().setLogger(logger);
+		await document.transform(quantize());
 
-	t.false(
-		document
-			.getRoot()
-			.listExtensionsUsed()
-			.some((ext) => ext.extensionName === 'KHR_mesh_quantization'),
-		'skips extension',
-	);
-});
-
-test('exclusions', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const prim = createPrimitive(doc);
-
-	await doc.transform(quantize({ pattern: /^(?!TEXCOORD_0$|NORMAL$)/ }));
-
-	t.truthy(prim.getAttribute('POSITION').getArray() instanceof Int16Array, 'position → Int16Array');
-	t.truthy(prim.getAttribute('TEXCOORD_0').getArray() instanceof Float32Array, 'uv → unchanged');
-	t.truthy(prim.getAttribute('NORMAL').getArray() instanceof Float32Array, 'normal → unchanged');
-
-	await doc.transform(quantize());
-
-	t.truthy(prim.getAttribute('TEXCOORD_0').getArray() instanceof Uint16Array, 'uv → Uint16Array');
-	t.truthy(prim.getAttribute('NORMAL').getArray() instanceof Int16Array, 'normal → Int16Array');
-});
-
-test('mesh volume', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const scene = createScene(doc);
-	const nodeA = doc.getRoot().listNodes()[0];
-	const nodeB = doc.getRoot().listNodes()[1];
-	const primA = doc.getRoot().listMeshes()[0].listPrimitives()[0];
-	const primB = doc.getRoot().listMeshes()[1].listPrimitives()[0];
-
-	const bboxSceneCopy = getBounds(scene);
-	const bboxNodeACopy = getBounds(nodeA);
-	const bboxNodeBCopy = getBounds(nodeB);
-	const bboxMeshACopy = primBounds(primA);
-	const bboxMeshBCopy = primBounds(primB);
-
-	t.deepEqual(bboxSceneCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
-	t.deepEqual(bboxNodeACopy, { min: [20, 10, 0], max: [25, 15, 0] }, 'original bbox - nodeA');
-	t.deepEqual(bboxNodeBCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - nodeB');
-	t.deepEqual(bboxMeshACopy, { min: [10, 10, 0], max: [15, 15, 0] }, 'original bbox - meshA');
-	t.deepEqual(bboxMeshBCopy, { min: [0, 0, 0], max: [100, 100, 100] }, 'original bbox - meshB');
-
-	await doc.transform(quantize({ quantizePosition: 14 }));
-
-	const bboxScene = getBounds(scene);
-	const bboxNodeA = getBounds(nodeA);
-	const bboxNodeB = getBounds(nodeB);
-	const bboxMeshA = primBounds(primA);
-	const bboxMeshB = primBounds(primB);
-
-	t.deepEqual(bboxScene, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - scene');
-	t.deepEqual(bboxNodeA, { min: [20, 10, 0], max: [25, 15, 0] }, 'bbox - nodeA');
-	t.deepEqual(bboxNodeB, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - nodeB');
-	t.deepEqual(bboxMeshA, { min: [-1, -1, 0], max: [1, 1, 0] }, 'bbox - meshA');
-	t.deepEqual(bboxMeshB, { min: [-1, -1, -1], max: [1, 1, 1] }, 'bbox - meshB');
-	t.is(doc.getRoot().listNodes().length, 2, 'total nodes');
-	t.is(doc.getRoot().listAccessors().length, 2, 'total accessors');
-	t.is(doc.getRoot().listSkins().length, 0, 'total skins');
-});
-
-test('scene volume', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const scene = createScene(doc);
-	const nodeA = doc.getRoot().listNodes()[0];
-	const nodeB = doc.getRoot().listNodes()[1];
-	const primA = doc.getRoot().listMeshes()[0].listPrimitives()[0];
-	const primB = doc.getRoot().listMeshes()[1].listPrimitives()[0];
-
-	const bboxSceneCopy = getBounds(scene);
-	const bboxNodeACopy = getBounds(nodeA);
-	const bboxNodeBCopy = getBounds(nodeB);
-	const bboxMeshACopy = primBounds(primA);
-	const bboxMeshBCopy = primBounds(primB);
-
-	t.deepEqual(bboxSceneCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
-	t.deepEqual(bboxNodeACopy, { min: [20, 10, 0], max: [25, 15, 0] }, 'original bbox - nodeA');
-	t.deepEqual(bboxNodeBCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - nodeB');
-	t.deepEqual(bboxMeshACopy, { min: [10, 10, 0], max: [15, 15, 0] }, 'original bbox - meshA');
-	t.deepEqual(bboxMeshBCopy, { min: [0, 0, 0], max: [100, 100, 100] }, 'original bbox - meshB');
-
-	await doc.transform(
-		quantize({
-			quantizePosition: 14,
-			quantizationVolume: 'scene',
-		}),
-	);
-
-	const bboxScene = roundBbox(getBounds(scene), 3);
-	const bboxNodeA = roundBbox(getBounds(nodeA), 2);
-	const bboxNodeB = roundBbox(getBounds(nodeB), 3);
-	const bboxMeshA = roundBbox(primBounds(primA), 3);
-	const bboxMeshB = roundBbox(primBounds(primB), 3);
-
-	t.deepEqual(bboxScene, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - scene');
-	t.deepEqual(bboxNodeA, { min: [20, 10, 0], max: [25, 15, 0] }, 'bbox - nodeA');
-	t.deepEqual(bboxNodeB, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - nodeB');
-	t.deepEqual(bboxMeshA, { min: [-0.8, -0.8, -1], max: [-0.7, -0.7, -1] }, 'bbox - meshA');
-	t.deepEqual(bboxMeshB, { min: [-1, -1, -1], max: [1, 1, 1] }, 'bbox - meshB');
-	t.is(doc.getRoot().listNodes().length, 2, 'total nodes');
-	t.is(doc.getRoot().listAccessors().length, 2, 'total accessors');
-	t.is(doc.getRoot().listSkins().length, 0, 'total skins');
-});
-
-test('skinned mesh', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const scene = createScene(doc);
-	const nodeA = doc.getRoot().listNodes()[0];
-	const nodeB = doc.getRoot().listNodes()[1];
-	const primA = doc.getRoot().listMeshes()[0].listPrimitives()[0];
-	const primB = doc.getRoot().listMeshes()[1].listPrimitives()[0];
-
-	const bboxSceneCopy = getBounds(scene);
-	const bboxNodeACopy = getBounds(nodeA);
-	const bboxNodeBCopy = getBounds(nodeB);
-	const bboxMeshACopy = primBounds(primA);
-	const bboxMeshBCopy = primBounds(primB);
-
-	t.deepEqual(bboxSceneCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
-	t.deepEqual(bboxNodeACopy, { min: [20, 10, 0], max: [25, 15, 0] }, 'original bbox - nodeA');
-	t.deepEqual(bboxNodeBCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - nodeB');
-	t.deepEqual(bboxMeshACopy, { min: [10, 10, 0], max: [15, 15, 0] }, 'original bbox - meshA');
-	t.deepEqual(bboxMeshBCopy, { min: [0, 0, 0], max: [100, 100, 100] }, 'original bbox - meshB');
-
-	const ibm = doc
-		.createAccessor()
-		.setType('MAT4')
-		.setArray(
-			new Float32Array([
-				1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
-			]),
+		strictEqual(
+			document
+				.getRoot()
+				.listExtensionsUsed()
+				.some((ext) => ext.extensionName === 'KHR_mesh_quantization'),
+			false,
+			'skips extension',
 		);
-	nodeB.setSkin(doc.createSkin().setInverseBindMatrices(ibm));
+	});
 
-	await doc.transform(quantize({ quantizePosition: 14 }));
+	test('exclusions', async () => {
+		const doc = new Document().setLogger(logger);
+		const prim = createPrimitive(doc);
 
-	const bboxScene = getBounds(scene);
-	const bboxNodeA = getBounds(nodeA);
-	const bboxNodeB = getBounds(nodeB);
-	const bboxMeshA = primBounds(primA);
-	const bboxMeshB = primBounds(primB);
+		await doc.transform(quantize({ pattern: /^(?!TEXCOORD_0$|NORMAL$)/ }));
 
-	// NodeA now affects scene bounds, because getBounds() does not check IBMs.
-	t.deepEqual(bboxScene, { min: [-0.5, -0.5, -0.5], max: [25, 15, 0.5] }, 'bbox - scene');
-	t.deepEqual(bboxNodeA, { min: [20, 10, 0], max: [25, 15, 0] }, 'bbox - nodeA');
-	t.deepEqual(bboxNodeB, { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] }, 'bbox - nodeB');
-	t.deepEqual(bboxMeshA, { min: [-1, -1, 0], max: [1, 1, 0] }, 'bbox - meshA');
-	t.deepEqual(bboxMeshB, { min: [-1, -1, -1], max: [1, 1, 1] }, 'bbox - meshB');
-	t.deepEqual(
-		Array.from(nodeB.getSkin().getInverseBindMatrices().getArray()),
-		[50, 0, 0, 0, 0, 50, 0, 0, 0, 0, 50, 0, 50, 50, 50, 1, 50, 0, 0, 0, 0, 50, 0, 0, 0, 0, 50, 0, 50, 50, 50, 1],
-		'ibm - meshB',
-	);
-	t.is(doc.getRoot().listNodes().length, 2, 'total nodes');
-	t.is(doc.getRoot().listAccessors().length, 3, 'total accessors');
-	t.is(doc.getRoot().listSkins().length, 1, 'total skins');
-});
+		ok(prim.getAttribute('POSITION').getArray() instanceof Int16Array, 'position → Int16Array');
+		ok(prim.getAttribute('TEXCOORD_0').getArray() instanceof Float32Array, 'uv → unchanged');
+		ok(prim.getAttribute('NORMAL').getArray() instanceof Float32Array, 'normal → unchanged');
 
-test('morph targets', async (t) => {
-	const doc = new Document().setLogger(logger);
+		await doc.transform(quantize());
 
-	// Note: Neither prim.POSITION nor target.POSITION includes the origin (<0,0,0>),
-	// but it MUST be included in the quantization volume to quantize targets correctly.
-	const target = doc.createPrimitiveTarget().setAttribute(
-		'POSITION',
-		doc
+		ok(prim.getAttribute('TEXCOORD_0').getArray() instanceof Uint16Array, 'uv → Uint16Array');
+		ok(prim.getAttribute('NORMAL').getArray() instanceof Int16Array, 'normal → Int16Array');
+	});
+
+	test('mesh volume', async () => {
+		const doc = new Document().setLogger(logger);
+		const scene = createScene(doc);
+		const nodeA = doc.getRoot().listNodes()[0];
+		const nodeB = doc.getRoot().listNodes()[1];
+		const primA = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+		const primB = doc.getRoot().listMeshes()[1].listPrimitives()[0];
+
+		const bboxSceneCopy = getBounds(scene);
+		const bboxNodeACopy = getBounds(nodeA);
+		const bboxNodeBCopy = getBounds(nodeB);
+		const bboxMeshACopy = primBounds(primA);
+		const bboxMeshBCopy = primBounds(primB);
+
+		deepEqual(bboxSceneCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
+		deepEqual(bboxNodeACopy, { min: [20, 10, 0], max: [25, 15, 0] }, 'original bbox - nodeA');
+		deepEqual(bboxNodeBCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - nodeB');
+		deepEqual(bboxMeshACopy, { min: [10, 10, 0], max: [15, 15, 0] }, 'original bbox - meshA');
+		deepEqual(bboxMeshBCopy, { min: [0, 0, 0], max: [100, 100, 100] }, 'original bbox - meshB');
+
+		await doc.transform(quantize({ quantizePosition: 14 }));
+
+		const bboxScene = getBounds(scene);
+		const bboxNodeA = getBounds(nodeA);
+		const bboxNodeB = getBounds(nodeB);
+		const bboxMeshA = primBounds(primA);
+		const bboxMeshB = primBounds(primB);
+
+		deepEqual(bboxScene, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - scene');
+		deepEqual(bboxNodeA, { min: [20, 10, 0], max: [25, 15, 0] }, 'bbox - nodeA');
+		deepEqual(bboxNodeB, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - nodeB');
+		deepEqual(bboxMeshA, { min: [-1, -1, 0], max: [1, 1, 0] }, 'bbox - meshA');
+		deepEqual(bboxMeshB, { min: [-1, -1, -1], max: [1, 1, 1] }, 'bbox - meshB');
+		strictEqual(doc.getRoot().listNodes().length, 2, 'total nodes');
+		strictEqual(doc.getRoot().listAccessors().length, 2, 'total accessors');
+		strictEqual(doc.getRoot().listSkins().length, 0, 'total skins');
+	});
+
+	test('scene volume', async () => {
+		const doc = new Document().setLogger(logger);
+		const scene = createScene(doc);
+		const nodeA = doc.getRoot().listNodes()[0];
+		const nodeB = doc.getRoot().listNodes()[1];
+		const primA = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+		const primB = doc.getRoot().listMeshes()[1].listPrimitives()[0];
+
+		const bboxSceneCopy = getBounds(scene);
+		const bboxNodeACopy = getBounds(nodeA);
+		const bboxNodeBCopy = getBounds(nodeB);
+		const bboxMeshACopy = primBounds(primA);
+		const bboxMeshBCopy = primBounds(primB);
+
+		deepEqual(bboxSceneCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
+		deepEqual(bboxNodeACopy, { min: [20, 10, 0], max: [25, 15, 0] }, 'original bbox - nodeA');
+		deepEqual(bboxNodeBCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - nodeB');
+		deepEqual(bboxMeshACopy, { min: [10, 10, 0], max: [15, 15, 0] }, 'original bbox - meshA');
+		deepEqual(bboxMeshBCopy, { min: [0, 0, 0], max: [100, 100, 100] }, 'original bbox - meshB');
+
+		await doc.transform(
+			quantize({
+				quantizePosition: 14,
+				quantizationVolume: 'scene',
+			}),
+		);
+
+		const bboxScene = roundBbox(getBounds(scene), 3);
+		const bboxNodeA = roundBbox(getBounds(nodeA), 2);
+		const bboxNodeB = roundBbox(getBounds(nodeB), 3);
+		const bboxMeshA = roundBbox(primBounds(primA), 3);
+		const bboxMeshB = roundBbox(primBounds(primB), 3);
+
+		deepEqual(bboxScene, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - scene');
+		deepEqual(bboxNodeA, { min: [20, 10, 0], max: [25, 15, 0] }, 'bbox - nodeA');
+		deepEqual(bboxNodeB, { min: [0, 0, 0], max: [50, 50, 50] }, 'bbox - nodeB');
+		deepEqual(bboxMeshA, { min: [-0.8, -0.8, -1], max: [-0.7, -0.7, -1] }, 'bbox - meshA');
+		deepEqual(bboxMeshB, { min: [-1, -1, -1], max: [1, 1, 1] }, 'bbox - meshB');
+		strictEqual(doc.getRoot().listNodes().length, 2, 'total nodes');
+		strictEqual(doc.getRoot().listAccessors().length, 2, 'total accessors');
+		strictEqual(doc.getRoot().listSkins().length, 0, 'total skins');
+	});
+
+	test('skinned mesh', async () => {
+		const doc = new Document().setLogger(logger);
+		const scene = createScene(doc);
+		const nodeA = doc.getRoot().listNodes()[0];
+		const nodeB = doc.getRoot().listNodes()[1];
+		const primA = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+		const primB = doc.getRoot().listMeshes()[1].listPrimitives()[0];
+
+		const bboxSceneCopy = getBounds(scene);
+		const bboxNodeACopy = getBounds(nodeA);
+		const bboxNodeBCopy = getBounds(nodeB);
+		const bboxMeshACopy = primBounds(primA);
+		const bboxMeshBCopy = primBounds(primB);
+
+		deepEqual(bboxSceneCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - scene');
+		deepEqual(bboxNodeACopy, { min: [20, 10, 0], max: [25, 15, 0] }, 'original bbox - nodeA');
+		deepEqual(bboxNodeBCopy, { min: [0, 0, 0], max: [50, 50, 50] }, 'original bbox - nodeB');
+		deepEqual(bboxMeshACopy, { min: [10, 10, 0], max: [15, 15, 0] }, 'original bbox - meshA');
+		deepEqual(bboxMeshBCopy, { min: [0, 0, 0], max: [100, 100, 100] }, 'original bbox - meshB');
+
+		const ibm = doc
+			.createAccessor()
+			.setType('MAT4')
+			.setArray(
+				new Float32Array([
+					1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+				]),
+			);
+		nodeB.setSkin(doc.createSkin().setInverseBindMatrices(ibm));
+
+		await doc.transform(quantize({ quantizePosition: 14 }));
+
+		const bboxScene = getBounds(scene);
+		const bboxNodeA = getBounds(nodeA);
+		const bboxNodeB = getBounds(nodeB);
+		const bboxMeshA = primBounds(primA);
+		const bboxMeshB = primBounds(primB);
+
+		// NodeA now affects scene bounds, because getBounds() does not check IBMs.
+		deepEqual(bboxScene, { min: [-0.5, -0.5, -0.5], max: [25, 15, 0.5] }, 'bbox - scene');
+		deepEqual(bboxNodeA, { min: [20, 10, 0], max: [25, 15, 0] }, 'bbox - nodeA');
+		deepEqual(bboxNodeB, { min: [-0.5, -0.5, -0.5], max: [0.5, 0.5, 0.5] }, 'bbox - nodeB');
+		deepEqual(bboxMeshA, { min: [-1, -1, 0], max: [1, 1, 0] }, 'bbox - meshA');
+		deepEqual(bboxMeshB, { min: [-1, -1, -1], max: [1, 1, 1] }, 'bbox - meshB');
+		deepEqual(
+			Array.from(nodeB.getSkin().getInverseBindMatrices().getArray()),
+			[
+				50, 0, 0, 0, 0, 50, 0, 0, 0, 0, 50, 0, 50, 50, 50, 1, 50, 0, 0, 0, 0, 50, 0, 0, 0, 0, 50, 0, 50, 50, 50,
+				1,
+			],
+			'ibm - meshB',
+		);
+		strictEqual(doc.getRoot().listNodes().length, 2, 'total nodes');
+		strictEqual(doc.getRoot().listAccessors().length, 3, 'total accessors');
+		strictEqual(doc.getRoot().listSkins().length, 1, 'total skins');
+	});
+
+	test('morph targets', async () => {
+		const doc = new Document().setLogger(logger);
+
+		// Note: Neither prim.POSITION nor target.POSITION includes the origin (<0,0,0>),
+		// but it MUST be included in the quantization volume to quantize targets correctly.
+		const target = doc.createPrimitiveTarget().setAttribute(
+			'POSITION',
+			doc
+				.createAccessor()
+				.setType('VEC3')
+				.setArray(new Float32Array([5, 5, 5, 10, 5, 5, 10, 20, 5, 10, 5, 30, 40, 40, 40])),
+		);
+		const prim = createPrimitive(doc).addTarget(target);
+		prim.getAttribute('POSITION').setArray(
+			new Float32Array([10, 10, 5, 10, 15, 5, 15, 10, 5, 15, 15, 5, 10, 10, 5]),
+		);
+
+		const scene = doc.getRoot().listScenes().pop();
+
+		const bboxSceneCopy = getBounds(scene);
+		const bboxMeshCopy = primBounds(prim);
+		const bboxTargetCopy = primBounds(target);
+
+		deepEqual(bboxSceneCopy, { min: [10, 10, 5], max: [15, 15, 5] }, 'original bbox - scene');
+		deepEqual(bboxMeshCopy, { min: [10, 10, 5], max: [15, 15, 5] }, 'original bbox - mesh');
+		deepEqual(bboxTargetCopy, { min: [5, 5, 5], max: [40, 40, 40] }, 'original bbox - target');
+
+		await doc.transform(quantize({ quantizePosition: 14 }));
+
+		const bboxScene = roundBbox(getBounds(scene), 2);
+		const bboxMesh = roundBbox(primBounds(prim), 3);
+		const bboxTarget = roundBbox(primBounds(target), 3);
+
+		deepEqual(bboxScene, { min: [10, 10, 5], max: [15, 15, 5] }, 'bbox - scene');
+		deepEqual(bboxMesh, { min: [-0.75, -0.75, -0.875], max: [-0.625, -0.625, -0.875] }, 'bbox - mesh');
+		deepEqual(bboxTarget, { min: [0.125, 0.125, 0.125], max: [1, 1, 1] }, 'bbox - target');
+	});
+
+	test('attributes', async () => {
+		const doc = new Document().setLogger(logger);
+		const prim = createPrimitive(doc);
+		const normalCopy = prim.getAttribute('NORMAL').clone();
+		const tangentCopy = prim.getAttribute('TANGENT').clone();
+		const uvCopy = prim.getAttribute('TEXCOORD_0').clone();
+		const colorCopy = prim.getAttribute('COLOR_0').clone();
+		const jointsCopy = prim.getAttribute('JOINTS_0').clone();
+		const weightsCopy = prim.getAttribute('WEIGHTS_0').clone();
+		const tempCopy = prim.getAttribute('_TEMPERATURE').clone();
+
+		await doc.transform(
+			quantize({
+				quantizeNormal: 12,
+				quantizeTexcoord: 12,
+				quantizeColor: 8,
+				quantizeWeight: 10,
+				quantizeGeneric: 10,
+			}),
+		);
+
+		const normal = prim.getAttribute('NORMAL');
+		const tangent = prim.getAttribute('TANGENT');
+		const uv = prim.getAttribute('TEXCOORD_0');
+		const color = prim.getAttribute('COLOR_0');
+		const joints = prim.getAttribute('JOINTS_0');
+		const weights = prim.getAttribute('WEIGHTS_0');
+		const temp = prim.getAttribute('_TEMPERATURE');
+
+		if (normalCopy.getNormalized() || !(normalCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of normals was modified');
+		}
+		if (tangentCopy.getNormalized() || !(tangentCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of tangents was modified');
+		}
+		if (uvCopy.getNormalized() || !(uvCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of UVs was modified');
+		}
+		if (colorCopy.getNormalized() || !(colorCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of colors was modified');
+		}
+		if (jointsCopy.getNormalized() || !(jointsCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of joints was modified');
+		}
+		if (weightsCopy.getNormalized() || !(weightsCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of weights was modified');
+		}
+		if (tempCopy.getNormalized() || !(tempCopy.getArray() instanceof Float32Array)) {
+			fail('Backup copy of custom attribute was modified');
+		}
+
+		ok(normal.getNormalized(), 'normal → normalized');
+		ok(normal.getArray() instanceof Int16Array, 'normal → Int16Array');
+		elementPairs(normal, normalCopy, round(2)).forEach(([a, b], i) => deepEqual(a, b, `normal value #${i + 1}`));
+
+		ok(tangent.getNormalized(), 'tangent → normalized');
+		ok(tangent.getArray() instanceof Int16Array, 'tangent → Int16Array');
+		elementPairs(tangent, tangentCopy, round(2)).forEach(([a, b], i) => deepEqual(a, b, `tangent value #${i + 1}`));
+
+		ok(uv.getNormalized(), 'uv → normalized');
+		ok(uv.getArray() instanceof Uint16Array, 'uv → Uint16Array');
+		elementPairs(uv, uvCopy, round(3)).forEach(([a, b], i) => deepEqual(a, b, `uv value #${i + 1}`));
+
+		ok(color.getNormalized(), 'color → normalized');
+		ok(color.getArray() instanceof Uint8Array, 'color → Uint8Array');
+		elementPairs(color, colorCopy, round(1)).forEach(([a, b], i) => deepEqual(a, b, `color value #${i + 1}`));
+
+		strictEqual(joints.getNormalized(), false, 'joints → normalized');
+		ok(joints.getArray() instanceof Uint8Array, 'joints → Uint8Array');
+		elementPairs(joints, jointsCopy, round(6)).forEach(([a, b], i) => deepEqual(a, b, `joints value #${i + 1}`));
+		ok(weights.getNormalized(), 'weights → normalized');
+		ok(weights.getArray() instanceof Uint16Array, 'weights → Uint16Array');
+		elementPairs(weights, weightsCopy, round(6)).forEach(([a, b], i) => deepEqual(a, b, `weights value #${i + 1}`));
+
+		ok(temp.getNormalized(), 'custom → normalized');
+		ok(temp.getArray() instanceof Uint16Array, 'custom → Uint16Array');
+		elementPairs(temp, tempCopy, round(3)).forEach(([a, b], i) => deepEqual(a, b, `custom value #${i + 1}`));
+	});
+
+	test('indices', async () => {
+		const doc = new Document().setLogger(logger);
+		const prim = createPrimitive(doc);
+		prim.setIndices(
+			doc
+				.createAccessor()
+				.setType('SCALAR')
+				.setArray(new Uint32Array([0, 1, 2, 3, 4])),
+		);
+		const indicesCopy = prim.getIndices().clone();
+
+		await doc.transform(quantize());
+
+		const indices = prim.getIndices();
+
+		if (indicesCopy.getNormalized() || !(indicesCopy.getArray() instanceof Uint32Array)) {
+			fail('Backup copy of indices was modified');
+		}
+
+		strictEqual(indices.getNormalized(), false, 'indices → not normalized');
+		ok(indices.getArray() instanceof Uint16Array, 'indices → Uint16Array');
+		elementPairs(indices, indicesCopy, round(8)).forEach(([a, b], i) => deepEqual(a, b, `indices value #${i + 1}`));
+	});
+
+	test('skinned mesh parenting', async () => {
+		let doc: Document;
+		let mesh: Mesh, node: Node;
+		let scaleChannel: AnimationChannel, weightsChannel: AnimationChannel;
+
+		// (1) Don't reparent meshes or retarget non-TRS animation when not required.
+
+		doc = new Document().setLogger(logger);
+		createScene(doc);
+		node = doc.getRoot().listNodes()[0];
+		mesh = node.getMesh();
+		weightsChannel = doc.createAnimationChannel().setTargetNode(node).setTargetPath('weights');
+		doc.createAnimation().addChannel(weightsChannel);
+
+		await doc.transform(quantize());
+
+		strictEqual(node.getMesh(), mesh, "don't reparent mesh");
+		strictEqual(weightsChannel.getTargetNode(), node, "don't retarget non-TRS animation");
+
+		// (2) Reparent meshes and retarget non-TRS animation when parent is affected by TRS animation.
+
+		doc = new Document().setLogger(logger);
+		createScene(doc);
+		node = doc.getRoot().listNodes()[0];
+		mesh = node.getMesh();
+		scaleChannel = doc.createAnimationChannel().setTargetNode(node).setTargetPath('scale');
+		weightsChannel = doc.createAnimationChannel().setTargetNode(node).setTargetPath('weights');
+		doc.createAnimation().addChannel(weightsChannel).addChannel(scaleChannel);
+
+		await doc.transform(quantize());
+
+		strictEqual(node.getMesh(), null, 'reparent mesh');
+		strictEqual(weightsChannel.getTargetNode(), node.listChildren()[0], 'retarget non-TRS animation');
+		strictEqual(scaleChannel.getTargetNode(), node, "don't retarget TRS animation");
+	});
+
+	test('instancing', async () => {
+		const doc = new Document().setLogger(logger);
+		createScene(doc);
+		const node = doc.getRoot().listNodes()[0];
+		const mesh = node.getMesh();
+		const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
+		const batchTranslation = doc
 			.createAccessor()
 			.setType('VEC3')
-			.setArray(new Float32Array([5, 5, 5, 10, 5, 5, 10, 20, 5, 10, 5, 30, 40, 40, 40])),
-	);
-	const prim = createPrimitive(doc).addTarget(target);
-	prim.getAttribute('POSITION').setArray(new Float32Array([10, 10, 5, 10, 15, 5, 15, 10, 5, 15, 15, 5, 10, 10, 5]));
+			.setArray(new Float32Array([0, 0, 0, 1, 1, 1]));
+		let batch = batchExtension.createInstancedMesh().setAttribute('TRANSLATION', batchTranslation);
+		node.setExtension('EXT_mesh_gpu_instancing', batch);
 
-	const scene = doc.getRoot().listScenes().pop();
+		await doc.transform(quantize());
 
-	const bboxSceneCopy = getBounds(scene);
-	const bboxMeshCopy = primBounds(prim);
-	const bboxTargetCopy = primBounds(target);
+		batch = node.getExtension('EXT_mesh_gpu_instancing');
 
-	t.deepEqual(bboxSceneCopy, { min: [10, 10, 5], max: [15, 15, 5] }, 'original bbox - scene');
-	t.deepEqual(bboxMeshCopy, { min: [10, 10, 5], max: [15, 15, 5] }, 'original bbox - mesh');
-	t.deepEqual(bboxTargetCopy, { min: [5, 5, 5], max: [40, 40, 40] }, 'original bbox - target');
+		strictEqual(node.getMesh(), mesh, 'node hash mesh');
+		deepEqual(node.getTranslation(), [10, 0, 0], 'node has original translation');
+		deepEqual(node.getScale(), [1, 1, 1], 'node has original scale');
+		ok(batch, 'node has instancing extension');
+		deepEqual(
+			Array.from(batch.getAttribute('TRANSLATION').getArray()),
+			[12.5, 12.5, 0, 13.5, 13.5, 1],
+			'batch translation includes quantization transform',
+		);
+		deepEqual(
+			Array.from(batch.getAttribute('SCALE').getArray()),
+			[2.5, 2.5, 2.5, 2.5, 2.5, 2.5],
+			'batch scale added to attributes',
+		);
+	});
 
-	await doc.transform(quantize({ quantizePosition: 14 }));
+	test('volumetric materials', async () => {
+		const doc = new Document().setLogger(logger);
+		createScene(doc);
+		const primA = doc.getRoot().listNodes()[0].getMesh().listPrimitives()[0];
+		const primB = doc.getRoot().listNodes()[1].getMesh().listPrimitives()[0];
 
-	const bboxScene = roundBbox(getBounds(scene), 2);
-	const bboxMesh = roundBbox(primBounds(prim), 3);
-	const bboxTarget = roundBbox(primBounds(target), 3);
+		// Add volumetric material (thickness is in local units).
+		const volumeExtension = doc.createExtension(KHRMaterialsVolume);
+		const volume = volumeExtension.createVolume().setThicknessFactor(1.0);
+		const material = doc.createMaterial().setExtension('KHR_materials_volume', volume);
+		primA.setMaterial(material);
+		primB.setMaterial(material);
 
-	t.deepEqual(bboxScene, { min: [10, 10, 5], max: [15, 15, 5] }, 'bbox - scene');
-	t.deepEqual(bboxMesh, { min: [-0.75, -0.75, -0.875], max: [-0.625, -0.625, -0.875] }, 'bbox - mesh');
-	t.deepEqual(bboxTarget, { min: [0.125, 0.125, 0.125], max: [1, 1, 1] }, 'bbox - target');
-});
+		await doc.transform(quantize());
 
-test('attributes', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const prim = createPrimitive(doc);
-	const normalCopy = prim.getAttribute('NORMAL').clone();
-	const tangentCopy = prim.getAttribute('TANGENT').clone();
-	const uvCopy = prim.getAttribute('TEXCOORD_0').clone();
-	const colorCopy = prim.getAttribute('COLOR_0').clone();
-	const jointsCopy = prim.getAttribute('JOINTS_0').clone();
-	const weightsCopy = prim.getAttribute('WEIGHTS_0').clone();
-	const tempCopy = prim.getAttribute('_TEMPERATURE').clone();
+		ok(primA.getMaterial() !== material, 'new material for prim A');
+		ok(primB.getMaterial() !== material, 'new material for prim B');
+		ok(material.isDisposed(), 'dispose old material');
+		strictEqual(doc.getRoot().listMaterials().length, 2, 'material count = 2');
 
-	await doc.transform(
-		quantize({
-			quantizeNormal: 12,
-			quantizeTexcoord: 12,
-			quantizeColor: 8,
-			quantizeWeight: 10,
-			quantizeGeneric: 10,
-		}),
-	);
+		const volumeA = primA.getMaterial().getExtension<Volume>('KHR_materials_volume');
+		const volumeB = primB.getMaterial().getExtension<Volume>('KHR_materials_volume');
+		strictEqual(volumeA.getThicknessFactor(), 1 / 2.5, 'volumeA.thickness');
+		strictEqual(volumeB.getThicknessFactor(), 1 / 50, 'volumeB.thickness');
+	});
 
-	const normal = prim.getAttribute('NORMAL');
-	const tangent = prim.getAttribute('TANGENT');
-	const uv = prim.getAttribute('TEXCOORD_0');
-	const color = prim.getAttribute('COLOR_0');
-	const joints = prim.getAttribute('JOINTS_0');
-	const weights = prim.getAttribute('WEIGHTS_0');
-	const temp = prim.getAttribute('_TEMPERATURE');
+	test('no side effects', async () => {
+		const document = new Document();
+		const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+		attributeA.clone();
 
-	if (normalCopy.getNormalized() || !(normalCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of normals was modified');
-	}
-	if (tangentCopy.getNormalized() || !(tangentCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of tangents was modified');
-	}
-	if (uvCopy.getNormalized() || !(uvCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of UVs was modified');
-	}
-	if (colorCopy.getNormalized() || !(colorCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of colors was modified');
-	}
-	if (jointsCopy.getNormalized() || !(jointsCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of joints was modified');
-	}
-	if (weightsCopy.getNormalized() || !(weightsCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of weights was modified');
-	}
-	if (tempCopy.getNormalized() || !(tempCopy.getArray() instanceof Float32Array)) {
-		t.fail('Backup copy of custom attribute was modified');
-	}
+		await document.transform(quantize({ cleanup: false }));
 
-	t.truthy(normal.getNormalized(), 'normal → normalized');
-	t.truthy(normal.getArray() instanceof Int16Array, 'normal → Int16Array');
-	elementPairs(normal, normalCopy, round(2)).forEach(([a, b], i) => t.deepEqual(a, b, `normal value #${i + 1}`));
-
-	t.truthy(tangent.getNormalized(), 'tangent → normalized');
-	t.truthy(tangent.getArray() instanceof Int16Array, 'tangent → Int16Array');
-	elementPairs(tangent, tangentCopy, round(2)).forEach(([a, b], i) => t.deepEqual(a, b, `tangent value #${i + 1}`));
-
-	t.truthy(uv.getNormalized(), 'uv → normalized');
-	t.truthy(uv.getArray() instanceof Uint16Array, 'uv → Uint16Array');
-	elementPairs(uv, uvCopy, round(3)).forEach(([a, b], i) => t.deepEqual(a, b, `uv value #${i + 1}`));
-
-	t.truthy(color.getNormalized(), 'color → normalized');
-	t.truthy(color.getArray() instanceof Uint8Array, 'color → Uint8Array');
-	elementPairs(color, colorCopy, round(1)).forEach(([a, b], i) => t.deepEqual(a, b, `color value #${i + 1}`));
-
-	t.falsy(joints.getNormalized(), 'joints → normalized');
-	t.truthy(joints.getArray() instanceof Uint8Array, 'joints → Uint8Array');
-	elementPairs(joints, jointsCopy, round(6)).forEach(([a, b], i) => t.deepEqual(a, b, `joints value #${i + 1}`));
-	t.truthy(weights.getNormalized(), 'weights → normalized');
-	t.truthy(weights.getArray() instanceof Uint16Array, 'weights → Uint16Array');
-	elementPairs(weights, weightsCopy, round(6)).forEach(([a, b], i) => t.deepEqual(a, b, `weights value #${i + 1}`));
-
-	t.truthy(temp.getNormalized(), 'custom → normalized');
-	t.truthy(temp.getArray() instanceof Uint16Array, 'custom → Uint16Array');
-	elementPairs(temp, tempCopy, round(3)).forEach(([a, b], i) => t.deepEqual(a, b, `custom value #${i + 1}`));
-});
-
-test('indices', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const prim = createPrimitive(doc);
-	prim.setIndices(
-		doc
-			.createAccessor()
-			.setType('SCALAR')
-			.setArray(new Uint32Array([0, 1, 2, 3, 4])),
-	);
-	const indicesCopy = prim.getIndices().clone();
-
-	await doc.transform(quantize());
-
-	const indices = prim.getIndices();
-
-	if (indicesCopy.getNormalized() || !(indicesCopy.getArray() instanceof Uint32Array)) {
-		t.fail('Backup copy of indices was modified');
-	}
-
-	t.falsy(indices.getNormalized(), 'indices → not normalized');
-	t.truthy(indices.getArray() instanceof Uint16Array, 'indices → Uint16Array');
-	elementPairs(indices, indicesCopy, round(8)).forEach(([a, b], i) => t.deepEqual(a, b, `indices value #${i + 1}`));
-});
-
-test('skinned mesh parenting', async (t) => {
-	let doc: Document;
-	let mesh: Mesh, node: Node;
-	let scaleChannel: AnimationChannel, weightsChannel: AnimationChannel;
-
-	// (1) Don't reparent meshes or retarget non-TRS animation when not required.
-
-	doc = new Document().setLogger(logger);
-	createScene(doc);
-	node = doc.getRoot().listNodes()[0];
-	mesh = node.getMesh();
-	weightsChannel = doc.createAnimationChannel().setTargetNode(node).setTargetPath('weights');
-	doc.createAnimation().addChannel(weightsChannel);
-
-	await doc.transform(quantize());
-
-	t.is(node.getMesh(), mesh, "don't reparent mesh");
-	t.is(weightsChannel.getTargetNode(), node, "don't retarget non-TRS animation");
-
-	// (2) Reparent meshes and retarget non-TRS animation when parent is affected by TRS animation.
-
-	doc = new Document().setLogger(logger);
-	createScene(doc);
-	node = doc.getRoot().listNodes()[0];
-	mesh = node.getMesh();
-	scaleChannel = doc.createAnimationChannel().setTargetNode(node).setTargetPath('scale');
-	weightsChannel = doc.createAnimationChannel().setTargetNode(node).setTargetPath('weights');
-	doc.createAnimation().addChannel(weightsChannel).addChannel(scaleChannel);
-
-	await doc.transform(quantize());
-
-	t.is(node.getMesh(), null, 'reparent mesh');
-	t.is(weightsChannel.getTargetNode(), node.listChildren()[0], 'retarget non-TRS animation');
-	t.is(scaleChannel.getTargetNode(), node, "don't retarget TRS animation");
-});
-
-test('instancing', async (t) => {
-	const doc = new Document().setLogger(logger);
-	createScene(doc);
-	const node = doc.getRoot().listNodes()[0];
-	const mesh = node.getMesh();
-	const batchExtension = doc.createExtension(EXTMeshGPUInstancing);
-	const batchTranslation = doc
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([0, 0, 0, 1, 1, 1]));
-	let batch = batchExtension.createInstancedMesh().setAttribute('TRANSLATION', batchTranslation);
-	node.setExtension('EXT_mesh_gpu_instancing', batch);
-
-	await doc.transform(quantize());
-
-	batch = node.getExtension('EXT_mesh_gpu_instancing');
-
-	t.is(node.getMesh(), mesh, 'node hash mesh');
-	t.deepEqual(node.getTranslation(), [10, 0, 0], 'node has original translation');
-	t.deepEqual(node.getScale(), [1, 1, 1], 'node has original scale');
-	t.truthy(batch, 'node has instancing extension');
-	t.deepEqual(
-		Array.from(batch.getAttribute('TRANSLATION').getArray()),
-		[12.5, 12.5, 0, 13.5, 13.5, 1],
-		'batch translation includes quantization transform',
-	);
-	t.deepEqual(
-		Array.from(batch.getAttribute('SCALE').getArray()),
-		[2.5, 2.5, 2.5, 2.5, 2.5, 2.5],
-		'batch scale added to attributes',
-	);
-});
-
-test('volumetric materials', async (t) => {
-	const doc = new Document().setLogger(logger);
-	createScene(doc);
-	const primA = doc.getRoot().listNodes()[0].getMesh().listPrimitives()[0];
-	const primB = doc.getRoot().listNodes()[1].getMesh().listPrimitives()[0];
-
-	// Add volumetric material (thickness is in local units).
-	const volumeExtension = doc.createExtension(KHRMaterialsVolume);
-	const volume = volumeExtension.createVolume().setThicknessFactor(1.0);
-	const material = doc.createMaterial().setExtension('KHR_materials_volume', volume);
-	primA.setMaterial(material);
-	primB.setMaterial(material);
-
-	await doc.transform(quantize());
-
-	t.truthy(primA.getMaterial() !== material, 'new material for prim A');
-	t.truthy(primB.getMaterial() !== material, 'new material for prim B');
-	t.truthy(material.isDisposed(), 'dispose old material');
-	t.is(doc.getRoot().listMaterials().length, 2, 'material count = 2');
-
-	const volumeA = primA.getMaterial().getExtension<Volume>('KHR_materials_volume');
-	const volumeB = primB.getMaterial().getExtension<Volume>('KHR_materials_volume');
-	t.is(volumeA.getThicknessFactor(), 1 / 2.5, 'volumeA.thickness');
-	t.is(volumeB.getThicknessFactor(), 1 / 50, 'volumeB.thickness');
-});
-
-test('no side effects', async (t) => {
-	const document = new Document();
-	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
-	attributeA.clone();
-
-	await document.transform(quantize({ cleanup: false }));
-
-	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+		strictEqual(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/reorder.test.ts
+++ b/packages/functions/test/reorder.test.ts
@@ -1,7 +1,8 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, type GLTF, Primitive } from '@gltf-transform/core';
 import { reorder } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import { MeshoptEncoder } from 'meshoptimizer';
 
 const CUBE_INDICES = new Uint32Array([4, 2, 5, 3, 1, 4, 0, 1, 3, 1, 2, 4]);
@@ -20,128 +21,137 @@ for (let i = 0; i < CUBE_POSITIONS.length; i++) {
 	CUBE_POSITIONS_EXPECTED[REMAP[i] * 3 + 2] = CUBE_POSITIONS[i * 3 + 2];
 }
 
-test('no indices', async (t) => {
-	// Without indices, don't reorder. Need a lossy weld first.
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
-	const prim1 = root.listMeshes()[0].listPrimitives()[0];
+describe('reorder', () => {
+	test('no indices', async () => {
+		// Without indices, don't reorder. Need a lossy weld first.
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+		const prim1 = root.listMeshes()[0].listPrimitives()[0];
 
-	await doc.transform(reorder({ encoder: MeshoptEncoder }));
+		await doc.transform(reorder({ encoder: MeshoptEncoder }));
 
-	t.truthy(prim1.getIndices() === null && prim1.getAttribute('POSITION') === position1, 'primitive unchanged');
-	t.truthy(!position1.isDisposed(), 'positions not disposed');
-	t.deepEqual(position1.getArray(), CUBE_POSITIONS, 'positions unchanged');
-});
+		ok(prim1.getIndices() === null && prim1.getAttribute('POSITION') === position1, 'primitive unchanged');
+		ok(!position1.isDisposed(), 'positions not disposed');
+		deepEqual(position1.getArray(), CUBE_POSITIONS, 'positions unchanged');
+	});
 
-test('shared indices', async (t) => {
-	// With shared indices and unshared attributes, indices should be cloned.
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const indices = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES);
-	const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
-	const position2 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
-	const prim1 = root.listMeshes()[0].listPrimitives()[0].setIndices(indices);
-	const prim2 = root.listMeshes()[1].listPrimitives()[0].setIndices(indices);
+	test('shared indices', async () => {
+		// With shared indices and unshared attributes, indices should be cloned.
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const indices = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES);
+		const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+		const position2 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+		const prim1 = root.listMeshes()[0].listPrimitives()[0].setIndices(indices);
+		const prim2 = root.listMeshes()[1].listPrimitives()[0].setIndices(indices);
 
-	await doc.transform(reorder({ encoder: MeshoptEncoder }));
+		await doc.transform(reorder({ encoder: MeshoptEncoder }));
 
-	t.truthy(indices !== prim1.getIndices(), 'indices #1 cloned');
-	t.truthy(indices !== prim2.getIndices(), 'indices #2 cloned');
-	t.truthy(prim1.getIndices() === prim2.getIndices(), 'indices shared');
-	t.truthy(prim1.getAttribute('POSITION') !== prim2.getAttribute('POSITION'), 'positions remain unshared');
-	t.truthy(indices.isDisposed(), 'original indices disposed');
-	t.truthy(position1.isDisposed(), 'original positions #1 disposed');
-	t.truthy(position2.isDisposed(), 'original positions #2 disposed');
-	t.deepEqual(Array.from(prim1.getIndices().getArray()), Array.from(CUBE_INDICES_EXPECTED), 'indices reordered');
-	t.deepEqual(
-		Array.from(prim1.getAttribute('POSITION').getArray()),
-		Array.from(CUBE_POSITIONS_EXPECTED),
-		'positions #1 reordered',
-	);
-	t.deepEqual(
-		Array.from(prim2.getAttribute('POSITION').getArray()),
-		Array.from(CUBE_POSITIONS_EXPECTED),
-		'positions #2 reordered',
-	);
-});
+		ok(indices !== prim1.getIndices(), 'indices #1 cloned');
+		ok(indices !== prim2.getIndices(), 'indices #2 cloned');
+		ok(prim1.getIndices() === prim2.getIndices(), 'indices shared');
+		ok(prim1.getAttribute('POSITION') !== prim2.getAttribute('POSITION'), 'positions remain unshared');
+		ok(indices.isDisposed(), 'original indices disposed');
+		ok(position1.isDisposed(), 'original positions #1 disposed');
+		ok(position2.isDisposed(), 'original positions #2 disposed');
+		deepEqual(Array.from(prim1.getIndices().getArray()), Array.from(CUBE_INDICES_EXPECTED), 'indices reordered');
+		deepEqual(
+			Array.from(prim1.getAttribute('POSITION').getArray()),
+			Array.from(CUBE_POSITIONS_EXPECTED),
+			'positions #1 reordered',
+		);
+		deepEqual(
+			Array.from(prim2.getAttribute('POSITION').getArray()),
+			Array.from(CUBE_POSITIONS_EXPECTED),
+			'positions #2 reordered',
+		);
+	});
 
-test('shared attributes', async (t) => {
-	// With shared attributes and unshared indices, attributes should be truncated.
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const indices1 = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES.slice(0, 6));
-	const indices2 = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES.slice(6, 9));
-	const indices3 = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES.slice(9, 12));
-	const position = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
-	const mesh = root.listMeshes()[0];
-	const prim1 = mesh.listPrimitives()[0].setIndices(indices1);
-	const prim2 = prim1.clone().setIndices(indices2);
-	const prim3 = prim1.clone().setIndices(indices3);
-	mesh.addPrimitive(prim2).addPrimitive(prim3);
+	test('shared attributes', async () => {
+		// With shared attributes and unshared indices, attributes should be truncated.
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const indices1 = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES.slice(0, 6));
+		const indices2 = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES.slice(6, 9));
+		const indices3 = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES.slice(9, 12));
+		const position = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+		const mesh = root.listMeshes()[0];
+		const prim1 = mesh.listPrimitives()[0].setIndices(indices1);
+		const prim2 = prim1.clone().setIndices(indices2);
+		const prim3 = prim1.clone().setIndices(indices3);
+		mesh.addPrimitive(prim2).addPrimitive(prim3);
 
-	await doc.transform(reorder({ encoder: MeshoptEncoder }));
+		await doc.transform(reorder({ encoder: MeshoptEncoder }));
 
-	t.truthy(indices1.isDisposed() && indices2.isDisposed() && indices3.isDisposed(), 'indices disposed');
-	t.truthy(position.isDisposed(), 'positions disposed');
-	t.deepEqual(prim1.getIndices().getCount(), 6, 'indices #1 reordered');
-	t.deepEqual(prim2.getIndices().getCount(), 3, 'indices #2 reordered');
-	t.deepEqual(prim3.getIndices().getCount(), 3, 'indices #3 reordered');
-	t.deepEqual(prim1.getAttribute('POSITION').getCount(), 5, 'positions #1 truncated');
-	t.deepEqual(prim2.getAttribute('POSITION').getCount(), 3, 'positions #2 truncated');
-	t.deepEqual(prim3.getAttribute('POSITION').getCount(), 3, 'positions #3 truncated');
-});
+		ok(indices1.isDisposed() && indices2.isDisposed() && indices3.isDisposed(), 'indices disposed');
+		ok(position.isDisposed(), 'positions disposed');
+		deepEqual(prim1.getIndices().getCount(), 6, 'indices #1 reordered');
+		deepEqual(prim2.getIndices().getCount(), 3, 'indices #2 reordered');
+		deepEqual(prim3.getIndices().getCount(), 3, 'indices #3 reordered');
+		deepEqual(prim1.getAttribute('POSITION').getCount(), 5, 'positions #1 truncated');
+		deepEqual(prim2.getAttribute('POSITION').getCount(), 3, 'positions #2 truncated');
+		deepEqual(prim3.getAttribute('POSITION').getCount(), 3, 'positions #3 truncated');
+	});
 
-test('morph targets', async (t) => {
-	// With shared indices and unshared attributes, indices should be cloned.
-	const doc = new Document().setLogger(logger);
-	const root = doc.getRoot();
-	const indices = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES);
-	const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
-	const position2 = createFloatAttribute(
-		doc,
-		'_TMP',
-		Accessor.Type.VEC3,
-		new Float32Array([0.0, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 4.0, 0.0, 0.0, 5.0, 0.0, 0.0, 6.0]),
-	);
-	const target = doc.createPrimitiveTarget().setAttribute('POSITION', position2.detach());
-	const prim = root.listMeshes()[0].listPrimitives()[0].setIndices(indices);
-	prim.addTarget(target);
+	test('morph targets', async () => {
+		// With shared indices and unshared attributes, indices should be cloned.
+		const doc = new Document().setLogger(logger);
+		const root = doc.getRoot();
+		const indices = doc.createAccessor().setType('SCALAR').setArray(CUBE_INDICES);
+		const position1 = createFloatAttribute(doc, 'POSITION', Accessor.Type.VEC3, CUBE_POSITIONS);
+		const position2 = createFloatAttribute(
+			doc,
+			'_TMP',
+			Accessor.Type.VEC3,
+			new Float32Array([
+				0.0, 0.0, 1.0, 0.0, 0.0, 2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 4.0, 0.0, 0.0, 5.0, 0.0, 0.0, 6.0,
+			]),
+		);
+		const target = doc.createPrimitiveTarget().setAttribute('POSITION', position2.detach());
+		const prim = root.listMeshes()[0].listPrimitives()[0].setIndices(indices);
+		prim.addTarget(target);
 
-	await doc.transform(reorder({ encoder: MeshoptEncoder }));
+		await doc.transform(reorder({ encoder: MeshoptEncoder }));
 
-	t.truthy(indices !== prim.getIndices(), 'indices #1 cloned');
-	t.truthy(indices.isDisposed(), 'original indices disposed');
-	t.truthy(position1.isDisposed(), 'original positions disposed');
-	t.truthy(position2.isDisposed(), 'original morph positions disposed');
-	t.deepEqual(Array.from(prim.getIndices().getArray()), Array.from(CUBE_INDICES_EXPECTED), 'indices reordered');
-	t.deepEqual(
-		Array.from(prim.getAttribute('POSITION').getArray()),
-		Array.from(CUBE_POSITIONS_EXPECTED),
-		'positions reordered',
-	);
+		ok(indices !== prim.getIndices(), 'indices #1 cloned');
+		ok(indices.isDisposed(), 'original indices disposed');
+		ok(position1.isDisposed(), 'original positions disposed');
+		ok(position2.isDisposed(), 'original morph positions disposed');
+		deepEqual(Array.from(prim.getIndices().getArray()), Array.from(CUBE_INDICES_EXPECTED), 'indices reordered');
+		deepEqual(
+			Array.from(prim.getAttribute('POSITION').getArray()),
+			Array.from(CUBE_POSITIONS_EXPECTED),
+			'positions reordered',
+		);
 
-	t.deepEqual(
-		Array.from(target.getAttribute('POSITION').getArray()),
-		[0, 0, 5.0, 0, 0, 3.0, 0, 0, 6.0, 0, 0, 2.0, 0, 0, 4.0, 0, 0, 1.0],
-		'morph positions reordered',
-	);
-});
+		deepEqual(
+			Array.from(target.getAttribute('POSITION').getArray()),
+			[0, 0, 5.0, 0, 0, 3.0, 0, 0, 6.0, 0, 0, 2.0, 0, 0, 4.0, 0, 0, 1.0],
+			'morph positions reordered',
+		);
+	});
 
-test('no side effects', async (t) => {
-	const document = new Document().setLogger(logger);
-	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
-	attributeA.clone();
+	test('no side effects', async () => {
+		const document = new Document().setLogger(logger);
+		const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+		attributeA.clone();
 
-	await document.transform(reorder({ cleanup: false, encoder: MeshoptEncoder }));
+		await document.transform(reorder({ cleanup: false, encoder: MeshoptEncoder }));
 
-	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+		strictEqual(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+	});
 });
 
 /* UTILITIES */
 
 /** Builds a new float32 attribute for given type and data. */
-function createFloatAttribute(doc: Document, semantic: string, type: GLTF.AccessorType, array: Float32Array): Accessor {
+function createFloatAttribute(
+	doc: Document,
+	semantic: string,
+	type: GLTF.AccessorType,
+	array: Float32Array<ArrayBuffer>,
+): Accessor {
 	const attribute = doc.createAccessor().setType(type).setArray(array);
 	const prim = doc.createPrimitive().setAttribute(semantic, attribute).setMode(Primitive.Mode.TRIANGLES);
 	doc.createMesh().addPrimitive(prim);

--- a/packages/functions/test/reorder.test.ts
+++ b/packages/functions/test/reorder.test.ts
@@ -21,7 +21,7 @@ for (let i = 0; i < CUBE_POSITIONS.length; i++) {
 	CUBE_POSITIONS_EXPECTED[REMAP[i] * 3 + 2] = CUBE_POSITIONS[i * 3 + 2];
 }
 
-describe('reorder', () => {
+describe('functions::reorder', () => {
 	test('no indices', async () => {
 		// Without indices, don't reorder. Need a lossy weld first.
 		const doc = new Document().setLogger(logger);

--- a/packages/functions/test/resample.test.ts
+++ b/packages/functions/test/resample.test.ts
@@ -1,78 +1,81 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document } from '@gltf-transform/core';
 import { resample } from '@gltf-transform/functions';
 import { logger, quat } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('all', async (t) => {
-	const doc = new Document().setLogger(logger);
+describe('resample', () => {
+	test('all', async () => {
+		const doc = new Document().setLogger(logger);
 
-	const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
-	const outArray = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5]);
-	const outSplineArray = new Uint8Array([
-		0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 1, 4, 0, 0, 0,
-		0, 1, 5, 0, 0,
-	]);
+		const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
+		const outArray = new Uint8Array([1, 1, 1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5]);
+		const outSplineArray = new Uint8Array([
+			0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 2, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 1, 4, 0, 0,
+			0, 0, 1, 5, 0, 0,
+		]);
 
-	const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inArray);
-	const output = doc.createAccessor('output').setType(Accessor.Type.VEC2).setArray(outArray);
-	const outputSpline = doc.createAccessor('outputSpline').setType(Accessor.Type.VEC2).setArray(outSplineArray);
+		const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inArray);
+		const output = doc.createAccessor('output').setType(Accessor.Type.VEC2).setArray(outArray);
+		const outputSpline = doc.createAccessor('outputSpline').setType(Accessor.Type.VEC2).setArray(outSplineArray);
 
-	const samplerA = doc.createAnimationSampler().setInterpolation('STEP').setInput(input).setOutput(output);
-	const samplerB = samplerA.clone().setInterpolation('LINEAR');
-	const samplerC = samplerA.clone().setOutput(outputSpline).setInterpolation('CUBICSPLINE');
+		const samplerA = doc.createAnimationSampler().setInterpolation('STEP').setInput(input).setOutput(output);
+		const samplerB = samplerA.clone().setInterpolation('LINEAR');
+		const samplerC = samplerA.clone().setOutput(outputSpline).setInterpolation('CUBICSPLINE');
 
-	doc.createAnimation().addSampler(samplerA).addSampler(samplerB).addSampler(samplerC);
+		doc.createAnimation().addSampler(samplerA).addSampler(samplerB).addSampler(samplerC);
 
-	await doc.transform(resample());
+		await doc.transform(resample());
 
-	t.is(doc.getRoot().listAccessors().length, 6, 'splits shared accessors');
+		strictEqual(doc.getRoot().listAccessors().length, 6, 'splits shared accessors');
 
-	// Merge duplicate keyframes.
-	t.deepEqual(toArray(samplerA.getInput()), [0, 2, 3, 4, 5, 6], 'STEP input');
-	t.deepEqual(toArray(samplerA.getOutput()), [1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5], 'STEP output');
+		// Merge duplicate keyframes.
+		deepEqual(toArray(samplerA.getInput()), [0, 2, 3, 4, 5, 6], 'STEP input');
+		deepEqual(toArray(samplerA.getOutput()), [1, 1, 1, 1, 1, 2, 1, 3, 1, 4, 1, 5], 'STEP output');
 
-	// Merge colinear keyframes.
-	t.deepEqual(toArray(samplerB.getInput()), [0, 2, 6], 'LINEAR input');
-	t.deepEqual(toArray(samplerB.getOutput()), [1, 1, 1, 1, 1, 5], 'LINEAR output');
+		// Merge colinear keyframes.
+		deepEqual(toArray(samplerB.getInput()), [0, 2, 6], 'LINEAR input');
+		deepEqual(toArray(samplerB.getOutput()), [1, 1, 1, 1, 1, 5], 'LINEAR output');
 
-	// No change.
-	t.deepEqual(toArray(samplerC.getInput()), Array.from(inArray), 'CUBICSPLINE input (unchanged)');
-	t.deepEqual(toArray(samplerC.getOutput()), Array.from(outSplineArray), 'CUBICSPLINE output (unchanged)');
-});
+		// No change.
+		deepEqual(toArray(samplerC.getInput()), Array.from(inArray), 'CUBICSPLINE input (unchanged)');
+		deepEqual(toArray(samplerC.getOutput()), Array.from(outSplineArray), 'CUBICSPLINE output (unchanged)');
+	});
 
-test('rotation', async (t) => {
-	const doc = new Document().setLogger(logger);
+	test('rotation', async () => {
+		const doc = new Document().setLogger(logger);
 
-	const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
-	const outArray = new Float32Array([
-		...quat.fromEuler([], 0, 0, 0),
-		...quat.fromEuler([], 45, 0, 0),
-		...quat.fromEuler([], 90, 0, 0),
-		...quat.fromEuler([], 135, 0, 0),
-		...quat.fromEuler([], 180, 0, 0), // resampling can't create >=180º steps!
-		...quat.fromEuler([], 225, 0, 0),
-		...quat.fromEuler([], 270, 0, 0),
-	]);
+		const inArray = new Uint8Array([0, 1, 2, 3, 4, 5, 6]);
+		const outArray = new Float32Array([
+			...quat.fromEuler([], 0, 0, 0),
+			...quat.fromEuler([], 45, 0, 0),
+			...quat.fromEuler([], 90, 0, 0),
+			...quat.fromEuler([], 135, 0, 0),
+			...quat.fromEuler([], 180, 0, 0), // resampling can't create >=180º steps!
+			...quat.fromEuler([], 225, 0, 0),
+			...quat.fromEuler([], 270, 0, 0),
+		]);
 
-	const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inArray);
-	const output = doc.createAccessor('output').setType(Accessor.Type.VEC4).setArray(outArray);
-	const sampler = doc.createAnimationSampler().setInterpolation('LINEAR').setInput(input).setOutput(output);
-	const channel = doc.createAnimationChannel().setTargetPath('rotation').setSampler(sampler);
-	doc.createAnimation().addChannel(channel).addSampler(sampler);
+		const input = doc.createAccessor('input').setType(Accessor.Type.SCALAR).setArray(inArray);
+		const output = doc.createAccessor('output').setType(Accessor.Type.VEC4).setArray(outArray);
+		const sampler = doc.createAnimationSampler().setInterpolation('LINEAR').setInput(input).setOutput(output);
+		const channel = doc.createAnimationChannel().setTargetPath('rotation').setSampler(sampler);
+		doc.createAnimation().addChannel(channel).addSampler(sampler);
 
-	await doc.transform(resample());
+		await doc.transform(resample());
 
-	t.deepEqual(toArray(sampler.getInput()), [0, 3, 6], 'input');
-	t.deepEqual(
-		toArray(sampler.getOutput()),
-		// biome-ignore format: Readability.
-		[
+		deepEqual(toArray(sampler.getInput()), [0, 3, 6], 'input');
+		deepEqual(
+			toArray(sampler.getOutput()),
+			// biome-ignore format: Readability.
+			[
 			0, 0, 0, 1,
 			0.9238795042037964, 0, 0, 0.3826834261417389,
 			0.7071067690849304, 0, -0, -0.7071067690849304
 		],
-		'output',
-	);
+			'output',
+		);
+	});
 });
 
 function toArray(accessor: Accessor): number[] {

--- a/packages/functions/test/resample.test.ts
+++ b/packages/functions/test/resample.test.ts
@@ -4,7 +4,7 @@ import { Accessor, Document } from '@gltf-transform/core';
 import { resample } from '@gltf-transform/functions';
 import { logger, quat } from '@gltf-transform/test-utils';
 
-describe('resample', () => {
+describe('functions::resample', () => {
 	test('all', async () => {
 		const doc = new Document().setLogger(logger);
 

--- a/packages/functions/test/sequence.test.ts
+++ b/packages/functions/test/sequence.test.ts
@@ -1,42 +1,45 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { sequence } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const root = doc.getRoot();
-	const scene = doc.createScene();
+describe('sequence', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const root = doc.getRoot();
+		const scene = doc.createScene();
 
-	for (let i = 0; i < 4; i++) {
-		scene.addChild(doc.createNode(`Step.00${i + 1}`));
-	}
+		for (let i = 0; i < 4; i++) {
+			scene.addChild(doc.createNode(`Step.00${i + 1}`));
+		}
 
-	await doc.transform(sequence({ fps: 1, pattern: /^Step\.\d{3}$/ }));
+		await doc.transform(sequence({ fps: 1, pattern: /^Step\.\d{3}$/ }));
 
-	const anim = root.listAnimations().pop();
+		const anim = root.listAnimations().pop();
 
-	t.truthy(anim, 'creates animation');
-	t.deepEqual(
-		anim.listChannels().map((channel) => channel.getTargetNode().getName()),
-		['Step.001', 'Step.002', 'Step.003', 'Step.004'],
-		'creates one channel per node',
-	);
-	t.is(anim.listChannels()[0].getTargetPath(), 'scale', 'channels target scale');
-	t.is(anim.listSamplers().length, 4, 'creates one sampler per node');
-	t.deepEqual(anim.listSamplers()[0].getInput().getArray(), new Float32Array([0, 1]), 'input #1');
-	t.deepEqual(anim.listSamplers()[0].getOutput().getArray(), new Float32Array([1, 1, 1, 0, 0, 0]), 'output #1');
-	t.deepEqual(anim.listSamplers()[1].getInput().getArray(), new Float32Array([0, 1, 2]), 'input #2');
-	t.deepEqual(
-		anim.listSamplers()[1].getOutput().getArray(),
-		new Float32Array([0, 0, 0, 1, 1, 1, 0, 0, 0]),
-		'output #2',
-	);
-	t.deepEqual(anim.listSamplers()[2].getInput().getArray(), new Float32Array([1, 2, 3]), 'input #3');
-	t.deepEqual(
-		anim.listSamplers()[2].getOutput().getArray(),
-		new Float32Array([0, 0, 0, 1, 1, 1, 0, 0, 0]),
-		'output #3',
-	);
-	t.deepEqual(anim.listSamplers()[3].getInput().getArray(), new Float32Array([2, 3]), 'input #4');
-	t.deepEqual(anim.listSamplers()[3].getOutput().getArray(), new Float32Array([0, 0, 0, 1, 1, 1]), 'output #4');
+		ok(anim, 'creates animation');
+		deepEqual(
+			anim.listChannels().map((channel) => channel.getTargetNode().getName()),
+			['Step.001', 'Step.002', 'Step.003', 'Step.004'],
+			'creates one channel per node',
+		);
+		strictEqual(anim.listChannels()[0].getTargetPath(), 'scale', 'channels target scale');
+		strictEqual(anim.listSamplers().length, 4, 'creates one sampler per node');
+		deepEqual(anim.listSamplers()[0].getInput().getArray(), new Float32Array([0, 1]), 'input #1');
+		deepEqual(anim.listSamplers()[0].getOutput().getArray(), new Float32Array([1, 1, 1, 0, 0, 0]), 'output #1');
+		deepEqual(anim.listSamplers()[1].getInput().getArray(), new Float32Array([0, 1, 2]), 'input #2');
+		deepEqual(
+			anim.listSamplers()[1].getOutput().getArray(),
+			new Float32Array([0, 0, 0, 1, 1, 1, 0, 0, 0]),
+			'output #2',
+		);
+		deepEqual(anim.listSamplers()[2].getInput().getArray(), new Float32Array([1, 2, 3]), 'input #3');
+		deepEqual(
+			anim.listSamplers()[2].getOutput().getArray(),
+			new Float32Array([0, 0, 0, 1, 1, 1, 0, 0, 0]),
+			'output #3',
+		);
+		deepEqual(anim.listSamplers()[3].getInput().getArray(), new Float32Array([2, 3]), 'input #4');
+		deepEqual(anim.listSamplers()[3].getOutput().getArray(), new Float32Array([0, 0, 0, 1, 1, 1]), 'output #4');
+	});
 });

--- a/packages/functions/test/sequence.test.ts
+++ b/packages/functions/test/sequence.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { sequence } from '@gltf-transform/functions';
 
-describe('sequence', () => {
+describe('functions::sequence', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const root = doc.getRoot();

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -39,7 +39,7 @@ async function createIO(): Promise<NodeIO> {
 	return io;
 }
 
-describe('simplify', () => {
+describe('functions::simplify', () => {
 	test('welded', async () => {
 		const io = await createIO();
 		const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));

--- a/packages/functions/test/simplify.test.ts
+++ b/packages/functions/test/simplify.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, getBounds, NodeIO, Primitive } from '@gltf-transform/core';
 import { KHRDracoMeshCompression, KHRMeshQuantization } from '@gltf-transform/extensions';
 import {
@@ -17,7 +19,6 @@ import {
 	logger,
 	roundBbox,
 } from '@gltf-transform/test-utils';
-import test from 'ava';
 import draco3d from 'draco3dgltf';
 import { MeshoptSimplifier } from 'meshoptimizer';
 import path, { dirname } from 'path';
@@ -38,200 +39,202 @@ async function createIO(): Promise<NodeIO> {
 	return io;
 }
 
-test('welded', async (t) => {
-	const io = await createIO();
-	const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
-	const scene = document.getRoot().getDefaultScene()!;
+describe('simplify', () => {
+	test('welded', async () => {
+		const io = await createIO();
+		const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
+		const scene = document.getRoot().getDefaultScene()!;
 
-	const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
-	const srcBounds = roundBbox(getBounds(scene), 2);
+		const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
+		const srcBounds = roundBbox(getBounds(scene), 2);
 
-	await document.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
+		await document.transform(weld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
 
-	const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
-	const dstBounds = roundBbox(getBounds(scene), 2);
+		const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
+		const dstBounds = roundBbox(getBounds(scene), 2);
 
-	t.truthy((srcCount - dstCount) / srcCount > 0.45, '>=45% reduction');
-	t.truthy(srcCount > dstCount, 'src.count > dst.count');
-	t.deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
-});
+		ok((srcCount - dstCount) / srcCount > 0.45, '>=45% reduction');
+		ok(srcCount > dstCount, 'src.count > dst.count');
+		deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
+	});
 
-test('unwelded', async (t) => {
-	const io = await createIO();
-	const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
-	const scene = document.getRoot().getDefaultScene()!;
+	test('unwelded', async () => {
+		const io = await createIO();
+		const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
+		const scene = document.getRoot().getDefaultScene()!;
 
-	const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
-	const srcBounds = roundBbox(getBounds(scene), 2);
+		const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
+		const srcBounds = roundBbox(getBounds(scene), 2);
 
-	await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
+		await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.001 }));
 
-	const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
-	const dstBounds = roundBbox(getBounds(scene), 2);
+		const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
+		const dstBounds = roundBbox(getBounds(scene), 2);
 
-	t.truthy((srcCount - dstCount) / srcCount > 0.45, '>=45% reduction');
-	t.truthy(srcCount > dstCount, 'src.count > dst.count');
-	t.deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
-});
+		ok((srcCount - dstCount) / srcCount > 0.45, '>=45% reduction');
+		ok(srcCount > dstCount, 'src.count > dst.count');
+		deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
+	});
 
-test('shared accessors', async (t) => {
-	const io = await createIO();
-	const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
+	test('shared accessors', async () => {
+		const io = await createIO();
+		const document = await io.read(path.join(__dirname, 'in', 'DenseSphere.glb'));
 
-	// Remove existing nodes.
-	const scene = document.getRoot().getDefaultScene()!;
-	const root = document.getRoot();
-	root.listNodes().forEach((node) => node.dispose());
+		// Remove existing nodes.
+		const scene = document.getRoot().getDefaultScene()!;
+		const root = document.getRoot();
+		root.listNodes().forEach((node) => node.dispose());
 
-	// Create two meshes sharing a vertex stream with different indices.
-	const meshA = document.getRoot().listMeshes()[0];
-	const primA = meshA.listPrimitives()[0];
-	const primB = primA.clone();
-	splitPrim(primA, 0, 0.5);
-	splitPrim(primB, 0.5, 1);
-	const meshB = document.createMesh().addPrimitive(primB);
+		// Create two meshes sharing a vertex stream with different indices.
+		const meshA = document.getRoot().listMeshes()[0];
+		const primA = meshA.listPrimitives()[0];
+		const primB = primA.clone();
+		splitPrim(primA, 0, 0.5);
+		splitPrim(primB, 0.5, 1);
+		const meshB = document.createMesh().addPrimitive(primB);
 
-	// Place both meshes in scene.
-	const nodeA = document.createNode('A').setTranslation([5, 0, 0]).setMesh(meshA);
-	const nodeB = document.createNode('B').setTranslation([-5, 0, 0]).setMesh(meshB);
-	scene.addChild(nodeA).addChild(nodeB);
+		// Place both meshes in scene.
+		const nodeA = document.createNode('A').setTranslation([5, 0, 0]).setMesh(meshA);
+		const nodeB = document.createNode('B').setTranslation([-5, 0, 0]).setMesh(meshB);
+		scene.addChild(nodeA).addChild(nodeB);
 
-	const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
-	const srcBounds = roundBbox(getBounds(scene), 2);
+		const srcCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
+		const srcBounds = roundBbox(getBounds(scene), 2);
 
-	await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
+		await document.transform(unweld(), simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
 
-	const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
-	const dstBounds = roundBbox(getBounds(scene), 2);
+		const dstCount = getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE);
+		const dstBounds = roundBbox(getBounds(scene), 2);
 
-	t.truthy((srcCount - dstCount) / srcCount > 0.5, '>=50% reduction');
-	t.truthy(srcCount > dstCount, 'src.count > dst.count');
-	t.deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
-});
+		ok((srcCount - dstCount) / srcCount > 0.5, '>=50% reduction');
+		ok(srcCount > dstCount, 'src.count > dst.count');
+		deepEqual(srcBounds, dstBounds, 'src.bounds = dst.bounds');
+	});
 
-test('degenerate', async (t) => {
-	const document = new Document().setLogger(logger);
-	const position = document
-		.createAccessor()
-		.setArray(new Float32Array([0, 0, 0, 0, 0.01, 0, 0, 0, 1]))
-		.setType('VEC3');
-	const prim = document.createPrimitive().setAttribute('POSITION', position);
-	const mesh = document.createMesh().addPrimitive(prim);
-	const node = document.createNode().setMesh(mesh);
-	const scene = document.createScene().addChild(node);
+	test('degenerate', async () => {
+		const document = new Document().setLogger(logger);
+		const position = document
+			.createAccessor()
+			.setArray(new Float32Array([0, 0, 0, 0, 0.01, 0, 0, 0, 1]))
+			.setType('VEC3');
+		const prim = document.createPrimitive().setAttribute('POSITION', position);
+		const mesh = document.createMesh().addPrimitive(prim);
+		const node = document.createNode().setMesh(mesh);
+		const scene = document.createScene().addChild(node);
 
-	await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.01, error: 0.1 }));
+		await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.01, error: 0.1 }));
 
-	t.true(prim.isDisposed(), 'prim disposed');
-	t.true(mesh.isDisposed(), 'mesh disposed');
-	t.false(node.isDisposed(), 'node kept');
-	t.false(scene.isDisposed(), 'scene kept');
-	t.is(getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE), 0, '0 vertices');
-});
+		ok(prim.isDisposed(), 'prim disposed');
+		ok(mesh.isDisposed(), 'mesh disposed');
+		strictEqual(node.isDisposed(), false, 'node kept');
+		strictEqual(scene.isDisposed(), false, 'scene kept');
+		strictEqual(getSceneVertexCount(scene, VertexCountMethod.UPLOAD_NAIVE), 0, '0 vertices');
+	});
 
-test('torus', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document);
-	const srcIndices = prim.getIndices()!;
-	document.createMesh().addPrimitive(prim);
+	test('torus', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document);
+		const srcIndices = prim.getIndices()!;
+		document.createMesh().addPrimitive(prim);
 
-	t.true(srcIndices.getCount() / 3 > 1000, '>1000 triangles (before)');
+		ok(srcIndices.getCount() / 3 > 1000, '>1000 triangles (before)');
 
-	await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.01 }));
+		await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.01 }));
 
-	const dstIndices = prim.getIndices()!;
-	t.true(dstIndices.getCount() / 3 < 750, '<750 triangles (after)');
-});
+		const dstIndices = prim.getIndices()!;
+		ok(dstIndices.getCount() / 3 < 750, '<750 triangles (after)');
+	});
 
-test('torus submesh', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document);
-	const srcIndices = prim.getIndices()!;
-	srcIndices.setArray(srcIndices.getArray().slice(0, 90));
-	document.createMesh().addPrimitive(prim);
+	test('torus submesh', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document);
+		const srcIndices = prim.getIndices()!;
+		srcIndices.setArray(srcIndices.getArray().slice(0, 90));
+		document.createMesh().addPrimitive(prim);
 
-	t.true(srcIndices.getCount() / 3 === 30, '30 triangles (before)');
+		ok(srcIndices.getCount() / 3 === 30, '30 triangles (before)');
 
-	await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.25, error: 0.05 }));
+		await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.25, error: 0.05 }));
 
-	const dstIndices = prim.getIndices()!;
-	t.true(dstIndices.getCount() / 3 < 20, '<20 triangles (after)');
-});
+		const dstIndices = prim.getIndices()!;
+		ok(dstIndices.getCount() / 3 < 20, '<20 triangles (after)');
+	});
 
-test('points - unwelded', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document, { tubularSegments: 12, radialSegments: 4 })
-		.setMode(POINTS)
-		.setIndices(null);
-	document.createMesh().addPrimitive(prim);
+	test('points - unwelded', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document, { tubularSegments: 12, radialSegments: 4 })
+			.setMode(POINTS)
+			.setIndices(null);
+		document.createMesh().addPrimitive(prim);
 
-	t.is(prim.getAttribute('POSITION').getCount(), 65, '65 vertices (before)');
+		strictEqual(prim.getAttribute('POSITION').getCount(), 65, '65 vertices (before)');
 
-	await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
+		await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
 
-	t.true(prim.getAttribute('POSITION').getCount() < 40, '<40 vertices (after)');
-});
+		ok(prim.getAttribute('POSITION').getCount() < 40, '<40 vertices (after)');
+	});
 
-test('points - welded', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document, { tubularSegments: 12, radialSegments: 4 }).setMode(POINTS);
-	prim.getIndices().setArray(new Uint16Array(65).map((_, i) => i));
-	document.createMesh().addPrimitive(prim);
+	test('points - welded', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document, { tubularSegments: 12, radialSegments: 4 }).setMode(POINTS);
+		prim.getIndices().setArray(new Uint16Array(65).map((_, i) => i));
+		document.createMesh().addPrimitive(prim);
 
-	t.is(prim.getAttribute('POSITION').getCount(), 65, '65 vertices (before)');
-	t.truthy(prim.getIndices(), 'welded (before)');
+		strictEqual(prim.getAttribute('POSITION').getCount(), 65, '65 vertices (before)');
+		ok(prim.getIndices(), 'welded (before)');
 
-	await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
+		await document.transform(simplify({ simplifier: MeshoptSimplifier, ratio: 0.5 }));
 
-	t.true(prim.getAttribute('POSITION').getCount() < 40, '<40 vertices (after)');
-	t.is(prim.getIndices(), null, 'unwelded (after)');
-});
+		ok(prim.getAttribute('POSITION').getCount() < 40, '<40 vertices (after)');
+		strictEqual(prim.getIndices(), null, 'unwelded (after)');
+	});
 
-test('lines', async (t) => {
-	const document = new Document().setLogger(logger);
-	const primBase = createLineLoopPrim(document).setMode(LINES);
-	const primLines = createLineLoopPrim(document).setMode(LINES);
-	const primLineStrip = createLineLoopPrim(document).setMode(LINE_STRIP);
-	const primLineLoop = createLineLoopPrim(document).setMode(LINE_LOOP);
+	test('lines', async () => {
+		const document = new Document().setLogger(logger);
+		const primBase = createLineLoopPrim(document).setMode(LINES);
+		const primLines = createLineLoopPrim(document).setMode(LINES);
+		const primLineStrip = createLineLoopPrim(document).setMode(LINE_STRIP);
+		const primLineLoop = createLineLoopPrim(document).setMode(LINE_LOOP);
 
-	await MeshoptSimplifier.ready;
-	simplifyPrimitive(primLines, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
-	simplifyPrimitive(primLineStrip, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
+		await MeshoptSimplifier.ready;
+		simplifyPrimitive(primLines, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
+		simplifyPrimitive(primLineStrip, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
 
-	t.is(primBase.equals(primLines), true, 'LINES unchanged');
-	t.is(primBase.equals(primLineStrip, new Set(['mode'])), true, 'LINE_STRIP unchanged');
-	t.is(primBase.equals(primLineLoop, new Set(['mode'])), true, 'LINE_LOOP unchanged');
-});
+		strictEqual(primBase.equals(primLines), true, 'LINES unchanged');
+		strictEqual(primBase.equals(primLineStrip, new Set(['mode'])), true, 'LINE_STRIP unchanged');
+		strictEqual(primBase.equals(primLineLoop, new Set(['mode'])), true, 'LINE_LOOP unchanged');
+	});
 
-test('triangle-strip and triangle-mode', async (t) => {
-	const document = new Document().setLogger(logger);
-	const primTriangleStripBase = createTriangleStripPrim(document, 32);
-	const primTriangleStrip = createTriangleStripPrim(document, 32);
-	const primTriangleFanBase = createTriangleFanPrim(document, 32);
-	const primTriangleFan = createTriangleFanPrim(document, 32);
+	test('triangle-strip and triangle-mode', async () => {
+		const document = new Document().setLogger(logger);
+		const primTriangleStripBase = createTriangleStripPrim(document, 32);
+		const primTriangleStrip = createTriangleStripPrim(document, 32);
+		const primTriangleFanBase = createTriangleFanPrim(document, 32);
+		const primTriangleFan = createTriangleFanPrim(document, 32);
 
-	await MeshoptSimplifier.ready;
-	simplifyPrimitive(primTriangleStrip, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
-	simplifyPrimitive(primTriangleFan, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
+		await MeshoptSimplifier.ready;
+		simplifyPrimitive(primTriangleStrip, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
+		simplifyPrimitive(primTriangleFan, { simplifier: MeshoptSimplifier, ratio: 0.5, error: 0.25 });
 
-	t.is(primTriangleStrip.getMode(), TRIANGLES, 'triangle-strip → triangles');
-	t.is(primTriangleFan.getMode(), TRIANGLES, 'triangle-fan → triangles');
+		strictEqual(primTriangleStrip.getMode(), TRIANGLES, 'triangle-strip → triangles');
+		strictEqual(primTriangleFan.getMode(), TRIANGLES, 'triangle-fan → triangles');
 
-	const triangleStripRatio = getGLPrimitiveCount(primTriangleStrip) / getGLPrimitiveCount(primTriangleStripBase);
-	const triangleFanRatio = getGLPrimitiveCount(primTriangleFan) / getGLPrimitiveCount(primTriangleFanBase);
+		const triangleStripRatio = getGLPrimitiveCount(primTriangleStrip) / getGLPrimitiveCount(primTriangleStripBase);
+		const triangleFanRatio = getGLPrimitiveCount(primTriangleFan) / getGLPrimitiveCount(primTriangleFanBase);
 
-	t.true(Math.abs(triangleStripRatio - 0.5) < 0.01, 'triangle strip reduced ~ 50%');
-	t.true(Math.abs(triangleFanRatio - 0.5) < 0.01, 'triangle fan reduced ~ 50%');
-});
+		ok(Math.abs(triangleStripRatio - 0.5) < 0.01, 'triangle strip reduced ~ 50%');
+		ok(Math.abs(triangleFanRatio - 0.5) < 0.01, 'triangle fan reduced ~ 50%');
+	});
 
-test('no side effects', async (t) => {
-	const document = new Document().setLogger(logger);
-	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
-	attributeA.clone();
+	test('no side effects', async () => {
+		const document = new Document().setLogger(logger);
+		const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+		attributeA.clone();
 
-	await document.transform(simplify({ simplifier: MeshoptSimplifier }));
+		await document.transform(simplify({ simplifier: MeshoptSimplifier }));
 
-	t.is(document.getRoot().listAccessors().length, 2, 'skips unused accessors');
+		strictEqual(document.getRoot().listAccessors().length, 2, 'skips unused accessors');
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/sort-primitive-weights.test.ts
+++ b/packages/functions/test/sort-primitive-weights.test.ts
@@ -1,23 +1,25 @@
+import { deepEqual, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { sortPrimitiveWeights } from '@gltf-transform/functions';
 import { round } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('unlimited weights', async (t) => {
-	const prim = createSkinnedPrimitive();
+describe('sortPrimitiveWeights', () => {
+	test('unlimited weights', async () => {
+		const prim = createSkinnedPrimitive();
 
-	sortPrimitiveWeights(prim);
+		sortPrimitiveWeights(prim);
 
-	let weights = [
-		...prim.getAttribute('WEIGHTS_0')!.getElement(0, []),
-		...prim.getAttribute('WEIGHTS_1')!.getElement(0, []),
-	];
+		let weights = [
+			...prim.getAttribute('WEIGHTS_0')!.getElement(0, []),
+			...prim.getAttribute('WEIGHTS_1')!.getElement(0, []),
+		];
 
-	t.is(sum(weights), 1, 'sum === 1, vertex #1');
-	t.deepEqual(weights.map(round(2)), [0.38, 0.2, 0.15, 0.13, 0.1, 0.04, 0, 0], 'weights, vertex #1');
+		strictEqual(sum(weights), 1, 'sum === 1, vertex #1');
+		deepEqual(weights.map(round(2)), [0.38, 0.2, 0.15, 0.13, 0.1, 0.04, 0, 0], 'weights, vertex #1');
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		[
 			...prim.getAttribute('JOINTS_0')!.getElement(0, []),
 			...prim.getAttribute('JOINTS_1')!.getElement(0, []),
@@ -26,16 +28,16 @@ test('unlimited weights', async (t) => {
 		'joints, vertex #1'
 	);
 
-	weights = [
-		...prim.getAttribute('WEIGHTS_0')!.getElement(1, []),
-		...prim.getAttribute('WEIGHTS_1')!.getElement(1, []),
-	];
+		weights = [
+			...prim.getAttribute('WEIGHTS_0')!.getElement(1, []),
+			...prim.getAttribute('WEIGHTS_1')!.getElement(1, []),
+		];
 
-	t.is(sum(weights), 1, 'sum === 1, vertex #2');
-	t.deepEqual(weights.map(round(2)), [0.74, 0.11, 0.11, 0.02, 0.01, 0, 0, 0], 'weights, vertex #2');
+		strictEqual(sum(weights), 1, 'sum === 1, vertex #2');
+		deepEqual(weights.map(round(2)), [0.74, 0.11, 0.11, 0.02, 0.01, 0, 0, 0], 'weights, vertex #2');
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		[
 			...prim.getAttribute('JOINTS_0')!.getElement(1, []),
 			...prim.getAttribute('JOINTS_1')!.getElement(1, []),
@@ -43,50 +45,51 @@ test('unlimited weights', async (t) => {
 		[13, 12, 8, 10, 11, 0, 0, 0],
 		'joints, vertex #2'
 	);
-});
+	});
 
-test('limited weights', async (t) => {
-	const prim = createSkinnedPrimitive();
+	test('limited weights', async () => {
+		const prim = createSkinnedPrimitive();
 
-	sortPrimitiveWeights(prim, 4);
+		sortPrimitiveWeights(prim, 4);
 
-	t.falsy(prim.getAttribute('WEIGHTS_1'), 'limit weights');
-	t.falsy(prim.getAttribute('JOINTS_1'), 'limit joints');
+		strictEqual(prim.getAttribute('WEIGHTS_1'), null, 'limit weights');
+		strictEqual(prim.getAttribute('JOINTS_1'), null, 'limit joints');
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		prim.getAttribute('WEIGHTS_0')!.getElement(0, []).map(round(2)),
 		[0.44, 0.23, 0.17, 0.15],
 		'weights, vertex #1 (truncated)'
 	);
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		prim.getAttribute('JOINTS_0')!.getElement(0, []),
 		[1, 6, 3, 5],
 		'joints, vertex #1 (truncated)'
 	);
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		prim.getAttribute('WEIGHTS_0')!.getElement(1, []).map(round(2)),
 		[0.75, 0.12, 0.11, 0.02],
 		'weights, vertex #2 (truncated)'
 	);
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		prim.getAttribute('JOINTS_0')!.getElement(1, []),
 		[13, 12, 8, 10],
 		'joints, vertex #2 (truncated)'
 	);
-});
+	});
 
-test('invalid limits', async (t) => {
-	const prim = createSkinnedPrimitive();
-	t.throws(() => sortPrimitiveWeights(prim, 0), { message: /limit/i }, 'limit = 0');
-	t.throws(() => sortPrimitiveWeights(prim, -1), { message: /limit/i }, 'limit < 0');
-	t.throws(() => sortPrimitiveWeights(prim, 3), { message: /limit/i }, 'limit % 4 > 0');
+	test('invalid limits', async () => {
+		const prim = createSkinnedPrimitive();
+		throws(() => sortPrimitiveWeights(prim, 0), { message: /limit/i }, 'limit = 0');
+		throws(() => sortPrimitiveWeights(prim, -1), { message: /limit/i }, 'limit < 0');
+		throws(() => sortPrimitiveWeights(prim, 3), { message: /limit/i }, 'limit % 4 > 0');
+	});
 });
 
 function createSkinnedPrimitive() {

--- a/packages/functions/test/sort-primitive-weights.test.ts
+++ b/packages/functions/test/sort-primitive-weights.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { sortPrimitiveWeights } from '@gltf-transform/functions';
 import { round } from '@gltf-transform/test-utils';
 
-describe('sortPrimitiveWeights', () => {
+describe('functions::sortPrimitiveWeights', () => {
 	test('unlimited weights', async () => {
 		const prim = createSkinnedPrimitive();
 

--- a/packages/functions/test/sparse.test.ts
+++ b/packages/functions/test/sparse.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { sparse } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('sparse', () => {
+describe('functions::sparse', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const denseAccessor = document.createAccessor().setArray(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]));

--- a/packages/functions/test/sparse.test.ts
+++ b/packages/functions/test/sparse.test.ts
@@ -1,13 +1,16 @@
+import { strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { sparse } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const denseAccessor = document.createAccessor().setArray(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]));
-	const sparseAccessor = document.createAccessor().setArray(new Float32Array([0, 0, 0, 0, 1, 0, 0, 0]));
-	await document.transform(sparse());
-	t.is(denseAccessor.getSparse(), false, 'denseAccessor.sparse = false');
-	t.is(sparseAccessor.getSparse(), true, 'sparseAccessor.sparse = true');
+describe('sparse', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const denseAccessor = document.createAccessor().setArray(new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]));
+		const sparseAccessor = document.createAccessor().setArray(new Float32Array([0, 0, 0, 0, 1, 0, 0, 0]));
+		await document.transform(sparse());
+		strictEqual(denseAccessor.getSparse(), false, 'denseAccessor.sparse = false');
+		strictEqual(sparseAccessor.getSparse(), true, 'sparseAccessor.sparse = true');
+	});
 });

--- a/packages/functions/test/tangents.test.ts
+++ b/packages/functions/test/tangents.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { tangents } from '@gltf-transform/functions';
 
-describe('tangents', () => {
+describe('functions::tangents', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const positionArray = new Float32Array([1, 1, 1]);

--- a/packages/functions/test/tangents.test.ts
+++ b/packages/functions/test/tangents.test.ts
@@ -1,46 +1,49 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { tangents } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const positionArray = new Float32Array([1, 1, 1]);
-	const normalArray = new Uint16Array([0, 1, 0]);
-	const texcoordArray = new Float32Array([10, 5]);
-	const resultArray = new Float32Array([-1, -1, -1, -1]);
-	const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
-	const normal = doc.createAccessor().setType('VEC3').setArray(normalArray);
-	const texcoord0 = doc
-		.createAccessor()
-		.setType('VEC2')
-		.setArray(new Float32Array([0, 0]));
-	const texcoord1 = doc.createAccessor().setType('VEC2').setArray(texcoordArray);
-	const normalTexture = doc.createTexture();
-	const material = doc.createMaterial().setNormalTexture(normalTexture);
-	material.getNormalTextureInfo().setTexCoord(1);
-	const prim = doc
-		.createPrimitive()
-		.setMaterial(material)
-		.setAttribute('POSITION', position)
-		.setAttribute('NORMAL', normal)
-		.setAttribute('TEXCOORD_0', texcoord0)
-		.setAttribute('TEXCOORD_1', texcoord1);
-	doc.createMesh().addPrimitive(prim);
+describe('tangents', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const positionArray = new Float32Array([1, 1, 1]);
+		const normalArray = new Uint16Array([0, 1, 0]);
+		const texcoordArray = new Float32Array([10, 5]);
+		const resultArray = new Float32Array([-1, -1, -1, -1]);
+		const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
+		const normal = doc.createAccessor().setType('VEC3').setArray(normalArray);
+		const texcoord0 = doc
+			.createAccessor()
+			.setType('VEC2')
+			.setArray(new Float32Array([0, 0]));
+		const texcoord1 = doc.createAccessor().setType('VEC2').setArray(texcoordArray);
+		const normalTexture = doc.createTexture();
+		const material = doc.createMaterial().setNormalTexture(normalTexture);
+		material.getNormalTextureInfo().setTexCoord(1);
+		const prim = doc
+			.createPrimitive()
+			.setMaterial(material)
+			.setAttribute('POSITION', position)
+			.setAttribute('NORMAL', normal)
+			.setAttribute('TEXCOORD_0', texcoord0)
+			.setAttribute('TEXCOORD_1', texcoord1);
+		doc.createMesh().addPrimitive(prim);
 
-	let a, b, c;
-	await doc.transform(
-		tangents({
-			generateTangents: (_a, _b, _c) => {
-				a = _a;
-				b = _b;
-				c = _c;
-				return resultArray;
-			},
-		}),
-	);
+		let a, b, c;
+		await doc.transform(
+			tangents({
+				generateTangents: (_a, _b, _c) => {
+					a = _a;
+					b = _b;
+					c = _c;
+					return resultArray;
+				},
+			}),
+		);
 
-	t.deepEqual(Array.from(a), Array.from(positionArray), 'provides position');
-	t.deepEqual(Array.from(b), Array.from(normalArray), 'provides normal');
-	t.deepEqual(Array.from(c), Array.from(texcoordArray), 'provides texcoord');
-	t.is(prim.getAttribute('TANGENT').getArray(), resultArray, 'sets tangent');
+		deepEqual(Array.from(a), Array.from(positionArray), 'provides position');
+		deepEqual(Array.from(b), Array.from(normalArray), 'provides normal');
+		deepEqual(Array.from(c), Array.from(texcoordArray), 'provides texcoord');
+		strictEqual(prim.getAttribute('TANGENT').getArray(), resultArray, 'sets tangent');
+	});
 });

--- a/packages/functions/test/texture-compress.test.ts
+++ b/packages/functions/test/texture-compress.test.ts
@@ -19,7 +19,7 @@ const EXPECTED_AVIF = new Uint8Array([106, 107, 108]); // larger than original; 
 
 const NON_SQUARE = ndarray(new Uint8Array(256 * 512 * 4), [256, 512, 4]);
 
-describe('textureCompress', () => {
+describe('functions::textureCompress', () => {
 	test('unknown format', async () => {
 		const { encoder, calls } = createMockEncoder();
 		const document = new Document().setLogger(logger);

--- a/packages/functions/test/texture-compress.test.ts
+++ b/packages/functions/test/texture-compress.test.ts
@@ -1,8 +1,9 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { EXTTextureAVIF, EXTTextureWebP } from '@gltf-transform/extensions';
 import { compressTexture, textureCompress } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import ndarray from 'ndarray';
 import { savePixels } from 'ndarray-pixels';
 
@@ -18,311 +19,313 @@ const EXPECTED_AVIF = new Uint8Array([106, 107, 108]); // larger than original; 
 
 const NON_SQUARE = ndarray(new Uint8Array(256 * 512 * 4), [256, 512, 4]);
 
-test('unknown format', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const texture = document.createTexture('Other').setImage(ORIGINAL_OTHER).setMimeType('image/other');
-	await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i }));
-	t.deepEqual(calls, [], '0 conversions');
-	t.is(texture.getMimeType(), 'image/other', 'unknown mime type unchanged');
-	t.is(texture.getImage(), ORIGINAL_OTHER, 'unknown image unchanged');
-});
+describe('textureCompress', () => {
+	test('unknown format', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const texture = document.createTexture('Other').setImage(ORIGINAL_OTHER).setMimeType('image/other');
+		await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i }));
+		deepEqual(calls, [], '0 conversions');
+		strictEqual(texture.getMimeType(), 'image/other', 'unknown mime type unchanged');
+		strictEqual(texture.getImage(), ORIGINAL_OTHER, 'unknown image unchanged');
+	});
 
-test('incompatible format', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const texture = document.createTexture('PNG').setImage(ORIGINAL_PNG).setMimeType('image/png');
-	document.createMaterial().setBaseColorTexture(texture).setAlphaMode('BLEND');
+	test('incompatible format', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const texture = document.createTexture('PNG').setImage(ORIGINAL_PNG).setMimeType('image/png');
+		document.createMaterial().setBaseColorTexture(texture).setAlphaMode('BLEND');
 
-	await document.transform(textureCompress({ encoder, targetFormat: 'jpeg', formats: /.*/i, slots: /.*/i }));
-	t.deepEqual(calls, [], '0 calls');
-	t.is(texture.getMimeType(), 'image/png', 'texture with alpha unchanged');
-	t.is(texture.getImage(), ORIGINAL_PNG, 'texture with alpha unchanged');
+		await document.transform(textureCompress({ encoder, targetFormat: 'jpeg', formats: /.*/i, slots: /.*/i }));
+		deepEqual(calls, [], '0 calls');
+		strictEqual(texture.getMimeType(), 'image/png', 'texture with alpha unchanged');
+		strictEqual(texture.getImage(), ORIGINAL_PNG, 'texture with alpha unchanged');
 
-	await document.transform(textureCompress({ encoder, targetFormat: 'png', formats: /.*/i, slots: /.*/i }));
-	t.deepEqual(calls, [['toFormat', ['png', { quality: undefined, effort: undefined }]]], '1 call');
-	t.is(texture.getMimeType(), 'image/png', 'texture with alpha optimized');
-	t.deepEqual(texture.getImage(), EXPECTED_PNG, 'texture with alpha optimized');
-});
+		await document.transform(textureCompress({ encoder, targetFormat: 'png', formats: /.*/i, slots: /.*/i }));
+		deepEqual(calls, [['toFormat', ['png', { quality: undefined, effort: undefined }]]], '1 call');
+		strictEqual(texture.getMimeType(), 'image/png', 'texture with alpha optimized');
+		deepEqual(texture.getImage(), EXPECTED_PNG, 'texture with alpha optimized');
+	});
 
-test('size increase', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const texture = document.createTexture('AVIF').setImage(ORIGINAL_AVIF).setMimeType('image/avif');
-	await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i, targetFormat: 'avif' }));
-	t.deepEqual(
-		calls,
-		[
+	test('size increase', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const texture = document.createTexture('AVIF').setImage(ORIGINAL_AVIF).setMimeType('image/avif');
+		await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i, targetFormat: 'avif' }));
+		deepEqual(
+			calls,
 			[
-				'toFormat',
-				['avif', { quality: undefined, effort: undefined, lossless: false, chromaSubsampling: '4:4:4' }],
+				[
+					'toFormat',
+					['avif', { quality: undefined, effort: undefined, lossless: false, chromaSubsampling: '4:4:4' }],
+				],
 			],
-		],
-		'1 call',
-	);
-	t.is(texture.getImage(), ORIGINAL_AVIF, 'file size not increased');
-});
+			'1 call',
+		);
+		strictEqual(texture.getImage(), ORIGINAL_AVIF, 'file size not increased');
+	});
 
-test('original formats', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const textureJPEG = document.createTexture('JPEG').setImage(ORIGINAL_JPEG).setMimeType('image/jpeg');
-	const texturePNG = document.createTexture('PNG').setImage(ORIGINAL_PNG).setMimeType('image/png');
+	test('original formats', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const textureJPEG = document.createTexture('JPEG').setImage(ORIGINAL_JPEG).setMimeType('image/jpeg');
+		const texturePNG = document.createTexture('PNG').setImage(ORIGINAL_PNG).setMimeType('image/png');
 
-	await document.transform(textureCompress({ encoder }));
-	t.deepEqual(
-		calls,
-		[
-			['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
-			['toFormat', ['png', { quality: undefined, effort: undefined }]],
-		],
-		'2 calls',
-	);
-	t.is(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg mime type unchanged');
-	t.is(texturePNG.getMimeType(), 'image/png', 'png mime type unchanged');
-	t.deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg optimized');
-	t.deepEqual(texturePNG.getImage(), EXPECTED_PNG, 'png optimized');
-});
+		await document.transform(textureCompress({ encoder }));
+		deepEqual(
+			calls,
+			[
+				['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
+				['toFormat', ['png', { quality: undefined, effort: undefined }]],
+			],
+			'2 calls',
+		);
+		strictEqual(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg mime type unchanged');
+		strictEqual(texturePNG.getMimeType(), 'image/png', 'png mime type unchanged');
+		deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg optimized');
+		deepEqual(texturePNG.getImage(), EXPECTED_PNG, 'png optimized');
+	});
 
-test('excluded slots', async (t) => {
-	const { encoder } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const textureJPEG = document.createTexture('JPEG').setImage(ORIGINAL_JPEG).setMimeType('image/jpeg');
-	const texturePNG = document.createTexture('PNG').setImage(ORIGINAL_PNG).setMimeType('image/png');
-	document.createMaterial().setBaseColorTexture(textureJPEG).setNormalTexture(texturePNG);
+	test('excluded slots', async () => {
+		const { encoder } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const textureJPEG = document.createTexture('JPEG').setImage(ORIGINAL_JPEG).setMimeType('image/jpeg');
+		const texturePNG = document.createTexture('PNG').setImage(ORIGINAL_PNG).setMimeType('image/png');
+		document.createMaterial().setBaseColorTexture(textureJPEG).setNormalTexture(texturePNG);
 
-	await document.transform(textureCompress({ encoder, slots: /^baseColor.*/, formats: /.*/i }));
-	t.is(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg mime type unchanged');
-	t.is(texturePNG.getMimeType(), 'image/png', 'png mime type unchanged');
-	t.deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg optimized');
-	t.deepEqual(texturePNG.getImage(), ORIGINAL_PNG, 'png unchanged');
+		await document.transform(textureCompress({ encoder, slots: /^baseColor.*/, formats: /.*/i }));
+		strictEqual(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg mime type unchanged');
+		strictEqual(texturePNG.getMimeType(), 'image/png', 'png mime type unchanged');
+		deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg optimized');
+		deepEqual(texturePNG.getImage(), ORIGINAL_PNG, 'png unchanged');
 
-	await document.transform(textureCompress({ encoder, slots: /^normal.*/, formats: /.*/i }));
-	t.is(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg mime type unchanged');
-	t.is(texturePNG.getMimeType(), 'image/png', 'png mime type unchanged');
-	t.deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg unchanged');
-	t.deepEqual(texturePNG.getImage(), EXPECTED_PNG, 'png optimized');
-});
+		await document.transform(textureCompress({ encoder, slots: /^normal.*/, formats: /.*/i }));
+		strictEqual(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg mime type unchanged');
+		strictEqual(texturePNG.getMimeType(), 'image/png', 'png mime type unchanged');
+		deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg unchanged');
+		deepEqual(texturePNG.getImage(), EXPECTED_PNG, 'png optimized');
+	});
 
-test('jpeg', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const textureJPEG = document
-		.createTexture('JPEG')
-		.setImage(ORIGINAL_JPEG)
-		.setMimeType('image/jpeg')
-		.setURI('baseColor.jpg');
-	const texturePNG = document
-		.createTexture('PNG')
-		.setImage(ORIGINAL_PNG)
-		.setMimeType('image/png')
-		.setURI('normal.png');
-	await document.transform(textureCompress({ encoder, targetFormat: 'jpeg', formats: /.*/i, slots: /.*/i }));
-	t.deepEqual(
-		calls,
-		[
-			['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
-			['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
-		],
-		'2 calls',
-	);
-	t.is(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg → image/jpeg');
-	t.is(texturePNG.getMimeType(), 'image/jpeg', 'png → image/jpeg');
-	t.is(textureJPEG.getURI(), 'baseColor.jpg', '.jpg → .jpg');
-	t.is(texturePNG.getURI(), 'normal.jpg', '.png → .jpg');
-	t.deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg optimized');
-	t.deepEqual(texturePNG.getImage(), EXPECTED_JPEG, 'png optimized');
-});
+	test('jpeg', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const textureJPEG = document
+			.createTexture('JPEG')
+			.setImage(ORIGINAL_JPEG)
+			.setMimeType('image/jpeg')
+			.setURI('baseColor.jpg');
+		const texturePNG = document
+			.createTexture('PNG')
+			.setImage(ORIGINAL_PNG)
+			.setMimeType('image/png')
+			.setURI('normal.png');
+		await document.transform(textureCompress({ encoder, targetFormat: 'jpeg', formats: /.*/i, slots: /.*/i }));
+		deepEqual(
+			calls,
+			[
+				['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
+				['toFormat', ['jpeg', { quality: undefined, chromaSubsampling: '4:4:4' }]],
+			],
+			'2 calls',
+		);
+		strictEqual(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg → image/jpeg');
+		strictEqual(texturePNG.getMimeType(), 'image/jpeg', 'png → image/jpeg');
+		strictEqual(textureJPEG.getURI(), 'baseColor.jpg', '.jpg → .jpg');
+		strictEqual(texturePNG.getURI(), 'normal.jpg', '.png → .jpg');
+		deepEqual(textureJPEG.getImage(), EXPECTED_JPEG, 'jpeg optimized');
+		deepEqual(texturePNG.getImage(), EXPECTED_JPEG, 'png optimized');
+	});
 
-test('jpeg / jpg', async (t) => {
-	const { encoder } = createMockEncoder();
+	test('jpeg / jpg', async () => {
+		const { encoder } = createMockEncoder();
 
-	const document = new Document().setLogger(logger);
-	const textureJPEG = document.createTexture().setImage(ORIGINAL_JPEG).setMimeType('image/jpeg').setURI('a.jpeg');
-	const textureJPG = document.createTexture().setImage(ORIGINAL_JPEG).setMimeType('image/jpeg').setURI('b.jpg');
+		const document = new Document().setLogger(logger);
+		const textureJPEG = document.createTexture().setImage(ORIGINAL_JPEG).setMimeType('image/jpeg').setURI('a.jpeg');
+		const textureJPG = document.createTexture().setImage(ORIGINAL_JPEG).setMimeType('image/jpeg').setURI('b.jpg');
 
-	await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i }));
+		await document.transform(textureCompress({ encoder, formats: /.*/i, slots: /.*/i }));
 
-	t.is(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg → image/jpeg');
-	t.is(textureJPG.getMimeType(), 'image/jpeg', 'jpg → image/jpeg');
-	t.is(textureJPEG.getURI(), 'a.jpeg', '.jpeg → .jpeg');
-	t.is(textureJPG.getURI(), 'b.jpg', '.jpg → .jpg');
+		strictEqual(textureJPEG.getMimeType(), 'image/jpeg', 'jpeg → image/jpeg');
+		strictEqual(textureJPG.getMimeType(), 'image/jpeg', 'jpg → image/jpeg');
+		strictEqual(textureJPEG.getURI(), 'a.jpeg', '.jpeg → .jpeg');
+		strictEqual(textureJPG.getURI(), 'b.jpg', '.jpg → .jpg');
 
-	await document.transform(textureCompress({ encoder, targetFormat: 'webp', formats: /.*/i, slots: /.*/i }));
+		await document.transform(textureCompress({ encoder, targetFormat: 'webp', formats: /.*/i, slots: /.*/i }));
 
-	t.is(textureJPEG.getMimeType(), 'image/webp', 'jpeg → image/webp');
-	t.is(textureJPG.getMimeType(), 'image/webp', 'jpg → image/webp');
-	t.is(textureJPEG.getURI(), 'a.webp', '.jpeg → .webp');
-	t.is(textureJPG.getURI(), 'b.webp', '.jpg → .webp');
-});
+		strictEqual(textureJPEG.getMimeType(), 'image/webp', 'jpeg → image/webp');
+		strictEqual(textureJPG.getMimeType(), 'image/webp', 'jpg → image/webp');
+		strictEqual(textureJPEG.getURI(), 'a.webp', '.jpeg → .webp');
+		strictEqual(textureJPG.getURI(), 'b.webp', '.jpg → .webp');
+	});
 
-test('png', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const textureJPEG = document
-		.createTexture('JPEG')
-		.setImage(ORIGINAL_JPEG)
-		.setMimeType('image/jpeg')
-		.setURI('baseColor.jpg');
-	const texturePNG = document
-		.createTexture('PNG')
-		.setImage(ORIGINAL_PNG)
-		.setMimeType('image/png')
-		.setURI('normal.png');
-	await document.transform(textureCompress({ encoder, targetFormat: 'png', formats: /.*/i, slots: /.*/i }));
-	t.deepEqual(
-		calls,
-		[
-			['toFormat', ['png', { quality: undefined, effort: undefined }]],
-			['toFormat', ['png', { quality: undefined, effort: undefined }]],
-		],
-		'2 calls',
-	);
-	t.is(textureJPEG.getMimeType(), 'image/png', 'jpeg → image/png');
-	t.is(texturePNG.getMimeType(), 'image/png', 'png → image/png');
-	t.is(textureJPEG.getURI(), 'baseColor.png', '.jpg → .png');
-	t.is(texturePNG.getURI(), 'normal.png', '.png → .png');
-	t.deepEqual(textureJPEG.getImage(), EXPECTED_PNG, 'jpeg optimized');
-	t.deepEqual(texturePNG.getImage(), EXPECTED_PNG, 'png optimized');
-});
+	test('png', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const textureJPEG = document
+			.createTexture('JPEG')
+			.setImage(ORIGINAL_JPEG)
+			.setMimeType('image/jpeg')
+			.setURI('baseColor.jpg');
+		const texturePNG = document
+			.createTexture('PNG')
+			.setImage(ORIGINAL_PNG)
+			.setMimeType('image/png')
+			.setURI('normal.png');
+		await document.transform(textureCompress({ encoder, targetFormat: 'png', formats: /.*/i, slots: /.*/i }));
+		deepEqual(
+			calls,
+			[
+				['toFormat', ['png', { quality: undefined, effort: undefined }]],
+				['toFormat', ['png', { quality: undefined, effort: undefined }]],
+			],
+			'2 calls',
+		);
+		strictEqual(textureJPEG.getMimeType(), 'image/png', 'jpeg → image/png');
+		strictEqual(texturePNG.getMimeType(), 'image/png', 'png → image/png');
+		strictEqual(textureJPEG.getURI(), 'baseColor.png', '.jpg → .png');
+		strictEqual(texturePNG.getURI(), 'normal.png', '.png → .png');
+		deepEqual(textureJPEG.getImage(), EXPECTED_PNG, 'jpeg optimized');
+		deepEqual(texturePNG.getImage(), EXPECTED_PNG, 'png optimized');
+	});
 
-test('webp', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	const textureJPEG = document
-		.createTexture('JPEG')
-		.setImage(ORIGINAL_JPEG)
-		.setMimeType('image/jpeg')
-		.setURI('baseColor.jpg');
-	const texturePNG = document
-		.createTexture('PNG')
-		.setImage(ORIGINAL_PNG)
-		.setMimeType('image/png')
-		.setURI('normal.png');
-	await document.transform(textureCompress({ encoder, targetFormat: 'webp', formats: /.*/i, slots: /.*/i }));
-	t.deepEqual(
-		calls,
-		[
-			['toFormat', ['webp', { quality: undefined, effort: undefined, lossless: false, nearLossless: false }]],
-			['toFormat', ['webp', { quality: undefined, effort: undefined, lossless: false, nearLossless: false }]],
-		],
-		'2 calls',
-	);
-	t.is(textureJPEG.getMimeType(), 'image/webp', 'jpeg → image/webp');
-	t.is(texturePNG.getMimeType(), 'image/webp', 'png → image/webp');
-	t.is(textureJPEG.getURI(), 'baseColor.webp', '.jpg → .webp');
-	t.is(texturePNG.getURI(), 'normal.webp', '.png → .webp');
-	t.deepEqual(textureJPEG.getImage(), EXPECTED_WEBP, 'jpeg optimized');
-	t.deepEqual(texturePNG.getImage(), EXPECTED_WEBP, 'png optimized');
-});
+	test('webp', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		const textureJPEG = document
+			.createTexture('JPEG')
+			.setImage(ORIGINAL_JPEG)
+			.setMimeType('image/jpeg')
+			.setURI('baseColor.jpg');
+		const texturePNG = document
+			.createTexture('PNG')
+			.setImage(ORIGINAL_PNG)
+			.setMimeType('image/png')
+			.setURI('normal.png');
+		await document.transform(textureCompress({ encoder, targetFormat: 'webp', formats: /.*/i, slots: /.*/i }));
+		deepEqual(
+			calls,
+			[
+				['toFormat', ['webp', { quality: undefined, effort: undefined, lossless: false, nearLossless: false }]],
+				['toFormat', ['webp', { quality: undefined, effort: undefined, lossless: false, nearLossless: false }]],
+			],
+			'2 calls',
+		);
+		strictEqual(textureJPEG.getMimeType(), 'image/webp', 'jpeg → image/webp');
+		strictEqual(texturePNG.getMimeType(), 'image/webp', 'png → image/webp');
+		strictEqual(textureJPEG.getURI(), 'baseColor.webp', '.jpg → .webp');
+		strictEqual(texturePNG.getURI(), 'normal.webp', '.png → .webp');
+		deepEqual(textureJPEG.getImage(), EXPECTED_WEBP, 'jpeg optimized');
+		deepEqual(texturePNG.getImage(), EXPECTED_WEBP, 'png optimized');
+	});
 
-test('fallback to ndarray-pixels', async (t) => {
-	const document = new Document().setLogger(logger);
-	document.createExtension(EXTTextureWebP);
+	test('fallback to ndarray-pixels', async () => {
+		const document = new Document().setLogger(logger);
+		document.createExtension(EXTTextureWebP);
 
-	const textureA = document
-		.createTexture('JPEG')
-		.setImage(await savePixels(NON_SQUARE, 'image/jpeg'))
-		.setMimeType('image/jpeg');
-	const textureB = document
-		.createTexture('PNG')
-		.setImage(await savePixels(NON_SQUARE, 'image/png'))
-		.setMimeType('image/png');
+		const textureA = document
+			.createTexture('JPEG')
+			.setImage(await savePixels(NON_SQUARE, 'image/jpeg'))
+			.setMimeType('image/jpeg');
+		const textureB = document
+			.createTexture('PNG')
+			.setImage(await savePixels(NON_SQUARE, 'image/png'))
+			.setMimeType('image/png');
 
-	await document.transform(textureCompress({ targetFormat: 'webp', resize: [128, 128] }));
+		await document.transform(textureCompress({ targetFormat: 'webp', resize: [128, 128] }));
 
-	t.is(textureA.getMimeType(), 'image/webp');
-	t.is(textureB.getMimeType(), 'image/webp');
+		strictEqual(textureA.getMimeType(), 'image/webp');
+		strictEqual(textureB.getMimeType(), 'image/webp');
 
-	// TODO(cleanup): Not registered automatically without I/O.
-	EXTTextureWebP.register();
+		// TODO(cleanup): Not registered automatically without I/O.
+		EXTTextureWebP.register();
 
-	t.deepEqual(textureA.getSize(), [64, 128]);
-	t.deepEqual(textureB.getSize(), [64, 128]);
-});
+		deepEqual(textureA.getSize(), [64, 128]);
+		deepEqual(textureB.getSize(), [64, 128]);
+	});
 
-test('chroma subsampling', async (t) => {
-	const { encoder, calls } = createMockEncoder();
-	const document = new Document().setLogger(logger);
-	document.createExtension(EXTTextureAVIF);
+	test('chroma subsampling', async () => {
+		const { encoder, calls } = createMockEncoder();
+		const document = new Document().setLogger(logger);
+		document.createExtension(EXTTextureAVIF);
 
-	const textureA = document
-		.createTexture('color')
-		.setImage(await savePixels(NON_SQUARE, 'image/png'))
-		.setMimeType('image/png');
-	const textureB = document
-		.createTexture('non-color')
-		.setImage(await savePixels(NON_SQUARE, 'image/png'))
-		.setMimeType('image/png');
-	document.createMaterial('material').setBaseColorTexture(textureA).setNormalTexture(textureB);
+		const textureA = document
+			.createTexture('color')
+			.setImage(await savePixels(NON_SQUARE, 'image/png'))
+			.setMimeType('image/png');
+		const textureB = document
+			.createTexture('non-color')
+			.setImage(await savePixels(NON_SQUARE, 'image/png'))
+			.setMimeType('image/png');
+		document.createMaterial('material').setBaseColorTexture(textureA).setNormalTexture(textureB);
 
-	await document.transform(textureCompress({ encoder, targetFormat: 'avif' }));
+		await document.transform(textureCompress({ encoder, targetFormat: 'avif' }));
 
-	t.is(textureA.getMimeType(), 'image/avif');
-	t.is(textureB.getMimeType(), 'image/avif');
+		strictEqual(textureA.getMimeType(), 'image/avif');
+		strictEqual(textureB.getMimeType(), 'image/avif');
 
-	t.is(calls[0][1][1].chromaSubsampling, '4:2:0', 'default (color)');
-	t.is(calls[1][1][1].chromaSubsampling, '4:4:4', 'default -> 4:4:4 (non-color)');
+		strictEqual(calls[0][1][1].chromaSubsampling, '4:2:0', 'default (color)');
+		strictEqual(calls[1][1][1].chromaSubsampling, '4:4:4', 'default -> 4:4:4 (non-color)');
 
-	await document.transform(textureCompress({ encoder, targetFormat: 'avif', chromaSubsampling: '4:2:0' }));
+		await document.transform(textureCompress({ encoder, targetFormat: 'avif', chromaSubsampling: '4:2:0' }));
 
-	t.is(calls[2][1][1].chromaSubsampling, '4:2:0', '4:2:0 (color)');
-	t.is(calls[3][1][1].chromaSubsampling, '4:2:0', '4:2:0 (non-color)');
+		strictEqual(calls[2][1][1].chromaSubsampling, '4:2:0', '4:2:0 (color)');
+		strictEqual(calls[3][1][1].chromaSubsampling, '4:2:0', '4:2:0 (non-color)');
 
-	await document.transform(textureCompress({ encoder, targetFormat: 'avif', chromaSubsampling: '4:4:4' }));
+		await document.transform(textureCompress({ encoder, targetFormat: 'avif', chromaSubsampling: '4:4:4' }));
 
-	t.is(calls[4][1][1].chromaSubsampling, '4:4:4', '4:4:4 (color)');
-	t.is(calls[5][1][1].chromaSubsampling, '4:4:4', '4:4:4 (non-color)');
-});
+		strictEqual(calls[4][1][1].chromaSubsampling, '4:4:4', '4:4:4 (color)');
+		strictEqual(calls[5][1][1].chromaSubsampling, '4:4:4', '4:4:4 (non-color)');
+	});
 
-test('resize - sharp', async (t) => {
-	const document = new Document();
-	const srcImage = await savePixels(ndarray(new Uint8Array(200 * 350 * 4), [200, 350, 4]), 'image/png');
-	const srcTexture = document.createTexture().setImage(srcImage).setMimeType('image/png');
+	test('resize - sharp', async () => {
+		const document = new Document();
+		const srcImage = await savePixels(ndarray(new Uint8Array(200 * 350 * 4), [200, 350, 4]), 'image/png');
+		const srcTexture = document.createTexture().setImage(srcImage).setMimeType('image/png');
 
-	const dstTextureCeil = srcTexture.clone();
-	const dstTextureFloor = srcTexture.clone();
-	const dstTextureNearest = srcTexture.clone();
-	const dstTexture200x200 = srcTexture.clone();
-	const dstTexture1024x1024 = srcTexture.clone();
+		const dstTextureCeil = srcTexture.clone();
+		const dstTextureFloor = srcTexture.clone();
+		const dstTextureNearest = srcTexture.clone();
+		const dstTexture200x200 = srcTexture.clone();
+		const dstTexture1024x1024 = srcTexture.clone();
 
-	const { encoder, calls } = createMockEncoder();
+		const { encoder, calls } = createMockEncoder();
 
-	await compressTexture(dstTextureCeil, { encoder, resize: 'ceil-pot' });
-	await compressTexture(dstTextureFloor, { encoder, resize: 'floor-pot' });
-	await compressTexture(dstTextureNearest, { encoder, resize: 'nearest-pot' });
-	await compressTexture(dstTexture200x200, { encoder, resize: [200, 200] });
-	await compressTexture(dstTexture1024x1024, { encoder, resize: [1024, 1024] });
+		await compressTexture(dstTextureCeil, { encoder, resize: 'ceil-pot' });
+		await compressTexture(dstTextureFloor, { encoder, resize: 'floor-pot' });
+		await compressTexture(dstTextureNearest, { encoder, resize: 'nearest-pot' });
+		await compressTexture(dstTexture200x200, { encoder, resize: [200, 200] });
+		await compressTexture(dstTexture1024x1024, { encoder, resize: [1024, 1024] });
 
-	t.deepEqual(calls[1][1].slice(0, 2), [256, 512], 'ceil - sharp');
-	t.deepEqual(calls[3][1].slice(0, 2), [128, 256], 'floor - sharp');
-	t.deepEqual(calls[5][1].slice(0, 2), [256, 256], 'nearest - sharp');
-	t.deepEqual(calls[7][1].slice(0, 2), [114, 200], '200x200 - sharp');
-	t.deepEqual(calls[9][1].slice(0, 2), [200, 350], '1024x1024 - sharp');
-});
+		deepEqual(calls[1][1].slice(0, 2), [256, 512], 'ceil - sharp');
+		deepEqual(calls[3][1].slice(0, 2), [128, 256], 'floor - sharp');
+		deepEqual(calls[5][1].slice(0, 2), [256, 256], 'nearest - sharp');
+		deepEqual(calls[7][1].slice(0, 2), [114, 200], '200x200 - sharp');
+		deepEqual(calls[9][1].slice(0, 2), [200, 350], '1024x1024 - sharp');
+	});
 
-test('resize - ndarray-pixels', async (t) => {
-	const document = new Document();
-	const srcImage = await savePixels(ndarray(new Uint8Array(200 * 350 * 4), [200, 350, 4]), 'image/png');
-	const srcTexture = document.createTexture().setImage(srcImage).setMimeType('image/png');
+	test('resize - ndarray-pixels', async () => {
+		const document = new Document();
+		const srcImage = await savePixels(ndarray(new Uint8Array(200 * 350 * 4), [200, 350, 4]), 'image/png');
+		const srcTexture = document.createTexture().setImage(srcImage).setMimeType('image/png');
 
-	const dstTextureCeil = srcTexture.clone();
-	const dstTextureFloor = srcTexture.clone();
-	const dstTextureNearest = srcTexture.clone();
-	const dstTexture200x200 = srcTexture.clone();
-	const dstTexture1024x1024 = srcTexture.clone();
+		const dstTextureCeil = srcTexture.clone();
+		const dstTextureFloor = srcTexture.clone();
+		const dstTextureNearest = srcTexture.clone();
+		const dstTexture200x200 = srcTexture.clone();
+		const dstTexture1024x1024 = srcTexture.clone();
 
-	await compressTexture(dstTextureCeil, { resize: 'ceil-pot' });
-	await compressTexture(dstTextureFloor, { resize: 'floor-pot' });
-	await compressTexture(dstTextureNearest, { resize: 'nearest-pot' });
-	await compressTexture(dstTexture200x200, { resize: [200, 200] });
-	await compressTexture(dstTexture1024x1024, { resize: [1024, 1024] });
+		await compressTexture(dstTextureCeil, { resize: 'ceil-pot' });
+		await compressTexture(dstTextureFloor, { resize: 'floor-pot' });
+		await compressTexture(dstTextureNearest, { resize: 'nearest-pot' });
+		await compressTexture(dstTexture200x200, { resize: [200, 200] });
+		await compressTexture(dstTexture1024x1024, { resize: [1024, 1024] });
 
-	t.deepEqual(dstTextureCeil.getSize(), [256, 512], 'ceil - ndarray-pixels');
-	t.deepEqual(dstTextureFloor.getSize(), [128, 256], 'floor - ndarray-pixels');
-	t.deepEqual(dstTextureNearest.getSize(), [256, 256], 'nearest - ndarray-pixels');
-	t.deepEqual(dstTexture200x200.getSize(), [114, 200], '200x200 - ndarray-pixels');
-	t.deepEqual(dstTexture1024x1024.getSize(), [200, 350], '1024x1024 - ndarray-pixels');
+		deepEqual(dstTextureCeil.getSize(), [256, 512], 'ceil - ndarray-pixels');
+		deepEqual(dstTextureFloor.getSize(), [128, 256], 'floor - ndarray-pixels');
+		deepEqual(dstTextureNearest.getSize(), [256, 256], 'nearest - ndarray-pixels');
+		deepEqual(dstTexture200x200.getSize(), [114, 200], '200x200 - ndarray-pixels');
+		deepEqual(dstTexture1024x1024.getSize(), [200, 350], '1024x1024 - ndarray-pixels');
+	});
 });
 
 function createMockEncoder() {

--- a/packages/functions/test/transform-mesh.test.ts
+++ b/packages/functions/test/transform-mesh.test.ts
@@ -4,7 +4,7 @@ import { type bbox, Document, Primitive, type PrimitiveTarget, type vec3 } from 
 import { transformMesh, transformPrimitive } from '@gltf-transform/functions';
 import { logger, mat4, round, roundBbox } from '@gltf-transform/test-utils';
 
-describe('transformMesh', () => {
+describe('functions::transformMesh', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const prim = createPrimitive(document);

--- a/packages/functions/test/transform-mesh.test.ts
+++ b/packages/functions/test/transform-mesh.test.ts
@@ -1,137 +1,140 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { type bbox, Document, Primitive, type PrimitiveTarget, type vec3 } from '@gltf-transform/core';
 import { transformMesh, transformPrimitive } from '@gltf-transform/functions';
 import { logger, mat4, round, roundBbox } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createPrimitive(document);
-	const normal = prim.getAttribute('NORMAL')!;
-	const tangent = prim.getAttribute('TANGENT')!;
+describe('transformMesh', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createPrimitive(document);
+		const normal = prim.getAttribute('NORMAL')!;
+		const tangent = prim.getAttribute('TANGENT')!;
 
-	transformPrimitive(prim, mat4.identity([]));
-	t.deepEqual(primBounds(prim), { min: [-0.5, 10, -0.5], max: [0.5, 10, 0.5] }, 'identity - position');
-	t.deepEqual(normal.getElement(0, []), [0, 1, 0], 'identity - normal');
-	t.deepEqual(tangent.getElement(0, []), [1, 0, 0, 1], 'identity - tangent');
+		transformPrimitive(prim, mat4.identity([]));
+		deepEqual(primBounds(prim), { min: [-0.5, 10, -0.5], max: [0.5, 10, 0.5] }, 'identity - position');
+		deepEqual(normal.getElement(0, []), [0, 1, 0], 'identity - normal');
+		deepEqual(tangent.getElement(0, []), [1, 0, 0, 1], 'identity - tangent');
 
-	transformPrimitive(prim, mat4.fromScaling([], [2, 1, 2]));
-	t.deepEqual(primBounds(prim), { min: [-1, 10, -1], max: [1, 10, 1] }, 'scale - position');
-	t.deepEqual(normal.getElement(0, []), [0, 1, 0], 'scale - normal');
-	t.deepEqual(tangent.getElement(0, []), [1, 0, 0, 1], 'scale - tangent');
+		transformPrimitive(prim, mat4.fromScaling([], [2, 1, 2]));
+		deepEqual(primBounds(prim), { min: [-1, 10, -1], max: [1, 10, 1] }, 'scale - position');
+		deepEqual(normal.getElement(0, []), [0, 1, 0], 'scale - normal');
+		deepEqual(tangent.getElement(0, []), [1, 0, 0, 1], 'scale - tangent');
 
-	transformPrimitive(prim, mat4.fromTranslation([], [0, -10, 0]));
-	t.deepEqual(primBounds(prim), { min: [-1, 0, -1], max: [1, 0, 1] }, 'translate - position');
-	t.deepEqual(normal.getElement(0, []), [0, 1, 0], 'translate - normal');
-	t.deepEqual(tangent.getElement(0, []), [1, 0, 0, 1], 'translate - tangent');
+		transformPrimitive(prim, mat4.fromTranslation([], [0, -10, 0]));
+		deepEqual(primBounds(prim), { min: [-1, 0, -1], max: [1, 0, 1] }, 'translate - position');
+		deepEqual(normal.getElement(0, []), [0, 1, 0], 'translate - normal');
+		deepEqual(tangent.getElement(0, []), [1, 0, 0, 1], 'translate - tangent');
 
-	transformPrimitive(prim, mat4.fromRotation([], Math.PI / 2, [1, 0, 0]));
-	t.deepEqual(roundBbox(primBounds(prim)), { min: [-1, -1, 0], max: [1, 1, 0] }, 'rotate - position');
-	t.deepEqual(normal.getElement(0, []).map(round()), [0, 0, 1], 'rotate - normal');
-	t.deepEqual(tangent.getElement(0, []).map(round()), [1, 0, 0, 1], 'rotate - tangent');
-});
+		transformPrimitive(prim, mat4.fromRotation([], Math.PI / 2, [1, 0, 0]));
+		deepEqual(roundBbox(primBounds(prim)), { min: [-1, -1, 0], max: [1, 1, 0] }, 'rotate - position');
+		deepEqual(normal.getElement(0, []).map(round()), [0, 0, 1], 'rotate - normal');
+		deepEqual(tangent.getElement(0, []).map(round()), [1, 0, 0, 1], 'rotate - tangent');
+	});
 
-test('shared prims', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createPrimitive(document);
-	const meshA = document.createMesh('A').addPrimitive(prim);
-	const meshB = document.createMesh('B').addPrimitive(prim);
+	test('shared prims', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createPrimitive(document);
+		const meshA = document.createMesh('A').addPrimitive(prim);
+		const meshB = document.createMesh('B').addPrimitive(prim);
 
-	t.is(meshA.listPrimitives()[0], meshB.listPrimitives()[0], 'meshA = meshB, before');
+		strictEqual(meshA.listPrimitives()[0], meshB.listPrimitives()[0], 'meshA = meshB, before');
 
-	transformMesh(meshA, mat4.fromScaling([], [2, 2, 2]));
+		transformMesh(meshA, mat4.fromScaling([], [2, 2, 2]));
 
-	// Shared primitives must be cloned, and the copy transformed.
-	t.true(meshA.listPrimitives()[0] !== meshB.listPrimitives()[0], 'meshA !== meshB, after');
-});
+		// Shared primitives must be cloned, and the copy transformed.
+		ok(meshA.listPrimitives()[0] !== meshB.listPrimitives()[0], 'meshA !== meshB, after');
+	});
 
-test('shared vertex streams', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createPrimitive(document);
-	const primA = prim.clone();
-	const primB = prim.clone();
-	const meshA = document.createMesh('A').addPrimitive(primA);
-	document.createMesh('B').addPrimitive(primB);
+	test('shared vertex streams', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createPrimitive(document);
+		const primA = prim.clone();
+		const primB = prim.clone();
+		const meshA = document.createMesh('A').addPrimitive(primA);
+		document.createMesh('B').addPrimitive(primB);
 
-	t.is(primA.getAttribute('POSITION'), primB.getAttribute('POSITION'), 'primA = primB, before');
+		strictEqual(primA.getAttribute('POSITION'), primB.getAttribute('POSITION'), 'primA = primB, before');
 
-	transformMesh(meshA, mat4.fromScaling([], [2, 2, 2]));
+		transformMesh(meshA, mat4.fromScaling([], [2, 2, 2]));
 
-	// Option 'overwrite' option removed in v4, all primitives are now compacted
-	// and their accessors cloned.
-	t.true(
-		primA.getAttribute('POSITION') !== primB.getAttribute('POSITION'),
-		'primA !== primB, after (overwrite=true)',
-	);
-});
+		// Option 'overwrite' option removed in v4, all primitives are now compacted
+		// and their accessors cloned.
+		ok(
+			primA.getAttribute('POSITION') !== primB.getAttribute('POSITION'),
+			'primA !== primB, after (overwrite=true)',
+		);
+	});
 
-test('update multiple vertex streams', async (t) => {
-	const document = new Document().setLogger(logger);
-	const primA = createPrimitive(document);
-	const primB = createPrimitive(document);
-	const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
+	test('update multiple vertex streams', async () => {
+		const document = new Document().setLogger(logger);
+		const primA = createPrimitive(document);
+		const primB = createPrimitive(document);
+		const mesh = document.createMesh().addPrimitive(primA).addPrimitive(primB);
 
-	transformMesh(mesh, mat4.fromScaling([], [2, 2, 2]));
+		transformMesh(mesh, mat4.fromScaling([], [2, 2, 2]));
 
-	// biome-ignore format: Readability.
-	const SCALED = [
+		// biome-ignore format: Readability.
+		const SCALED = [
 		0.5, 10, 0.5,
 		0.5, 10, -0.5,
 		-0.5, 10, -0.5,
 		-0.5, 10, 0.5
 	].map((value) => value * 2.0);
 
-	t.deepEqual(Array.from(primA.getAttribute('POSITION').getArray()), SCALED, 'primA.POSITION');
-	t.deepEqual(Array.from(primB.getAttribute('POSITION').getArray()), SCALED, 'primB.POSITION');
-});
+		deepEqual(Array.from(primA.getAttribute('POSITION').getArray()), SCALED, 'primA.POSITION');
+		deepEqual(Array.from(primB.getAttribute('POSITION').getArray()), SCALED, 'primB.POSITION');
+	});
 
-test('morph targets', async (t) => {
-	const document = new Document().setLogger(logger);
-	const primA = createPrimitive(document);
-	const primB = primA.clone();
-	const meshA = document.createMesh().addPrimitive(primA);
-	const meshB = document.createMesh().addPrimitive(primB);
+	test('morph targets', async () => {
+		const document = new Document().setLogger(logger);
+		const primA = createPrimitive(document);
+		const primB = primA.clone();
+		const meshA = document.createMesh().addPrimitive(primA);
+		const meshB = document.createMesh().addPrimitive(primB);
 
-	const targetPosition = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(
-			// biome-ignore format: Readability.
-			new Float32Array([
+		const targetPosition = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(
+				// biome-ignore format: Readability.
+				new Float32Array([
 				0, 1, 0,
 				0, 1, 0,
 				0, 1, 0,
 				0, 1, 0,
 			]),
+			);
+		const target = document.createPrimitiveTarget().setAttribute('POSITION', targetPosition);
+		primA.addTarget(target);
+		primB.addTarget(target.clone());
+
+		transformMesh(meshA, mat4.fromScaling([], [2, 2, 2]));
+
+		deepEqual(
+			Array.from(meshA.listPrimitives()[0].listTargets()[0].getAttribute('POSITION').getArray()),
+			// biome-ignore format: Readability.
+			[
+			0, 2, 0,
+			0, 2, 0,
+			0, 2, 0,
+			0, 2, 0,
+		],
+			'scales target position',
 		);
-	const target = document.createPrimitiveTarget().setAttribute('POSITION', targetPosition);
-	primA.addTarget(target);
-	primB.addTarget(target.clone());
 
-	transformMesh(meshA, mat4.fromScaling([], [2, 2, 2]));
-
-	t.deepEqual(
-		Array.from(meshA.listPrimitives()[0].listTargets()[0].getAttribute('POSITION').getArray()),
-		// biome-ignore format: Readability.
-		[
-			0, 2, 0,
-			0, 2, 0,
-			0, 2, 0,
-			0, 2, 0,
-		],
-		'scales target position',
-	);
-
-	t.deepEqual(
-		Array.from(meshB.listPrimitives()[0].listTargets()[0].getAttribute('POSITION').getArray()),
-		// biome-ignore format: Readability.
-		[
+		deepEqual(
+			Array.from(meshB.listPrimitives()[0].listTargets()[0].getAttribute('POSITION').getArray()),
+			// biome-ignore format: Readability.
+			[
 			0, 1, 0,
 			0, 1, 0,
 			0, 1, 0,
 			0, 1, 0,
 		],
-		'skips shared target position',
-	);
+			'skips shared target position',
+		);
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/uninstance.test.ts
+++ b/packages/functions/test/uninstance.test.ts
@@ -5,7 +5,7 @@ import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import { uninstance } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('uninstance', () => {
+describe('functions::uninstance', () => {
 	test('basic', async () => {
 		const document = new Document().setLogger(logger);
 		const buffer = document.createBuffer();

--- a/packages/functions/test/uninstance.test.ts
+++ b/packages/functions/test/uninstance.test.ts
@@ -1,15 +1,17 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import { uninstance } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document().setLogger(logger);
-	const buffer = document.createBuffer();
+describe('uninstance', () => {
+	test('basic', async () => {
+		const document = new Document().setLogger(logger);
+		const buffer = document.createBuffer();
 
-	// biome-ignore format: Readability.
-	const translation = document
+		// biome-ignore format: Readability.
+		const translation = document
 		.createAccessor()
 		.setType('VEC3')
 		.setArray(new Uint8Array([
@@ -19,47 +21,48 @@ test('basic', async (t) => {
 		]))
 		.setNormalized(true)
 		.setBuffer(buffer);
-	const id = document
-		.createAccessor()
-		.setType('SCALAR')
-		.setArray(new Uint16Array([100, 101, 102]))
-		.setBuffer(buffer);
+		const id = document
+			.createAccessor()
+			.setType('SCALAR')
+			.setArray(new Uint16Array([100, 101, 102]))
+			.setBuffer(buffer);
 
-	const batchExtension = document.createExtension(EXTMeshGPUInstancing);
-	const batch = batchExtension
-		.createInstancedMesh()
-		.setAttribute('TRANSLATION', translation)
-		.setAttribute('_INSTANCE_ID', id);
+		const batchExtension = document.createExtension(EXTMeshGPUInstancing);
+		const batch = batchExtension
+			.createInstancedMesh()
+			.setAttribute('TRANSLATION', translation)
+			.setAttribute('_INSTANCE_ID', id);
 
-	const mesh = document.createMesh();
-	const batchNode = document.createNode('Batch').setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch);
-	document.createScene().addChild(batchNode);
+		const mesh = document.createMesh();
+		const batchNode = document.createNode('Batch').setMesh(mesh).setExtension('EXT_mesh_gpu_instancing', batch);
+		document.createScene().addChild(batchNode);
 
-	await document.transform(uninstance());
+		await document.transform(uninstance());
 
-	t.is(batchNode.getMesh(), null, 'batchNode.mesh == null');
-	t.is(batchNode.getExtension('EXT_mesh_gpu_instancing'), null, 'node extension removed');
-	t.deepEqual(document.getRoot().listExtensionsUsed(), [], 'document extension removed');
+		strictEqual(batchNode.getMesh(), null, 'batchNode.mesh == null');
+		strictEqual(batchNode.getExtension('EXT_mesh_gpu_instancing'), null, 'node extension removed');
+		deepEqual(document.getRoot().listExtensionsUsed(), [], 'document extension removed');
 
-	t.deepEqual(
-		batchNode.listChildren().map((child) => child.getName()),
-		['Batch_0', 'Batch_1', 'Batch_2'],
-		'sets instance names',
-	);
-	t.deepEqual(
-		batchNode.listChildren().map((child) => child.getTranslation()),
-		[
-			[0, 0, 0],
-			[0, 0, 0.5019607843137255],
-			[0, 0, 1],
-		],
-		'sets instance translations',
-	);
-	t.deepEqual(
-		batchNode.listChildren().map((child) => child.getExtras()),
-		[{ _INSTANCE_ID: 100 }, { _INSTANCE_ID: 101 }, { _INSTANCE_ID: 102 }],
-		'sets instance extras',
-	);
-	t.is(translation.isDisposed(), true, 'disposes translation attribute');
-	t.is(id.isDisposed(), true, 'disposes id attribute');
+		deepEqual(
+			batchNode.listChildren().map((child) => child.getName()),
+			['Batch_0', 'Batch_1', 'Batch_2'],
+			'sets instance names',
+		);
+		deepEqual(
+			batchNode.listChildren().map((child) => child.getTranslation()),
+			[
+				[0, 0, 0],
+				[0, 0, 0.5019607843137255],
+				[0, 0, 1],
+			],
+			'sets instance translations',
+		);
+		deepEqual(
+			batchNode.listChildren().map((child) => child.getExtras()),
+			[{ _INSTANCE_ID: 100 }, { _INSTANCE_ID: 101 }, { _INSTANCE_ID: 102 }],
+			'sets instance extras',
+		);
+		strictEqual(translation.isDisposed(), true, 'disposes translation attribute');
+		strictEqual(id.isDisposed(), true, 'disposes id attribute');
+	});
 });

--- a/packages/functions/test/unlit.test.ts
+++ b/packages/functions/test/unlit.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { unlit } from '@gltf-transform/functions';
 
-describe('unlit', () => {
+describe('functions::unlit', () => {
 	test('basic', async () => {
 		const document = new Document();
 		document.createMaterial();

--- a/packages/functions/test/unlit.test.ts
+++ b/packages/functions/test/unlit.test.ts
@@ -1,11 +1,14 @@
+import { strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { unlit } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document();
-	document.createMaterial();
-	await document.transform(unlit());
-	const unlitExtension = document.getRoot().listExtensionsUsed()[0];
-	t.is(unlitExtension.extensionName, 'KHR_materials_unlit', 'adds extension');
+describe('unlit', () => {
+	test('basic', async () => {
+		const document = new Document();
+		document.createMaterial();
+		await document.transform(unlit());
+		const unlitExtension = document.getRoot().listExtensionsUsed()[0];
+		strictEqual(unlitExtension.extensionName, 'KHR_materials_unlit', 'adds extension');
+	});
 });

--- a/packages/functions/test/unpartition.test.ts
+++ b/packages/functions/test/unpartition.test.ts
@@ -4,7 +4,7 @@ import { Document } from '@gltf-transform/core';
 import { unpartition } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
 
-describe('unpartition', () => {
+describe('functions::unpartition', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const root = document.getRoot();

--- a/packages/functions/test/unpartition.test.ts
+++ b/packages/functions/test/unpartition.test.ts
@@ -1,27 +1,30 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { unpartition } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const document = new Document();
-	const root = document.getRoot();
-	const bufferA = document.createBuffer();
-	const bufferB = document.createBuffer();
-	const bufferC = document.createBuffer();
-	const accessorA = document.createAccessor().setBuffer(bufferA);
-	const accessorB = document.createAccessor().setBuffer(bufferB);
-	const accessorC = document.createAccessor().setBuffer(bufferC);
+describe('unpartition', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const root = document.getRoot();
+		const bufferA = document.createBuffer();
+		const bufferB = document.createBuffer();
+		const bufferC = document.createBuffer();
+		const accessorA = document.createAccessor().setBuffer(bufferA);
+		const accessorB = document.createAccessor().setBuffer(bufferB);
+		const accessorC = document.createAccessor().setBuffer(bufferC);
 
-	document.setLogger(logger);
+		document.setLogger(logger);
 
-	await document.transform(unpartition());
+		await document.transform(unpartition());
 
-	t.is(root.listBuffers().length, 1, 'buffers.length === 1');
-	t.falsy(bufferA.isDisposed(), 'buffersA live');
-	t.truthy(bufferB.isDisposed(), 'buffersB disposed');
-	t.truthy(bufferC.isDisposed(), 'buffersC disposed');
-	t.is(accessorA.getBuffer(), bufferA, 'accessorA → bufferA');
-	t.is(accessorB.getBuffer(), bufferA, 'accessorA → bufferA');
-	t.is(accessorC.getBuffer(), bufferA, 'accessorA → bufferA');
+		strictEqual(root.listBuffers().length, 1, 'buffers.length === 1');
+		strictEqual(bufferA.isDisposed(), false, 'buffersA live');
+		ok(bufferB.isDisposed(), 'buffersB disposed');
+		ok(bufferC.isDisposed(), 'buffersC disposed');
+		strictEqual(accessorA.getBuffer(), bufferA, 'accessorA → bufferA');
+		strictEqual(accessorB.getBuffer(), bufferA, 'accessorA → bufferA');
+		strictEqual(accessorC.getBuffer(), bufferA, 'accessorA → bufferA');
+	});
 });

--- a/packages/functions/test/unweld.test.ts
+++ b/packages/functions/test/unweld.test.ts
@@ -1,42 +1,45 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, Primitive } from '@gltf-transform/core';
 import { unweld } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', async (t) => {
-	const doc = new Document();
-	const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 1, 0, 0, -1, 0, 1, 0, 0, -1, 0, 0]);
-	const position = doc.createAccessor().setType(Accessor.Type.VEC3).setArray(positionArray);
-	const indices1 = doc.createAccessor().setArray(new Uint32Array([0, 3, 5, 0, 3, 6]));
-	const indices2 = doc.createAccessor().setArray(new Uint32Array([0, 3, 5, 1, 4, 5]));
-	const prim1 = doc
-		.createPrimitive()
-		.setIndices(indices1)
-		.setAttribute('POSITION', position)
-		.setMode(Primitive.Mode.TRIANGLES);
-	const prim2 = doc
-		.createPrimitive()
-		.setIndices(indices2)
-		.setAttribute('POSITION', position)
-		.setMode(Primitive.Mode.TRIANGLES);
-	const prim3 = doc.createPrimitive().setAttribute('POSITION', position).setMode(Primitive.Mode.TRIANGLE_FAN);
-	doc.createMesh().addPrimitive(prim1).addPrimitive(prim2).addPrimitive(prim3);
+describe('unweld', () => {
+	test('basic', async () => {
+		const doc = new Document();
+		const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 1, 0, 0, -1, 0, 1, 0, 0, -1, 0, 0]);
+		const position = doc.createAccessor().setType(Accessor.Type.VEC3).setArray(positionArray);
+		const indices1 = doc.createAccessor().setArray(new Uint32Array([0, 3, 5, 0, 3, 6]));
+		const indices2 = doc.createAccessor().setArray(new Uint32Array([0, 3, 5, 1, 4, 5]));
+		const prim1 = doc
+			.createPrimitive()
+			.setIndices(indices1)
+			.setAttribute('POSITION', position)
+			.setMode(Primitive.Mode.TRIANGLES);
+		const prim2 = doc
+			.createPrimitive()
+			.setIndices(indices2)
+			.setAttribute('POSITION', position)
+			.setMode(Primitive.Mode.TRIANGLES);
+		const prim3 = doc.createPrimitive().setAttribute('POSITION', position).setMode(Primitive.Mode.TRIANGLE_FAN);
+		doc.createMesh().addPrimitive(prim1).addPrimitive(prim2).addPrimitive(prim3);
 
-	await doc.transform(unweld());
+		await doc.transform(unweld());
 
-	t.is(prim1.getIndices(), null, 'no index on prim1');
-	t.is(prim2.getIndices(), null, 'no index on prim2');
-	t.is(prim3.getIndices(), null, 'no index on prim3');
+		strictEqual(prim1.getIndices(), null, 'no index on prim1');
+		strictEqual(prim2.getIndices(), null, 'no index on prim2');
+		strictEqual(prim3.getIndices(), null, 'no index on prim3');
 
-	t.deepEqual(
-		prim1.getAttribute('POSITION').getArray(),
-		new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, -1, 0, 0]),
-		'subset of vertices in prim1',
-	);
-	t.deepEqual(
-		prim2.getAttribute('POSITION').getArray(),
-		new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, -1, 0, 1, 0, 0]),
-		'subset of vertices in prim2',
-	);
-	t.deepEqual(prim3.getAttribute('POSITION').getArray(), positionArray, 'original vertices in prim3');
-	t.is(doc.getRoot().listAccessors().length, 3, 'keeps only needed accessors');
+		deepEqual(
+			prim1.getAttribute('POSITION').getArray(),
+			new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, -1, 0, 0]),
+			'subset of vertices in prim1',
+		);
+		deepEqual(
+			prim2.getAttribute('POSITION').getArray(),
+			new Float32Array([0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, -1, 0, 1, 0, 0]),
+			'subset of vertices in prim2',
+		);
+		deepEqual(prim3.getAttribute('POSITION').getArray(), positionArray, 'original vertices in prim3');
+		strictEqual(doc.getRoot().listAccessors().length, 3, 'keeps only needed accessors');
+	});
 });

--- a/packages/functions/test/unweld.test.ts
+++ b/packages/functions/test/unweld.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, Document, Primitive } from '@gltf-transform/core';
 import { unweld } from '@gltf-transform/functions';
 
-describe('unweld', () => {
+describe('functions::unweld', () => {
 	test('basic', async () => {
 		const doc = new Document();
 		const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 1, 0, 0, -1, 0, 1, 0, 0, -1, 0, 0]);

--- a/packages/functions/test/unwrap.test.ts
+++ b/packages/functions/test/unwrap.test.ts
@@ -1,3 +1,5 @@
+import { deepEqual, notDeepStrictEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { type Accessor, Document, type Primitive, type vec2 } from '@gltf-transform/core';
 import {
 	getPrimitiveVertexCount,
@@ -7,226 +9,227 @@ import {
 	VertexCountMethod,
 } from '@gltf-transform/functions';
 import { createTorusKnotPrimitive, logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import * as watlas from 'watlas';
 
 await watlas.Initialize();
 
-test('unwrapPrimitives - unindexed', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
-	document.createMesh().addPrimitive(prim);
+describe('unwrap', () => {
+	test('unwrapPrimitives - unindexed', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+		document.createMesh().addPrimitive(prim);
 
-	await document.transform(unweld());
+		await document.transform(unweld());
 
-	t.falsy(prim.getIndices(), 'indices = null (initial)');
+		strictEqual(prim.getIndices(), null, 'indices = null (initial)');
 
-	unwrapPrimitives([prim], { watlas, overwrite: false });
+		unwrapPrimitives([prim], { watlas, overwrite: false });
 
-	t.falsy(prim.getIndices(), 'indices = null (overwrite=false)');
+		strictEqual(prim.getIndices(), null, 'indices = null (overwrite=false)');
 
-	unwrapPrimitives([prim], { watlas, overwrite: true });
+		unwrapPrimitives([prim], { watlas, overwrite: true });
 
-	t.truthy(prim.getIndices(), 'indices != null (overwrite=true)');
-});
+		ok(prim.getIndices(), 'indices != null (overwrite=true)');
+	});
 
-test('unwrapPrimitives - vertex count', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+	test('unwrapPrimitives - vertex count', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
 
-	const srcIndexCount = prim.getIndices().getCount();
-	const srcVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
+		const srcIndexCount = prim.getIndices().getCount();
+		const srcVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
 
-	unwrapPrimitives([prim], { watlas, overwrite: true });
+		unwrapPrimitives([prim], { watlas, overwrite: true });
 
-	const dstIndexCount = prim.getIndices().getCount();
-	const dstVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
+		const dstIndexCount = prim.getIndices().getCount();
+		const dstVertexCount = getPrimitiveVertexCount(prim, VertexCountMethod.UPLOAD);
 
-	t.is(dstIndexCount, srcIndexCount, 'srcIndexCount == dst.indexCount');
-	t.is(srcVertexCount, 63, 'srcVertexCount = 63');
-	t.true(dstVertexCount > 100 && dstVertexCount < 150, '100 < dstVertexCount < 150');
-	t.is(getPrimitiveVertexCount(prim, VertexCountMethod.UNUSED), 0, 'no unused vertices');
-});
+		strictEqual(dstIndexCount, srcIndexCount, 'srcIndexCount == dst.indexCount');
+		strictEqual(srcVertexCount, 63, 'srcVertexCount = 63');
+		ok(dstVertexCount > 100 && dstVertexCount < 150, '100 < dstVertexCount < 150');
+		strictEqual(getPrimitiveVertexCount(prim, VertexCountMethod.UNUSED), 0, 'no unused vertices');
+	});
 
-test('unwrapPrimitives - texcoord', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+	test('unwrapPrimitives - texcoord', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
 
-	t.truthy(prim.getAttribute('TEXCOORD_0'), 'TEXCOORD_0 = A (initial)');
-	t.is(prim.getAttribute('TEXCOORD_1'), null, 'TEXCOORD_1 = null (initial)');
-	t.is(prim.getAttribute('TEXCOORD_3'), null, 'TEXCOORD_0 = null (initial)');
+		ok(prim.getAttribute('TEXCOORD_0'), 'TEXCOORD_0 = A (initial)');
+		strictEqual(prim.getAttribute('TEXCOORD_1'), null, 'TEXCOORD_1 = null (initial)');
+		strictEqual(prim.getAttribute('TEXCOORD_3'), null, 'TEXCOORD_0 = null (initial)');
 
-	unwrapPrimitives([prim], { watlas, texcoord: 1 });
+		unwrapPrimitives([prim], { watlas, texcoord: 1 });
 
-	t.truthy(prim.getAttribute('TEXCOORD_0'), 'TEXCOORD_0 = A');
-	t.truthy(prim.getAttribute('TEXCOORD_1'), 'TEXCOORD_1 = B');
-	t.is(prim.getAttribute('TEXCOORD_3'), null, 'TEXCOORD_0 = null');
-	t.notDeepEqual(prim.getAttribute('TEXCOORD_0'), prim.getAttribute('TEXCOORD_1'), 'A != B');
+		ok(prim.getAttribute('TEXCOORD_0'), 'TEXCOORD_0 = A');
+		ok(prim.getAttribute('TEXCOORD_1'), 'TEXCOORD_1 = B');
+		strictEqual(prim.getAttribute('TEXCOORD_3'), null, 'TEXCOORD_0 = null');
+		notDeepStrictEqual(prim.getAttribute('TEXCOORD_0'), prim.getAttribute('TEXCOORD_1'), 'A != B');
 
-	unwrapPrimitives([prim], { watlas, texcoord: 2 });
+		unwrapPrimitives([prim], { watlas, texcoord: 2 });
 
-	t.truthy(prim.getAttribute('TEXCOORD_0'), 'TEXCOORD_0 = A');
-	t.truthy(prim.getAttribute('TEXCOORD_1'), 'TEXCOORD_1 = B');
-	t.truthy(prim.getAttribute('TEXCOORD_2'), 'TEXCOORD_2 = C');
-	t.notDeepEqual(prim.getAttribute('TEXCOORD_0'), prim.getAttribute('TEXCOORD_1'), 'A != B');
-	t.notDeepEqual(prim.getAttribute('TEXCOORD_1'), prim.getAttribute('TEXCOORD_2'), 'B != C');
-});
+		ok(prim.getAttribute('TEXCOORD_0'), 'TEXCOORD_0 = A');
+		ok(prim.getAttribute('TEXCOORD_1'), 'TEXCOORD_1 = B');
+		ok(prim.getAttribute('TEXCOORD_2'), 'TEXCOORD_2 = C');
+		notDeepStrictEqual(prim.getAttribute('TEXCOORD_0'), prim.getAttribute('TEXCOORD_1'), 'A != B');
+		notDeepStrictEqual(prim.getAttribute('TEXCOORD_1'), prim.getAttribute('TEXCOORD_2'), 'B != C');
+	});
 
-test('unwrapPrimitives - overwrite', async (t) => {
-	const document = new Document().setLogger(logger);
-	const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+	test('unwrapPrimitives - overwrite', async () => {
+		const document = new Document().setLogger(logger);
+		const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });
 
-	const texCoordA = prim.getAttribute('TEXCOORD_0');
-	const texCoordB = texCoordA.clone();
-	prim.setAttribute('TEXCOORD_1', texCoordB);
+		const texCoordA = prim.getAttribute('TEXCOORD_0');
+		const texCoordB = texCoordA.clone();
+		prim.setAttribute('TEXCOORD_1', texCoordB);
 
-	scaleAccessor(texCoordA, 2);
-	scaleAccessor(texCoordB, 0.5);
+		scaleAccessor(texCoordA, 2);
+		scaleAccessor(texCoordB, 0.5);
 
-	const texCoordBoundsA = getTexCoordBounds(texCoordA);
-	const texCoordBoundsB = getTexCoordBounds(texCoordB);
-	const texCoordBoundsC = { min: [0, 0] as vec2, max: [1, 1] as vec2 };
+		const texCoordBoundsA = getTexCoordBounds(texCoordA);
+		const texCoordBoundsB = getTexCoordBounds(texCoordB);
+		const texCoordBoundsC = { min: [0, 0] as vec2, max: [1, 1] as vec2 };
 
-	t.is(prim.getAttribute('TEXCOORD_0'), texCoordA, 'TEXCOORD_0 = A');
-	t.is(prim.getAttribute('TEXCOORD_1'), texCoordB, 'TEXCOORD_1 = B');
-	t.deepEqual(texCoordBoundsA, { min: [0, 0], max: [2, 2] }, 'TEXCOORD_0 bounds');
-	t.deepEqual(texCoordBoundsB, { min: [0, 0], max: [0.5, 0.5] }, 'TEXCOORD_1 bounds');
+		strictEqual(prim.getAttribute('TEXCOORD_0'), texCoordA, 'TEXCOORD_0 = A');
+		strictEqual(prim.getAttribute('TEXCOORD_1'), texCoordB, 'TEXCOORD_1 = B');
+		deepEqual(texCoordBoundsA, { min: [0, 0], max: [2, 2] }, 'TEXCOORD_0 bounds');
+		deepEqual(texCoordBoundsB, { min: [0, 0], max: [0.5, 0.5] }, 'TEXCOORD_1 bounds');
 
-	unwrapPrimitives([prim], { watlas, texcoord: 1, overwrite: false });
+		unwrapPrimitives([prim], { watlas, texcoord: 1, overwrite: false });
 
-	t.is(prim.getAttribute('TEXCOORD_0'), texCoordA, 'TEXCOORD_0 = A');
-	t.is(prim.getAttribute('TEXCOORD_1'), texCoordB, 'TEXCOORD_1 = B');
-	t.deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_0')), texCoordBoundsA, 'TEXCOORD_0 = A');
-	t.deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_1')), texCoordBoundsB, 'TEXCOORD_1 = B');
+		strictEqual(prim.getAttribute('TEXCOORD_0'), texCoordA, 'TEXCOORD_0 = A');
+		strictEqual(prim.getAttribute('TEXCOORD_1'), texCoordB, 'TEXCOORD_1 = B');
+		deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_0')), texCoordBoundsA, 'TEXCOORD_0 = A');
+		deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_1')), texCoordBoundsB, 'TEXCOORD_1 = B');
 
-	unwrapPrimitives([prim], { watlas, texcoord: 1, overwrite: true });
+		unwrapPrimitives([prim], { watlas, texcoord: 1, overwrite: true });
 
-	// accessors may be replaced, and vertices reordered, but UV layout is the same.
-	t.deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_0')), texCoordBoundsA, 'TEXCOORD_0 = A');
-	t.deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_1')), texCoordBoundsC, 'TEXCOORD_1 = C');
-});
+		// accessors may be replaced, and vertices reordered, but UV layout is the same.
+		deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_0')), texCoordBoundsA, 'TEXCOORD_0 = A');
+		deepEqual(getTexCoordBounds(prim.getAttribute('TEXCOORD_1')), texCoordBoundsC, 'TEXCOORD_1 = C');
+	});
 
-test('unwrap - primitive', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('unwrap - primitive', async () => {
+		const document = new Document().setLogger(logger);
 
-	const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
-	const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
-	const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
-	const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
-	const meshB = document.createMesh('B').addPrimitive(primC);
-	const nodeA = document.createNode('A').setMesh(meshA);
-	const nodeB = document.createNode('B').setMesh(meshB);
-	document.createScene().addChild(nodeA).addChild(nodeB);
+		const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+		const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
+		const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
+		const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
+		const meshB = document.createMesh('B').addPrimitive(primC);
+		const nodeA = document.createNode('A').setMesh(meshA);
+		const nodeB = document.createNode('B').setMesh(meshB);
+		document.createScene().addChild(nodeA).addChild(nodeB);
 
-	scaleAccessor(primA.getAttribute('POSITION'), 10);
-	scaleAccessor(primB.getAttribute('POSITION'), 5);
-	scaleAccessor(primC.getAttribute('POSITION'), 0.5);
+		scaleAccessor(primA.getAttribute('POSITION'), 10);
+		scaleAccessor(primB.getAttribute('POSITION'), 5);
+		scaleAccessor(primC.getAttribute('POSITION'), 0.5);
 
-	primA.setAttribute('TEXCOORD_0', null);
-	primB.setAttribute('TEXCOORD_0', null);
-	primC.setAttribute('TEXCOORD_0', null);
+		primA.setAttribute('TEXCOORD_0', null);
+		primB.setAttribute('TEXCOORD_0', null);
+		primC.setAttribute('TEXCOORD_0', null);
 
-	await document.transform(unwrap({ watlas, groupBy: 'primitive', overwrite: true }));
+		await document.transform(unwrap({ watlas, groupBy: 'primitive', overwrite: true }));
 
-	const areaA = getTexCoordArea(primA, 0);
-	const areaB = getTexCoordArea(primB, 0);
-	const areaC = getTexCoordArea(primC, 0);
+		const areaA = getTexCoordArea(primA, 0);
+		const areaB = getTexCoordArea(primB, 0);
+		const areaC = getTexCoordArea(primC, 0);
 
-	t.true(areaA > 0.4 && areaA < 0.6, '0.4 < areaA < 0.6');
-	t.true(areaB > 0.4 && areaB < 0.6, '0.4 < areaB < 0.6');
-	t.true(areaC > 0.4 && areaC < 0.6, '0.4 < areaC < 0.6');
-});
+		ok(areaA > 0.4 && areaA < 0.6, '0.4 < areaA < 0.6');
+		ok(areaB > 0.4 && areaB < 0.6, '0.4 < areaB < 0.6');
+		ok(areaC > 0.4 && areaC < 0.6, '0.4 < areaC < 0.6');
+	});
 
-test('unwrap - mesh', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('unwrap - mesh', async () => {
+		const document = new Document().setLogger(logger);
 
-	const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
-	const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
-	const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
-	const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
-	const meshB = document.createMesh('B').addPrimitive(primC);
-	const nodeA = document.createNode('A').setMesh(meshA);
-	const nodeB = document.createNode('B').setMesh(meshB);
-	document.createScene().addChild(nodeA).addChild(nodeB);
+		const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+		const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
+		const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
+		const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
+		const meshB = document.createMesh('B').addPrimitive(primC);
+		const nodeA = document.createNode('A').setMesh(meshA);
+		const nodeB = document.createNode('B').setMesh(meshB);
+		document.createScene().addChild(nodeA).addChild(nodeB);
 
-	scaleAccessor(primA.getAttribute('POSITION'), 10);
-	scaleAccessor(primB.getAttribute('POSITION'), 5);
-	scaleAccessor(primC.getAttribute('POSITION'), 0.5);
+		scaleAccessor(primA.getAttribute('POSITION'), 10);
+		scaleAccessor(primB.getAttribute('POSITION'), 5);
+		scaleAccessor(primC.getAttribute('POSITION'), 0.5);
 
-	primA.setAttribute('TEXCOORD_0', null);
-	primB.setAttribute('TEXCOORD_0', null);
-	primC.setAttribute('TEXCOORD_0', null);
+		primA.setAttribute('TEXCOORD_0', null);
+		primB.setAttribute('TEXCOORD_0', null);
+		primC.setAttribute('TEXCOORD_0', null);
 
-	await document.transform(unwrap({ watlas, groupBy: 'mesh', overwrite: true }));
+		await document.transform(unwrap({ watlas, groupBy: 'mesh', overwrite: true }));
 
-	const areaA = getTexCoordArea(primA, 0);
-	const areaB = getTexCoordArea(primB, 0);
-	const areaC = getTexCoordArea(primC, 0);
+		const areaA = getTexCoordArea(primA, 0);
+		const areaB = getTexCoordArea(primB, 0);
+		const areaC = getTexCoordArea(primC, 0);
 
-	t.true(areaA > 0.3 && areaA < 0.5, '0.3 < areaA < 0.5');
-	t.true(areaB > 0.05 && areaB < 0.2, '0.05 < areaB < 0.2');
-	t.true(areaC > 0.4 && areaC < 0.6, '0.4 < areaC < 0.6');
-});
+		ok(areaA > 0.3 && areaA < 0.5, '0.3 < areaA < 0.5');
+		ok(areaB > 0.05 && areaB < 0.2, '0.05 < areaB < 0.2');
+		ok(areaC > 0.4 && areaC < 0.6, '0.4 < areaC < 0.6');
+	});
 
-test('unwrap - scene', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('unwrap - scene', async () => {
+		const document = new Document().setLogger(logger);
 
-	const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
-	const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
-	const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
-	const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
-	const meshB = document.createMesh('B').addPrimitive(primC);
-	const nodeA = document.createNode('A').setMesh(meshA);
-	const nodeB = document.createNode('B').setMesh(meshB);
-	document.createScene().addChild(nodeA).addChild(nodeB);
+		const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+		const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
+		const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
+		const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
+		const meshB = document.createMesh('B').addPrimitive(primC);
+		const nodeA = document.createNode('A').setMesh(meshA);
+		const nodeB = document.createNode('B').setMesh(meshB);
+		document.createScene().addChild(nodeA).addChild(nodeB);
 
-	scaleAccessor(primA.getAttribute('POSITION'), 10);
-	scaleAccessor(primB.getAttribute('POSITION'), 5);
-	scaleAccessor(primC.getAttribute('POSITION'), 0.5);
+		scaleAccessor(primA.getAttribute('POSITION'), 10);
+		scaleAccessor(primB.getAttribute('POSITION'), 5);
+		scaleAccessor(primC.getAttribute('POSITION'), 0.5);
 
-	primA.setAttribute('TEXCOORD_0', null);
-	primB.setAttribute('TEXCOORD_0', null);
-	primC.setAttribute('TEXCOORD_0', null);
+		primA.setAttribute('TEXCOORD_0', null);
+		primB.setAttribute('TEXCOORD_0', null);
+		primC.setAttribute('TEXCOORD_0', null);
 
-	await document.transform(unwrap({ watlas, groupBy: 'scene', overwrite: true }));
+		await document.transform(unwrap({ watlas, groupBy: 'scene', overwrite: true }));
 
-	const areaA = getTexCoordArea(primA, 0);
-	const areaB = getTexCoordArea(primB, 0);
-	const areaC = getTexCoordArea(primC, 0);
+		const areaA = getTexCoordArea(primA, 0);
+		const areaB = getTexCoordArea(primB, 0);
+		const areaC = getTexCoordArea(primC, 0);
 
-	t.true(areaA > 0.3 && areaA < 0.5, '0.3 < areaA < 0.5');
-	t.true(areaB > 0.05 && areaB < 0.2, '0.05 < areaB < 0.2');
-	t.true(areaC > 0.0 && areaC < 0.01, '0.0 < areaC < 0.01');
-});
+		ok(areaA > 0.3 && areaA < 0.5, '0.3 < areaA < 0.5');
+		ok(areaB > 0.05 && areaB < 0.2, '0.05 < areaB < 0.2');
+		ok(areaC > 0.0 && areaC < 0.01, '0.0 < areaC < 0.01');
+	});
 
-test('unwrap - scene scaled', async (t) => {
-	const document = new Document().setLogger(logger);
+	test('unwrap - scene scaled', async () => {
+		const document = new Document().setLogger(logger);
 
-	const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
-	const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
-	const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
-	const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
-	const meshB = document.createMesh('B').addPrimitive(primC);
-	const nodeA = document.createNode('A').setMesh(meshA);
-	const nodeB = document.createNode('B').setMesh(meshB);
-	document.createScene().addChild(nodeA).addChild(nodeB);
+		const primA = createTorusKnotPrimitive(document, { tubularSegments: 6 });
+		const primB = createTorusKnotPrimitive(document, { tubularSegments: 7 });
+		const primC = createTorusKnotPrimitive(document, { tubularSegments: 8 });
+		const meshA = document.createMesh('A').addPrimitive(primA).addPrimitive(primB);
+		const meshB = document.createMesh('B').addPrimitive(primC);
+		const nodeA = document.createNode('A').setMesh(meshA);
+		const nodeB = document.createNode('B').setMesh(meshB);
+		document.createScene().addChild(nodeA).addChild(nodeB);
 
-	nodeA.setScale([10, 10, 10]);
-	nodeB.setScale([0.5, 0.5, 0.5]);
+		nodeA.setScale([10, 10, 10]);
+		nodeB.setScale([0.5, 0.5, 0.5]);
 
-	primA.setAttribute('TEXCOORD_0', null);
-	primB.setAttribute('TEXCOORD_0', null);
-	primC.setAttribute('TEXCOORD_0', null);
+		primA.setAttribute('TEXCOORD_0', null);
+		primB.setAttribute('TEXCOORD_0', null);
+		primC.setAttribute('TEXCOORD_0', null);
 
-	await document.transform(unwrap({ watlas, groupBy: 'scene', overwrite: true }));
+		await document.transform(unwrap({ watlas, groupBy: 'scene', overwrite: true }));
 
-	const areaA = getTexCoordArea(primA, 0);
-	const areaB = getTexCoordArea(primB, 0);
-	const areaC = getTexCoordArea(primC, 0);
+		const areaA = getTexCoordArea(primA, 0);
+		const areaB = getTexCoordArea(primB, 0);
+		const areaC = getTexCoordArea(primC, 0);
 
-	t.true(areaA > 0.2 && areaA < 0.3, '0.2 < areaA < 0.3');
-	t.true(areaB > 0.2 && areaB < 0.3, '0.2 < areaB < 0.3');
-	t.true(areaC > 0.0 && areaC < 0.01, '0.0 < areaC < 0.01');
+		ok(areaA > 0.2 && areaA < 0.3, '0.2 < areaA < 0.3');
+		ok(areaB > 0.2 && areaB < 0.3, '0.2 < areaB < 0.3');
+		ok(areaC > 0.0 && areaC < 0.01, '0.0 < areaC < 0.01');
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/unwrap.test.ts
+++ b/packages/functions/test/unwrap.test.ts
@@ -13,7 +13,7 @@ import * as watlas from 'watlas';
 
 await watlas.Initialize();
 
-describe('unwrap', () => {
+describe('functions::unwrap', () => {
 	test('unwrapPrimitives - unindexed', async () => {
 		const document = new Document().setLogger(logger);
 		const prim = createTorusKnotPrimitive(document, { tubularSegments: 6 });

--- a/packages/functions/test/utils.test.ts
+++ b/packages/functions/test/utils.test.ts
@@ -1,79 +1,82 @@
+import { deepEqual, fail, ok, strictEqual, throws } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document, type GLTF, Primitive, type Transform, type TransformContext } from '@gltf-transform/core';
 import { assignDefaults, createTransform, getGLPrimitiveCount, isTransformPending } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('assignDefaults', (t) => {
-	t.deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: 4 }), { a: 1, b: 4, c: 3 }, 'number ← number');
-	t.deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: null }), { a: 1, b: null, c: 3 }, 'number ← null');
-	t.deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: undefined }), { a: 1, b: 2, c: 3 }, 'number ← undefined');
-	t.deepEqual(assignDefaults({ a: 1, b: null, c: 3 }, { b: 2 }), { a: 1, b: 2, c: 3 }, 'null ← number');
-	t.deepEqual(assignDefaults({ a: 1, b: undefined, c: 3 }, { b: 2 }), { a: 1, b: 2, c: 3 }, 'undefined ← number');
-	t.deepEqual(assignDefaults({ a: { ok: false } }, { a: { ok: true } }), { a: { ok: true } }, 'object ← object');
-	t.deepEqual(assignDefaults({ a: 'hello' }, {}), { a: 'hello' }, 'string ← empty');
-});
+describe('utils', () => {
+	test('assignDefaults', () => {
+		deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: 4 }), { a: 1, b: 4, c: 3 }, 'number ← number');
+		deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: null }), { a: 1, b: null, c: 3 }, 'number ← null');
+		deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: undefined }), { a: 1, b: 2, c: 3 }, 'number ← undefined');
+		deepEqual(assignDefaults({ a: 1, b: null, c: 3 }, { b: 2 }), { a: 1, b: 2, c: 3 }, 'null ← number');
+		deepEqual(assignDefaults({ a: 1, b: undefined, c: 3 }, { b: 2 }), { a: 1, b: 2, c: 3 }, 'undefined ← number');
+		deepEqual(assignDefaults({ a: { ok: false } }, { a: { ok: true } }), { a: { ok: true } }, 'object ← object');
+		deepEqual(assignDefaults({ a: 'hello' }, {}), { a: 'hello' }, 'string ← empty');
+	});
 
-test('getGLPrimitiveCount', async (t) => {
-	const doc = new Document();
+	test('getGLPrimitiveCount', async () => {
+		const doc = new Document();
 
-	const indices = doc.createAccessor().setArray(new Uint16Array(6));
-	const position = doc.createAccessor().setType(Accessor.Type.VEC3).setArray(new Float32Array(99));
-	const prim = doc.createPrimitive().setMode(Primitive.Mode.TRIANGLES).setAttribute('POSITION', position);
-	const indexedPrim = prim.clone().setIndices(indices);
+		const indices = doc.createAccessor().setArray(new Uint16Array(6));
+		const position = doc.createAccessor().setType(Accessor.Type.VEC3).setArray(new Float32Array(99));
+		const prim = doc.createPrimitive().setMode(Primitive.Mode.TRIANGLES).setAttribute('POSITION', position);
+		const indexedPrim = prim.clone().setIndices(indices);
 
-	prim.setMode(Primitive.Mode.POINTS);
-	indexedPrim.setMode(Primitive.Mode.POINTS);
-	t.is(getGLPrimitiveCount(prim), 33, 'points');
-	t.is(getGLPrimitiveCount(indexedPrim), 6, 'points (indexed)');
+		prim.setMode(Primitive.Mode.POINTS);
+		indexedPrim.setMode(Primitive.Mode.POINTS);
+		strictEqual(getGLPrimitiveCount(prim), 33, 'points');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 6, 'points (indexed)');
 
-	prim.setMode(Primitive.Mode.LINES);
-	indexedPrim.setMode(Primitive.Mode.LINES);
-	t.is(getGLPrimitiveCount(prim), 33 / 2, 'lines');
-	t.is(getGLPrimitiveCount(indexedPrim), 3, 'lines (indexed)');
+		prim.setMode(Primitive.Mode.LINES);
+		indexedPrim.setMode(Primitive.Mode.LINES);
+		strictEqual(getGLPrimitiveCount(prim), 33 / 2, 'lines');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 3, 'lines (indexed)');
 
-	prim.setMode(Primitive.Mode.LINE_STRIP);
-	indexedPrim.setMode(Primitive.Mode.LINE_STRIP);
-	t.is(getGLPrimitiveCount(prim), 32, 'line strip');
-	t.is(getGLPrimitiveCount(indexedPrim), 5, 'line strip (indexed)');
+		prim.setMode(Primitive.Mode.LINE_STRIP);
+		indexedPrim.setMode(Primitive.Mode.LINE_STRIP);
+		strictEqual(getGLPrimitiveCount(prim), 32, 'line strip');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 5, 'line strip (indexed)');
 
-	prim.setMode(Primitive.Mode.LINE_LOOP);
-	indexedPrim.setMode(Primitive.Mode.LINE_LOOP);
-	t.is(getGLPrimitiveCount(prim), 33, 'line loop');
-	t.is(getGLPrimitiveCount(indexedPrim), 6, 'line loop (indexed)');
+		prim.setMode(Primitive.Mode.LINE_LOOP);
+		indexedPrim.setMode(Primitive.Mode.LINE_LOOP);
+		strictEqual(getGLPrimitiveCount(prim), 33, 'line loop');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 6, 'line loop (indexed)');
 
-	prim.setMode(Primitive.Mode.TRIANGLES);
-	indexedPrim.setMode(Primitive.Mode.TRIANGLES);
-	t.is(getGLPrimitiveCount(prim), 11, 'triangles');
-	t.is(getGLPrimitiveCount(indexedPrim), 2, 'triangles (indexed)');
+		prim.setMode(Primitive.Mode.TRIANGLES);
+		indexedPrim.setMode(Primitive.Mode.TRIANGLES);
+		strictEqual(getGLPrimitiveCount(prim), 11, 'triangles');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 2, 'triangles (indexed)');
 
-	prim.setMode(Primitive.Mode.TRIANGLE_FAN);
-	indexedPrim.setMode(Primitive.Mode.TRIANGLE_FAN);
-	t.is(getGLPrimitiveCount(prim), 31, 'triangle strip');
-	t.is(getGLPrimitiveCount(indexedPrim), 4, 'triangle strip (indexed)');
+		prim.setMode(Primitive.Mode.TRIANGLE_FAN);
+		indexedPrim.setMode(Primitive.Mode.TRIANGLE_FAN);
+		strictEqual(getGLPrimitiveCount(prim), 31, 'triangle strip');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 4, 'triangle strip (indexed)');
 
-	prim.setMode(Primitive.Mode.TRIANGLE_STRIP);
-	indexedPrim.setMode(Primitive.Mode.TRIANGLE_STRIP);
-	t.is(getGLPrimitiveCount(prim), 31, 'triangle fan');
-	t.is(getGLPrimitiveCount(indexedPrim), 4, 'triangle fan (indexed)');
+		prim.setMode(Primitive.Mode.TRIANGLE_STRIP);
+		indexedPrim.setMode(Primitive.Mode.TRIANGLE_STRIP);
+		strictEqual(getGLPrimitiveCount(prim), 31, 'triangle fan');
+		strictEqual(getGLPrimitiveCount(indexedPrim), 4, 'triangle fan (indexed)');
 
-	prim.setMode('TEST' as unknown as GLTF.MeshPrimitiveMode);
-	t.throws(() => getGLPrimitiveCount(prim), { message: /mode/i }, 'invalid');
-});
+		prim.setMode('TEST' as unknown as GLTF.MeshPrimitiveMode);
+		throws(() => getGLPrimitiveCount(prim), { message: /mode/i }, 'invalid');
+	});
 
-test('transform pipeline', async (t) => {
-	const doc = new Document();
-	const first = createTransform('first', (_: Document, context?: TransformContext) => {
-		if (!isTransformPending(context, 'first', 'second')) {
-			throw new Error('Out of order!');
+	test('transform pipeline', async () => {
+		const doc = new Document();
+		const first = createTransform('first', (_: Document, context?: TransformContext) => {
+			if (!isTransformPending(context, 'first', 'second')) {
+				throw new Error('Out of order!');
+			}
+		});
+		const second: Transform = (_: Document) => undefined;
+
+		ok(doc.transform(first, second), '[a, b] OK');
+
+		try {
+			await doc.transform(second, first);
+			fail('[b, a] NOT OK');
+		} catch (e) {
+			ok(/out of order/i.test((e as Error).message), '[b, a] NOT OK');
 		}
 	});
-	const second: Transform = (_: Document) => undefined;
-
-	t.truthy(doc.transform(first, second), '[a, b] OK');
-
-	try {
-		await doc.transform(second, first);
-		t.fail('[b, a] NOT OK');
-	} catch (e) {
-		t.truthy(/out of order/i.test((e as Error).message), '[b, a] NOT OK');
-	}
 });

--- a/packages/functions/test/utils.test.ts
+++ b/packages/functions/test/utils.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, Document, type GLTF, Primitive, type Transform, type TransformContext } from '@gltf-transform/core';
 import { assignDefaults, createTransform, getGLPrimitiveCount, isTransformPending } from '@gltf-transform/functions';
 
-describe('utils', () => {
+describe('functions::utils', () => {
 	test('assignDefaults', () => {
 		deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: 4 }), { a: 1, b: 4, c: 3 }, 'number ← number');
 		deepEqual(assignDefaults({ a: 1, b: 2, c: 3 }, { b: null }), { a: 1, b: null, c: 3 }, 'number ← null');

--- a/packages/functions/test/vertex-color-space.test.ts
+++ b/packages/functions/test/vertex-color-space.test.ts
@@ -1,44 +1,47 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Accessor, Document } from '@gltf-transform/core';
 import { vertexColorSpace } from '@gltf-transform/functions';
-import test from 'ava';
 
-test('basic', (t) => {
-	const input = [0.25882352941176473, 0.5215686274509804, 0.9568627450980393]; // sRGB
-	const expected = [0.054480276435339814, 0.23455058215026167, 0.9046611743890203]; // linear
+describe('vertexColorSpace', () => {
+	test('basic', () => {
+		const input = [0.25882352941176473, 0.5215686274509804, 0.9568627450980393]; // sRGB
+		const expected = [0.054480276435339814, 0.23455058215026167, 0.9046611743890203]; // linear
 
-	const doc = new Document();
-	const mesh = doc.createMesh('test-mesh');
+		const doc = new Document();
+		const mesh = doc.createMesh('test-mesh');
 
-	const primitive1 = doc.createPrimitive();
-	const primitive2 = doc.createPrimitive();
-	mesh.addPrimitive(primitive1);
-	mesh.addPrimitive(primitive2);
+		const primitive1 = doc.createPrimitive();
+		const primitive2 = doc.createPrimitive();
+		mesh.addPrimitive(primitive1);
+		mesh.addPrimitive(primitive2);
 
-	const accessor1 = doc.createAccessor('#1');
-	const accessor2 = doc.createAccessor('#2');
-	accessor1.setType(Accessor.Type.VEC3).setArray(new Float32Array([...input, ...input]));
-	accessor2.setType(Accessor.Type.VEC4).setArray(new Float32Array([...input, 0.5]));
+		const accessor1 = doc.createAccessor('#1');
+		const accessor2 = doc.createAccessor('#2');
+		accessor1.setType(Accessor.Type.VEC3).setArray(new Float32Array([...input, ...input]));
+		accessor2.setType(Accessor.Type.VEC4).setArray(new Float32Array([...input, 0.5]));
 
-	primitive1.setAttribute('COLOR_0', accessor1).setAttribute('COLOR_1', accessor2);
-	primitive2.setAttribute('COLOR_0', accessor1);
+		primitive1.setAttribute('COLOR_0', accessor1).setAttribute('COLOR_1', accessor2);
+		primitive2.setAttribute('COLOR_0', accessor1);
 
-	vertexColorSpace({ inputColorSpace: 'srgb' })(doc);
+		vertexColorSpace({ inputColorSpace: 'srgb' })(doc);
 
-	let actual;
+		let actual;
 
-	actual = primitive1.getAttribute('COLOR_0').getArray();
-	t.is(actual[0].toFixed(3), expected[0].toFixed(3), 'prim1.color1[0].r');
-	t.is(actual[1].toFixed(3), expected[1].toFixed(3), 'prim1.color1[0].g');
-	t.is(actual[2].toFixed(3), expected[2].toFixed(3), 'prim1.color1[0].b');
-	t.is(actual[3].toFixed(3), expected[0].toFixed(3), 'prim1.color1[1].r');
-	t.is(actual[4].toFixed(3), expected[1].toFixed(3), 'prim1.color1[1].g');
-	t.is(actual[5].toFixed(3), expected[2].toFixed(3), 'prim1.color1[1].b');
+		actual = primitive1.getAttribute('COLOR_0').getArray();
+		strictEqual(actual[0].toFixed(3), expected[0].toFixed(3), 'prim1.color1[0].r');
+		strictEqual(actual[1].toFixed(3), expected[1].toFixed(3), 'prim1.color1[0].g');
+		strictEqual(actual[2].toFixed(3), expected[2].toFixed(3), 'prim1.color1[0].b');
+		strictEqual(actual[3].toFixed(3), expected[0].toFixed(3), 'prim1.color1[1].r');
+		strictEqual(actual[4].toFixed(3), expected[1].toFixed(3), 'prim1.color1[1].g');
+		strictEqual(actual[5].toFixed(3), expected[2].toFixed(3), 'prim1.color1[1].b');
 
-	actual = primitive1.getAttribute('COLOR_1').getArray();
-	t.is(actual[0].toFixed(3), expected[0].toFixed(3), 'prim1.color2[0].r');
-	t.is(actual[1].toFixed(3), expected[1].toFixed(3), 'prim1.color2[0].g');
-	t.is(actual[2].toFixed(3), expected[2].toFixed(3), 'prim1.color2[0].b');
-	t.is(actual[3].toFixed(3), '0.500', 'prim1.color2[0].a');
+		actual = primitive1.getAttribute('COLOR_1').getArray();
+		strictEqual(actual[0].toFixed(3), expected[0].toFixed(3), 'prim1.color2[0].r');
+		strictEqual(actual[1].toFixed(3), expected[1].toFixed(3), 'prim1.color2[0].g');
+		strictEqual(actual[2].toFixed(3), expected[2].toFixed(3), 'prim1.color2[0].b');
+		strictEqual(actual[3].toFixed(3), '0.500', 'prim1.color2[0].a');
 
-	t.deepEqual(primitive1.getAttribute('COLOR_0'), primitive2.getAttribute('COLOR_0'), 'shared COLOR_0 accessor');
+		deepEqual(primitive1.getAttribute('COLOR_0'), primitive2.getAttribute('COLOR_0'), 'shared COLOR_0 accessor');
+	});
 });

--- a/packages/functions/test/vertex-color-space.test.ts
+++ b/packages/functions/test/vertex-color-space.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { Accessor, Document } from '@gltf-transform/core';
 import { vertexColorSpace } from '@gltf-transform/functions';
 
-describe('vertexColorSpace', () => {
+describe('functions::vertexColorSpace', () => {
 	test('basic', () => {
 		const input = [0.25882352941176473, 0.5215686274509804, 0.9568627450980393]; // sRGB
 		const expected = [0.054480276435339814, 0.23455058215026167, 0.9046611743890203]; // linear

--- a/packages/functions/test/weld.test.ts
+++ b/packages/functions/test/weld.test.ts
@@ -1,17 +1,19 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { type Accessor, Document, type GLTF, getBounds, Primitive } from '@gltf-transform/core';
 import { weld } from '@gltf-transform/functions';
 import { logger } from '@gltf-transform/test-utils';
-import test from 'ava';
 import fs from 'fs/promises';
 import path, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-test('tolerance=0', async (t) => {
-	const doc = new Document().setLogger(logger);
-	// biome-ignore format: Readability.
-	const positionArray = new Float32Array([
+describe('weld', () => {
+	test('tolerance=0', async () => {
+		const doc = new Document().setLogger(logger);
+		// biome-ignore format: Readability.
+		const positionArray = new Float32Array([
 		0, 0, 0,
 		0, 0, 1,
 		0, 0, -1,
@@ -19,33 +21,33 @@ test('tolerance=0', async (t) => {
 		0, 0, 1,
 		0, 0, -1
 	]);
-	const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
-	const indices = doc.createAccessor().setArray(new Uint32Array([3, 4, 5, 0, 1, 2]));
-	const prim1 = doc.createPrimitive().setAttribute('POSITION', position).setMode(Primitive.Mode.TRIANGLES);
-	const prim2 = doc
-		.createPrimitive()
-		.setIndices(indices)
-		.setAttribute('POSITION', position)
-		.setMode(Primitive.Mode.TRIANGLES);
-	doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
+		const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
+		const indices = doc.createAccessor().setArray(new Uint32Array([3, 4, 5, 0, 1, 2]));
+		const prim1 = doc.createPrimitive().setAttribute('POSITION', position).setMode(Primitive.Mode.TRIANGLES);
+		const prim2 = doc
+			.createPrimitive()
+			.setIndices(indices)
+			.setAttribute('POSITION', position)
+			.setMode(Primitive.Mode.TRIANGLES);
+		doc.createMesh().addPrimitive(prim1).addPrimitive(prim2);
 
-	await doc.transform(weld({ overwrite: false }));
+		await doc.transform(weld({ overwrite: false }));
 
-	t.true(prim1.getIndices().getArray() instanceof Uint16Array, 'indices are u16');
-	t.deepEqual(Array.from(prim1.getIndices().getArray()), [0, 1, 2, 0, 1, 2], 'indices on prim1');
-	t.deepEqual(Array.from(prim2.getIndices().getArray()), [3, 4, 5, 0, 1, 2], 'indices on prim2');
-	t.deepEqual(
-		Array.from(prim1.getAttribute('POSITION').getArray()),
-		[0, 0, 0, 0, 0, 1, 0, 0, -1],
-		'vertices on prim1',
-	);
-	t.deepEqual(prim2.getAttribute('POSITION').getArray(), positionArray, 'vertices on prim2');
-});
+		ok(prim1.getIndices().getArray() instanceof Uint16Array, 'indices are u16');
+		deepEqual(Array.from(prim1.getIndices().getArray()), [0, 1, 2, 0, 1, 2], 'indices on prim1');
+		deepEqual(Array.from(prim2.getIndices().getArray()), [3, 4, 5, 0, 1, 2], 'indices on prim2');
+		deepEqual(
+			Array.from(prim1.getAttribute('POSITION').getArray()),
+			[0, 0, 0, 0, 0, 1, 0, 0, -1],
+			'vertices on prim1',
+		);
+		deepEqual(prim2.getAttribute('POSITION').getArray(), positionArray, 'vertices on prim2');
+	});
 
-test('attributes', async (t) => {
-	const doc = new Document().setLogger(logger);
-	// biome-ignore format: Readability.
-	const positionArray = new Uint8Array([
+	test('attributes', async () => {
+		const doc = new Document().setLogger(logger);
+		// biome-ignore format: Readability.
+		const positionArray = new Uint8Array([
 		0, 0, 0, // A: All A's match, weld 3
 		1, 0, 0, // B: Normals differ, weld 2 B's
 		0, 1, 1, // C: ❌ Colors differ, weld 2 C's
@@ -56,8 +58,8 @@ test('attributes', async (t) => {
 		1, 0, 0, // B: ❌
 		0, 1, 1, // C:
 	]);
-	// biome-ignore format: Readability.
-	const normalArray = new Int8Array([
+		// biome-ignore format: Readability.
+		const normalArray = new Int8Array([
 		63, 63, 0,
 		0, 63, 63,
 		63, 0, 63,
@@ -68,8 +70,8 @@ test('attributes', async (t) => {
 		0, -63, 63, // ❌
 		63, 0, 63,
 	]);
-	// biome-ignore format: Readability.
-	const colorArray = new Uint8Array([
+		// biome-ignore format: Readability.
+		const colorArray = new Uint8Array([
 		255, 0, 0, 1,
 		0, 255, 0, 1,
 		0, 0, 200, 1, // ❌
@@ -80,22 +82,22 @@ test('attributes', async (t) => {
 		0, 255, 0, 1,
 		0, 0, 255, 1,
 	]);
-	const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
-	const normal = doc.createAccessor().setType('VEC3').setArray(normalArray).setNormalized(true);
-	const color = doc.createAccessor().setType('VEC4').setArray(colorArray).setNormalized(true);
-	const prim = doc
-		.createPrimitive()
-		.setMode(Primitive.Mode.TRIANGLES)
-		.setAttribute('POSITION', position)
-		.setAttribute('NORMAL', normal)
-		.setAttribute('COLOR_0', color);
-	doc.createMesh().addPrimitive(prim);
+		const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
+		const normal = doc.createAccessor().setType('VEC3').setArray(normalArray).setNormalized(true);
+		const color = doc.createAccessor().setType('VEC4').setArray(colorArray).setNormalized(true);
+		const prim = doc
+			.createPrimitive()
+			.setMode(Primitive.Mode.TRIANGLES)
+			.setAttribute('POSITION', position)
+			.setAttribute('NORMAL', normal)
+			.setAttribute('COLOR_0', color);
+		doc.createMesh().addPrimitive(prim);
 
-	await doc.transform(weld());
+		await doc.transform(weld());
 
-	t.false(prim.isDisposed(), 'prim is not disposed');
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		strictEqual(prim.isDisposed(), false, 'prim is not disposed');
+		// biome-ignore format: Readability.
+		deepEqual(
 		Array.from(prim.getIndices()!.getArray()!),
 		[
 			0, 1, 2,
@@ -105,8 +107,8 @@ test('attributes', async (t) => {
 		'indices'
 	);
 
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		Array.from(prim.getAttribute('POSITION')!.getArray()!),
 		[
 			0, 0, 0,
@@ -117,8 +119,8 @@ test('attributes', async (t) => {
 		],
 		'position'
 	);
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		Array.from(prim.getAttribute('NORMAL')!.getArray()!),
 		[
 			63, 63, 0,
@@ -129,8 +131,8 @@ test('attributes', async (t) => {
 		],
 		'normal'
 	);
-	// biome-ignore format: Readability.
-	t.deepEqual(
+		// biome-ignore format: Readability.
+		deepEqual(
 		Array.from(prim.getAttribute('COLOR_0')!.getArray()!),
 		[
 			255, 0, 0, 1,
@@ -141,73 +143,73 @@ test('attributes', async (t) => {
 		],
 		'color'
 	);
-});
+	});
 
-test('u16 vs u32', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const smPrim = doc
-		.createPrimitive()
-		.setAttribute('POSITION', createUniqueAttribute(doc, 'VEC3', 65534))
-		.setMode(Primitive.Mode.TRIANGLES);
-	const lgPrim = doc
-		.createPrimitive()
-		.setAttribute('POSITION', createUniqueAttribute(doc, 'VEC3', 65535))
-		.setMode(Primitive.Mode.TRIANGLES);
-	doc.createMesh().addPrimitive(smPrim).addPrimitive(lgPrim);
+	test('u16 vs u32', async () => {
+		const doc = new Document().setLogger(logger);
+		const smPrim = doc
+			.createPrimitive()
+			.setAttribute('POSITION', createUniqueAttribute(doc, 'VEC3', 65534))
+			.setMode(Primitive.Mode.TRIANGLES);
+		const lgPrim = doc
+			.createPrimitive()
+			.setAttribute('POSITION', createUniqueAttribute(doc, 'VEC3', 65535))
+			.setMode(Primitive.Mode.TRIANGLES);
+		doc.createMesh().addPrimitive(smPrim).addPrimitive(lgPrim);
 
-	await doc.transform(weld());
+		await doc.transform(weld());
 
-	// 65535 is primitive restart; use 65534 as limit.
-	t.is(smPrim.getIndices().getArray().constructor, Uint16Array, 'u16 <= 65534');
-	t.is(lgPrim.getIndices().getArray().constructor, Uint32Array, 'u32 > 65534');
-});
+		// 65535 is primitive restart; use 65534 as limit.
+		strictEqual(smPrim.getIndices().getArray().constructor, Uint16Array, 'u16 <= 65534');
+		strictEqual(lgPrim.getIndices().getArray().constructor, Uint32Array, 'u32 > 65534');
+	});
 
-test('modes', async (t) => {
-	// Extracted primitive data from (unindexed) 01–06 samples:
-	// https://github.com/KhronosGroup/glTF-Asset-Generator/tree/master/Output/Positive/Mesh_PrimitiveMode
-	const datasetPath = path.resolve(__dirname, 'in/Mesh_PrimitiveMode_01_to_06.json');
-	const dataset = JSON.parse(await fs.readFile(datasetPath, 'utf-8'));
+	test('modes', async () => {
+		// Extracted primitive data from (unindexed) 01–06 samples:
+		// https://github.com/KhronosGroup/glTF-Asset-Generator/tree/master/Output/Positive/Mesh_PrimitiveMode
+		const datasetPath = path.resolve(__dirname, 'in/Mesh_PrimitiveMode_01_to_06.json');
+		const dataset = JSON.parse(await fs.readFile(datasetPath, 'utf-8'));
 
-	for (let i = 0; i < dataset.length; i++) {
-		const primDef = dataset[i];
+		for (let i = 0; i < dataset.length; i++) {
+			const primDef = dataset[i];
+			const document = new Document().setLogger(logger);
+			const position = document
+				.createAccessor()
+				.setArray(new Float32Array(primDef.attributes.POSITION))
+				.setType('VEC3');
+			const prim = document.createPrimitive().setMode(primDef.mode).setAttribute('POSITION', position);
+			const mesh = document.createMesh().addPrimitive(prim);
+			const node = document.createNode().setMesh(mesh);
+			document.createScene().addChild(node);
+
+			const bboxBefore = getBounds(node);
+			await document.transform(weld());
+			const bboxAfter = getBounds(node);
+
+			const id = `${(i + 1).toString().padStart(2, '0')}`;
+			deepEqual(bboxAfter, bboxBefore, `bbox unchanged - ${id}`);
+			ok(prim.getIndices().getCount() <= primDef.indices.length, `indices - ${id}`);
+		}
+	});
+
+	test('points', async () => {
+		const doc = new Document().setLogger(logger);
+		const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, -1]);
+		const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
+		const prim = doc.createPrimitive().setAttribute('POSITION', position).setMode(Primitive.Mode.POINTS);
+		doc.createMesh().addPrimitive(prim);
+
+		// points can't be welded, but also shouldn't throw an error.
+		await doc.transform(weld());
+
+		strictEqual(prim.isDisposed(), false, 'prim not disposed');
+		strictEqual(prim.getAttribute('POSITION').getArray().length, positionArray.length, 'prim vertices');
+	});
+
+	test('targets', async () => {
 		const document = new Document().setLogger(logger);
-		const position = document
-			.createAccessor()
-			.setArray(new Float32Array(primDef.attributes.POSITION))
-			.setType('VEC3');
-		const prim = document.createPrimitive().setMode(primDef.mode).setAttribute('POSITION', position);
-		const mesh = document.createMesh().addPrimitive(prim);
-		const node = document.createNode().setMesh(mesh);
-		document.createScene().addChild(node);
-
-		const bboxBefore = getBounds(node);
-		await document.transform(weld());
-		const bboxAfter = getBounds(node);
-
-		const id = `${(i + 1).toString().padStart(2, '0')}`;
-		t.deepEqual(bboxAfter, bboxBefore, `bbox unchanged - ${id}`);
-		t.true(prim.getIndices().getCount() <= primDef.indices.length, `indices - ${id}`);
-	}
-});
-
-test('points', async (t) => {
-	const doc = new Document().setLogger(logger);
-	const positionArray = new Float32Array([0, 0, 0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 1, 0, 0, -1]);
-	const position = doc.createAccessor().setType('VEC3').setArray(positionArray);
-	const prim = doc.createPrimitive().setAttribute('POSITION', position).setMode(Primitive.Mode.POINTS);
-	doc.createMesh().addPrimitive(prim);
-
-	// points can't be welded, but also shouldn't throw an error.
-	await doc.transform(weld());
-
-	t.false(prim.isDisposed(), 'prim not disposed');
-	t.is(prim.getAttribute('POSITION').getArray().length, positionArray.length, 'prim vertices');
-});
-
-test('targets', async (t) => {
-	const document = new Document().setLogger(logger);
-	// biome-ignore format: Readability.
-	const positionArray = new Float32Array([
+		// biome-ignore format: Readability.
+		const positionArray = new Float32Array([
 		0, 0, 0,
 		0, 0, 1,
 		0, 0, 2,
@@ -218,8 +220,8 @@ test('targets', async (t) => {
 		0, 0, 1,
 		0, 0, 2
 	]);
-	// biome-ignore format: Readability.
-	const positionTargetArray = new Float32Array([
+		// biome-ignore format: Readability.
+		const positionTargetArray = new Float32Array([
 		10, 0, 0, // ✅
 		10, 0, 0,
 		10, 0, 0,
@@ -230,38 +232,39 @@ test('targets', async (t) => {
 		5, 0, 0,
 		5, 0, 0,
 	]);
-	const position = document.createAccessor().setType('VEC3').setArray(positionArray);
-	const positionTarget = document.createAccessor().setType('VEC3').setArray(positionTargetArray);
+		const position = document.createAccessor().setType('VEC3').setArray(positionArray);
+		const positionTarget = document.createAccessor().setType('VEC3').setArray(positionTargetArray);
 
-	const primTarget = document.createPrimitiveTarget().setAttribute('POSITION', positionTarget);
-	const prim = document
-		.createPrimitive()
-		.setMode(Primitive.Mode.TRIANGLES)
-		.setAttribute('POSITION', position)
-		.addTarget(primTarget);
+		const primTarget = document.createPrimitiveTarget().setAttribute('POSITION', positionTarget);
+		const prim = document
+			.createPrimitive()
+			.setMode(Primitive.Mode.TRIANGLES)
+			.setAttribute('POSITION', position)
+			.addTarget(primTarget);
 
-	document.createMesh().addPrimitive(prim);
+		document.createMesh().addPrimitive(prim);
 
-	await document.transform(weld());
+		await document.transform(weld());
 
-	t.deepEqual(prim.getIndices().getArray(), new Uint16Array([0, 1, 2, 0, 1, 2, 3, 4, 5]), 'indices');
-	t.deepEqual(prim.getAttribute('POSITION').getArray(), positionArray.slice(9, 27), 'prim positions');
-	t.deepEqual(
-		prim.listTargets()[0].getAttribute('POSITION').getArray(),
-		positionTargetArray.slice(9, 27),
-		'target positions',
-	);
-	t.is(document.getRoot().listAccessors().length, 3, 'accessor count');
-});
+		deepEqual(prim.getIndices().getArray(), new Uint16Array([0, 1, 2, 0, 1, 2, 3, 4, 5]), 'indices');
+		deepEqual(prim.getAttribute('POSITION').getArray(), positionArray.slice(9, 27), 'prim positions');
+		deepEqual(
+			prim.listTargets()[0].getAttribute('POSITION').getArray(),
+			positionTargetArray.slice(9, 27),
+			'target positions',
+		);
+		strictEqual(document.getRoot().listAccessors().length, 3, 'accessor count');
+	});
 
-test('no side effects', async (t) => {
-	const document = new Document().setLogger(logger);
-	const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
-	attributeA.clone();
+	test('no side effects', async () => {
+		const document = new Document().setLogger(logger);
+		const attributeA = document.createAccessor().setType('VEC3').setArray(new Float32Array(9));
+		attributeA.clone();
 
-	await document.transform(weld({ cleanup: false }));
+		await document.transform(weld());
 
-	t.is(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+		strictEqual(document.getRoot().listAccessors().length, 2, 'skips prune and dedup');
+	});
 });
 
 /* UTILITIES */

--- a/packages/functions/test/weld.test.ts
+++ b/packages/functions/test/weld.test.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-describe('weld', () => {
+describe('functions::weld', () => {
 	test('tolerance=0', async () => {
 		const doc = new Document().setLogger(logger);
 		// biome-ignore format: Readability.

--- a/packages/view/test/DocumentView.test.ts
+++ b/packages/view/test/DocumentView.test.ts
@@ -8,7 +8,7 @@ import { type BufferGeometry, Group, type Mesh, type MeshStandardMaterial, type 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-describe('DocumentView', () => {
+describe('view::DocumentView', () => {
 	test('constructor', () => {
 		ok(new DocumentView(new Document(), { imageProvider }), 'constructor');
 	});

--- a/packages/view/test/DocumentView.test.ts
+++ b/packages/view/test/DocumentView.test.ts
@@ -1,211 +1,217 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 import { type BufferGeometry, Group, type Mesh, type MeshStandardMaterial, type Texture } from 'three';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('DocumentView', (t) => {
-	t.truthy(new DocumentView(new Document(), { imageProvider }), 'constructor');
-});
+describe('DocumentView', () => {
+	test('constructor', () => {
+		ok(new DocumentView(new Document(), { imageProvider }), 'constructor');
+	});
 
-test('DocumentView | view', async (t) => {
-	const document = new Document();
-	const textureDef = document.createTexture();
-	const materialDef = document
-		.createMaterial()
-		.setBaseColorTexture(textureDef)
-		.setMetallicRoughnessTexture(textureDef);
-	const primDef = document.createPrimitive().setMaterial(materialDef);
-	const meshDef = document.createMesh().addPrimitive(primDef);
-	const nodeDef = document.createNode().setMesh(meshDef);
-	const sceneDef = document.createScene().addChild(nodeDef);
+	test('view', async () => {
+		const document = new Document();
+		const textureDef = document.createTexture();
+		const materialDef = document
+			.createMaterial()
+			.setBaseColorTexture(textureDef)
+			.setMetallicRoughnessTexture(textureDef);
+		const primDef = document.createPrimitive().setMaterial(materialDef);
+		const meshDef = document.createMesh().addPrimitive(primDef);
+		const nodeDef = document.createNode().setMesh(meshDef);
+		const sceneDef = document.createScene().addChild(nodeDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
+		const documentView = new DocumentView(document, { imageProvider });
 
-	const scene = documentView.view(sceneDef);
-	const node = scene.children[0];
-	const mesh = node.children[0];
-	const prim = mesh.children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
-	let material = prim.material;
-	let texture = material.map as Texture;
+		const scene = documentView.view(sceneDef);
+		const node = scene.children[0];
+		const mesh = node.children[0];
+		const prim = mesh.children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
+		let material = prim.material;
+		let texture = material.map as Texture;
 
-	t.true(scene instanceof Group, 'scene → THREE.Group');
-	t.deepEqual(documentView.listViews(sceneDef), [scene], 'scene views');
-	t.is(documentView.listViews(nodeDef).length, 1, 'node views');
-	t.is(documentView.listViews(meshDef).length, 1, 'mesh views');
-	// 1 external prim, 1 internal prim. See SingleUserPool.
-	t.is(documentView.listViews(primDef).length, 2, 'prim views');
-	t.is(documentView.listViews(materialDef).length, 1, 'material views');
-	t.is(documentView.listViews(textureDef).length, 2, 'texture views');
-	t.is(documentView.getProperty(scene), sceneDef, 'scene → source');
-	t.is(documentView.getProperty(node), nodeDef, 'node → source');
-	t.is(documentView.getProperty(mesh), meshDef, 'mesh → source');
-	t.is(documentView.getProperty(prim), primDef, 'prim → source');
-	t.is(documentView.getProperty(material), materialDef, 'material → source');
-	t.is(documentView.getProperty(texture), textureDef, 'texture → source');
+		ok(scene instanceof Group, 'scene → THREE.Group');
+		deepEqual(documentView.listViews(sceneDef), [scene], 'scene views');
+		strictEqual(documentView.listViews(nodeDef).length, 1, 'node views');
+		strictEqual(documentView.listViews(meshDef).length, 1, 'mesh views');
+		// 1 external prim, 1 internal prim. See SingleUserPool.
+		strictEqual(documentView.listViews(primDef).length, 2, 'prim views');
+		strictEqual(documentView.listViews(materialDef).length, 1, 'material views');
+		strictEqual(documentView.listViews(textureDef).length, 2, 'texture views');
+		strictEqual(documentView.getProperty(scene), sceneDef, 'scene → source');
+		strictEqual(documentView.getProperty(node), nodeDef, 'node → source');
+		strictEqual(documentView.getProperty(mesh), meshDef, 'mesh → source');
+		strictEqual(documentView.getProperty(prim), primDef, 'prim → source');
+		strictEqual(documentView.getProperty(material), materialDef, 'material → source');
+		strictEqual(documentView.getProperty(texture), textureDef, 'texture → source');
 
-	material = documentView.view(materialDef) as MeshStandardMaterial;
-	t.is(material.type, 'MeshStandardMaterial', 'material → THREE.MeshStandardMaterial');
-	t.is(documentView.listViews(materialDef).length, 2, 'material views');
-	t.is(documentView.listViews(textureDef).length, 2, 'texture views');
-	t.is(documentView.getProperty(material), materialDef, 'material → source');
+		material = documentView.view(materialDef) as MeshStandardMaterial;
+		strictEqual(material.type, 'MeshStandardMaterial', 'material → THREE.MeshStandardMaterial');
+		strictEqual(documentView.listViews(materialDef).length, 2, 'material views');
+		strictEqual(documentView.listViews(textureDef).length, 2, 'texture views');
+		strictEqual(documentView.getProperty(material), materialDef, 'material → source');
 
-	texture = documentView.view(textureDef);
-	t.true(texture.isTexture, 'texture → THREE.Texture');
-	t.is(documentView.listViews(textureDef).length, 3, 'texture views');
-	t.is(documentView.getProperty(texture), textureDef, 'texture → source');
-});
+		texture = documentView.view(textureDef);
+		ok(texture.isTexture, 'texture → THREE.Texture');
+		strictEqual(documentView.listViews(textureDef).length, 3, 'texture views');
+		strictEqual(documentView.getProperty(texture), textureDef, 'texture → source');
+	});
 
-test('DocumentView | dispose', async (t) => {
-	const document = new Document();
-	const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
-	const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
-	const materialDef = document.createMaterial('Material').setBaseColorTexture(texDef1).setEmissiveTexture(texDef2);
-	const primDef = document.createPrimitive().setMaterial(materialDef);
-	const sceneDef = document
-		.createScene('Scene')
-		.addChild(document.createNode('Node').setMesh(document.createMesh('Mesh').addPrimitive(primDef)));
+	test('dispose', async () => {
+		const document = new Document();
+		const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
+		const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
+		const materialDef = document
+			.createMaterial('Material')
+			.setBaseColorTexture(texDef1)
+			.setEmissiveTexture(texDef2);
+		const primDef = document.createPrimitive().setMaterial(materialDef);
+		const sceneDef = document
+			.createScene('Scene')
+			.addChild(document.createNode('Node').setMesh(document.createMesh('Mesh').addPrimitive(primDef)));
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const scene = documentView.view(sceneDef);
-	const mesh = scene.getObjectByName('Mesh')!.children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
-	const { geometry, material } = mesh;
-	const { map, emissiveMap } = material as { map: Texture; emissiveMap: Texture };
+		const documentView = new DocumentView(document, { imageProvider });
+		const scene = documentView.view(sceneDef);
+		const mesh = scene.getObjectByName('Mesh')!.children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
+		const { geometry, material } = mesh;
+		const { map, emissiveMap } = material as { map: Texture; emissiveMap: Texture };
 
-	const disposed = new Set();
-	geometry.addEventListener('dispose', () => disposed.add(geometry));
-	material.addEventListener('dispose', () => disposed.add(material));
-	map.addEventListener('dispose', () => disposed.add(map));
-	emissiveMap.addEventListener('dispose', () => disposed.add(emissiveMap));
+		const disposed = new Set();
+		geometry.addEventListener('dispose', () => disposed.add(geometry));
+		material.addEventListener('dispose', () => disposed.add(material));
+		map.addEventListener('dispose', () => disposed.add(map));
+		emissiveMap.addEventListener('dispose', () => disposed.add(emissiveMap));
 
-	t.is(disposed.size, 0, 'initial resources');
+		strictEqual(disposed.size, 0, 'initial resources');
 
-	documentView.dispose();
+		documentView.dispose();
 
-	t.is(disposed.size, 4);
-	t.true(disposed.has(geometry), 'disposed geometry');
-	t.true(disposed.has(material), 'disposed material');
-	t.true(disposed.has(map), 'disposed baseColorTexture');
-	t.true(disposed.has(emissiveMap), 'disposed emissiveTexture');
-});
+		strictEqual(disposed.size, 4);
+		ok(disposed.has(geometry), 'disposed geometry');
+		ok(disposed.has(material), 'disposed material');
+		ok(disposed.has(map), 'disposed baseColorTexture');
+		ok(disposed.has(emissiveMap), 'disposed emissiveTexture');
+	});
 
-test('DocumentView | alloc', async (t) => {
-	// Parts of this test are subjective — we don't *really* need to keep a Mesh
-	// in memory if the MeshDef is unused — but it's important that the counts
-	// come to zero when things are disposed. And if these results change
-	// unintentionally, that's a good time to review side effects.
+	test('alloc', async () => {
+		// Parts of this test are subjective — we don't *really* need to keep a Mesh
+		// in memory if the MeshDef is unused — but it's important that the counts
+		// come to zero when things are disposed. And if these results change
+		// unintentionally, that's a good time to review side effects.
 
-	const document = new Document();
-	const positionDef = document
-		.createAccessor()
-		.setType('VEC3')
-		.setArray(new Float32Array([0, 0, 0]));
-	const primDef = document.createPrimitive().setAttribute('POSITION', positionDef);
-	const meshDef = document.createMesh().addPrimitive(primDef);
-	const nodeDef = document.createNode();
-	const sceneDef = document.createScene().addChild(nodeDef);
+		const document = new Document();
+		const positionDef = document
+			.createAccessor()
+			.setType('VEC3')
+			.setArray(new Float32Array([0, 0, 0]));
+		const primDef = document.createPrimitive().setAttribute('POSITION', positionDef);
+		const meshDef = document.createMesh().addPrimitive(primDef);
+		const nodeDef = document.createNode();
+		const sceneDef = document.createScene().addChild(nodeDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
+		const documentView = new DocumentView(document, { imageProvider });
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 0,
-			nodes: 0,
-			meshes: 0,
-			primitives: 0,
-		},
-		'1. empty',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 0,
+				nodes: 0,
+				meshes: 0,
+				primitives: 0,
+			},
+			'1. empty',
+		);
 
-	documentView.view(sceneDef);
+		documentView.view(sceneDef);
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 1,
-			nodes: 1,
-			meshes: 0,
-			primitives: 0,
-		},
-		'2. no mesh',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 1,
+				nodes: 1,
+				meshes: 0,
+				primitives: 0,
+			},
+			'2. no mesh',
+		);
 
-	nodeDef.setMesh(meshDef);
+		nodeDef.setMesh(meshDef);
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 1,
-			nodes: 1,
-			meshes: 2, // 1 internal, 1 view
-			primitives: 2, // 1 internal, 1 view
-		},
-		'3. add mesh',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 1,
+				nodes: 1,
+				meshes: 2, // 1 internal, 1 view
+				primitives: 2, // 1 internal, 1 view
+			},
+			'3. add mesh',
+		);
 
-	nodeDef.setMesh(null);
-	nodeDef.setMesh(meshDef);
-	nodeDef.setMesh(null);
-	nodeDef.setMesh(meshDef);
-	nodeDef.setMesh(null);
-	nodeDef.setMesh(meshDef);
+		nodeDef.setMesh(null);
+		nodeDef.setMesh(meshDef);
+		nodeDef.setMesh(null);
+		nodeDef.setMesh(meshDef);
+		nodeDef.setMesh(null);
+		nodeDef.setMesh(meshDef);
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 1,
-			nodes: 1,
-			meshes: 5, // garbage accumulation
-			primitives: 2,
-		},
-		'4. garbage accumulation',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 1,
+				nodes: 1,
+				meshes: 5, // garbage accumulation
+				primitives: 2,
+			},
+			'4. garbage accumulation',
+		);
 
-	documentView.gc();
+		documentView.gc();
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 1,
-			nodes: 1,
-			meshes: 2, // garbage collection
-			primitives: 2,
-		},
-		'5. garbage collection pt 1',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 1,
+				nodes: 1,
+				meshes: 2, // garbage collection
+				primitives: 2,
+			},
+			'5. garbage collection pt 1',
+		);
 
-	nodeDef.setMesh(null);
-	documentView.gc();
+		nodeDef.setMesh(null);
+		documentView.gc();
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 1,
-			nodes: 1,
-			meshes: 1, // garbage collection
-			primitives: 2,
-		},
-		'5. garbage collection pt 2',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 1,
+				nodes: 1,
+				meshes: 1, // garbage collection
+				primitives: 2,
+			},
+			'5. garbage collection pt 2',
+		);
 
-	primDef.dispose();
-	meshDef.dispose();
-	documentView.gc();
+		primDef.dispose();
+		meshDef.dispose();
+		documentView.gc();
 
-	t.deepEqual(
-		getPartialStats(documentView),
-		{
-			scenes: 1,
-			nodes: 1,
-			meshes: 0, // garbage collection
-			primitives: 0, // garbage collection
-		},
-		'5. garbage collection pt 2',
-	);
+		deepEqual(
+			getPartialStats(documentView),
+			{
+				scenes: 1,
+				nodes: 1,
+				meshes: 0, // garbage collection
+				primitives: 0, // garbage collection
+			},
+			'5. garbage collection pt 2',
+		);
+	});
 });
 
 interface PartialStats {

--- a/packages/view/test/InstancedMeshSubject.test.ts
+++ b/packages/view/test/InstancedMeshSubject.test.ts
@@ -1,14 +1,15 @@
+import { deepEqual, strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { EXTMeshGPUInstancing } from '@gltf-transform/extensions';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 import type { Group, InstancedMesh, Object3D } from 'three';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('InstancedMeshSubject', async (t) => {
+test('InstancedMeshSubject', async () => {
 	const document = new Document();
 	const batchExt = document.createExtension(EXTMeshGPUInstancing);
 	const batchTranslation = document
@@ -29,10 +30,10 @@ test('InstancedMeshSubject', async (t) => {
 	const group = node.children[0] as Group;
 	const mesh = group.children[0] as InstancedMesh;
 
-	t.deepEqual(node.children.map(toType), ['Group'], 'node.children → [Group]');
-	t.deepEqual(group.children.map(toType), ['Mesh'], 'group.children → [Mesh]');
-	t.is(mesh.isInstancedMesh, true, 'isInstancedMesh → true');
-	t.is(mesh.count, 3, 'count → 3');
+	deepEqual(node.children.map(toType), ['Group'], 'node.children → [Group]');
+	deepEqual(group.children.map(toType), ['Mesh'], 'group.children → [Mesh]');
+	strictEqual(mesh.isInstancedMesh, true, 'isInstancedMesh → true');
+	strictEqual(mesh.count, 3, 'count → 3');
 });
 
 function toType(object: Object3D): string {

--- a/packages/view/test/LightSubject.test.ts
+++ b/packages/view/test/LightSubject.test.ts
@@ -1,117 +1,124 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { KHRLightsPunctual, Light as LightDef } from '@gltf-transform/extensions';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 import type { DirectionalLight, Object3D, PointLight, SpotLight } from 'three';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('LightSubject | point', async (t) => {
-	const document = new Document();
-	const lightExt = document.createExtension(KHRLightsPunctual);
-	const lightDef = lightExt
-		.createLight('MyLight')
-		.setColor([1, 0, 0])
-		.setIntensity(2000)
-		.setRange(100)
-		.setType(LightDef.Type.POINT);
-	const nodeDef = document.createNode('Node').setExtension('KHR_lights_punctual', lightDef);
+describe('LightSubject', () => {
+	test('point', async () => {
+		const document = new Document();
+		const lightExt = document.createExtension(KHRLightsPunctual);
+		const lightDef = lightExt
+			.createLight('MyLight')
+			.setColor([1, 0, 0])
+			.setIntensity(2000)
+			.setRange(100)
+			.setType(LightDef.Type.POINT);
+		const nodeDef = document.createNode('Node').setExtension('KHR_lights_punctual', lightDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const node = documentView.view(nodeDef);
-	const light = node.children[0] as PointLight;
+		const documentView = new DocumentView(document, { imageProvider });
+		const node = documentView.view(nodeDef);
+		const light = node.children[0] as PointLight;
 
-	t.is(light.name, 'MyLight', 'node → light → name');
-	t.is(light.type, 'PointLight', 'node → light → type');
-	t.deepEqual(light.position.toArray(), [0, 0, 0], 'node → light → position');
-	t.is(light.intensity, 2000, 'node → light → intensity');
-	t.is(light.distance, 100, 'node → light → range');
-	t.deepEqual(light.color.toArray(), [1, 0, 0], 'node → light → color');
-	t.is(light.decay, 2, 'node → light → decay');
-});
+		strictEqual(light.name, 'MyLight', 'node → light → name');
+		strictEqual(light.type, 'PointLight', 'node → light → type');
+		deepEqual(light.position.toArray(), [0, 0, 0], 'node → light → position');
+		strictEqual(light.intensity, 2000, 'node → light → intensity');
+		strictEqual(light.distance, 100, 'node → light → range');
+		deepEqual(light.color.toArray(), [1, 0, 0], 'node → light → color');
+		strictEqual(light.decay, 2, 'node → light → decay');
+	});
 
-test('LightSubject | spot', async (t) => {
-	const document = new Document();
-	const lightExt = document.createExtension(KHRLightsPunctual);
-	const lightDef = lightExt
-		.createLight('MyLight')
-		.setColor([1, 1, 0])
-		.setIntensity(2000)
-		.setRange(null)
-		.setInnerConeAngle(Math.PI / 4)
-		.setOuterConeAngle(Math.PI / 2)
-		.setType(LightDef.Type.SPOT);
-	const nodeDef = document.createNode('Node').setExtension('KHR_lights_punctual', lightDef);
+	test('spot', async () => {
+		const document = new Document();
+		const lightExt = document.createExtension(KHRLightsPunctual);
+		const lightDef = lightExt
+			.createLight('MyLight')
+			.setColor([1, 1, 0])
+			.setIntensity(2000)
+			.setRange(null)
+			.setInnerConeAngle(Math.PI / 4)
+			.setOuterConeAngle(Math.PI / 2)
+			.setType(LightDef.Type.SPOT);
+		const nodeDef = document.createNode('Node').setExtension('KHR_lights_punctual', lightDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const node = documentView.view(nodeDef);
-	const light = node.children[0] as SpotLight;
+		const documentView = new DocumentView(document, { imageProvider });
+		const node = documentView.view(nodeDef);
+		const light = node.children[0] as SpotLight;
 
-	t.is(light.name, 'MyLight', 'node → light → name');
-	t.is(light.type, 'SpotLight', 'node → light → type');
-	t.deepEqual(light.position.toArray(), [0, 0, 0], 'node → light → position');
-	t.is(light.intensity, 2000, 'node → light → intensity');
-	t.is(light.distance, 0, 'node → light → range');
-	t.is(light.angle, Math.PI / 2, 'node → light → angle');
-	t.is(light.penumbra, 1.0 - Math.PI / 4 / (Math.PI / 2), 'node → light → penumbra');
-	t.deepEqual(light.color.toArray(), [1, 1, 0], 'node → light → color');
-	t.is(light.decay, 2, 'node → light → decay');
-});
+		strictEqual(light.name, 'MyLight', 'node → light → name');
+		strictEqual(light.type, 'SpotLight', 'node → light → type');
+		deepEqual(light.position.toArray(), [0, 0, 0], 'node → light → position');
+		strictEqual(light.intensity, 2000, 'node → light → intensity');
+		strictEqual(light.distance, 0, 'node → light → range');
+		strictEqual(light.angle, Math.PI / 2, 'node → light → angle');
+		strictEqual(light.penumbra, 1.0 - Math.PI / 4 / (Math.PI / 2), 'node → light → penumbra');
+		deepEqual(light.color.toArray(), [1, 1, 0], 'node → light → color');
+		strictEqual(light.decay, 2, 'node → light → decay');
+	});
 
-test('LightSubject | directional', async (t) => {
-	const document = new Document();
-	const lightExt = document.createExtension(KHRLightsPunctual);
-	const lightDef = lightExt
-		.createLight('MyLight')
-		.setColor([1, 1, 1])
-		.setIntensity(1.5)
-		.setType(LightDef.Type.DIRECTIONAL);
-	const nodeDef = document.createNode('Node').setExtension('KHR_lights_punctual', lightDef);
+	test('directional', async () => {
+		const document = new Document();
+		const lightExt = document.createExtension(KHRLightsPunctual);
+		const lightDef = lightExt
+			.createLight('MyLight')
+			.setColor([1, 1, 1])
+			.setIntensity(1.5)
+			.setType(LightDef.Type.DIRECTIONAL);
+		const nodeDef = document.createNode('Node').setExtension('KHR_lights_punctual', lightDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const node = documentView.view(nodeDef);
-	const light = node.children[0] as DirectionalLight;
+		const documentView = new DocumentView(document, { imageProvider });
+		const node = documentView.view(nodeDef);
+		const light = node.children[0] as DirectionalLight;
 
-	t.is(light.name, 'MyLight', 'node → light → name');
-	t.is(light.type, 'DirectionalLight', 'node → light → type');
-	t.deepEqual(light.position.toArray(), [0, 0, 0], 'node → light → position');
-	t.is(light.intensity, 1.5, 'node → light → intensity');
-	t.deepEqual(light.color.toArray(), [1, 1, 1], 'node → light → color');
-});
+		strictEqual(light.name, 'MyLight', 'node → light → name');
+		strictEqual(light.type, 'DirectionalLight', 'node → light → type');
+		deepEqual(light.position.toArray(), [0, 0, 0], 'node → light → position');
+		strictEqual(light.intensity, 1.5, 'node → light → intensity');
+		deepEqual(light.color.toArray(), [1, 1, 1], 'node → light → color');
+	});
 
-test('LightSubject | instances', async (t) => {
-	const document = new Document();
-	const lightExt = document.createExtension(KHRLightsPunctual);
-	const lightDef = lightExt.createLight('MyLight').setColor([1, 1, 1]).setIntensity(2000).setType(LightDef.Type.SPOT);
-	const nodeDefA = document
-		.createNode('NodeA')
-		.setRotation([1, 0, 0, 0])
-		.setExtension('KHR_lights_punctual', lightDef);
-	const nodeDefB = document
-		.createNode('NodeA')
-		.setRotation([0, 1, 0, 0])
-		.setExtension('KHR_lights_punctual', lightDef);
+	test('instances', async () => {
+		const document = new Document();
+		const lightExt = document.createExtension(KHRLightsPunctual);
+		const lightDef = lightExt
+			.createLight('MyLight')
+			.setColor([1, 1, 1])
+			.setIntensity(2000)
+			.setType(LightDef.Type.SPOT);
+		const nodeDefA = document
+			.createNode('NodeA')
+			.setRotation([1, 0, 0, 0])
+			.setExtension('KHR_lights_punctual', lightDef);
+		const nodeDefB = document
+			.createNode('NodeA')
+			.setRotation([0, 1, 0, 0])
+			.setExtension('KHR_lights_punctual', lightDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const nodeA = documentView.view(nodeDefA);
-	const nodeB = documentView.view(nodeDefB);
-	const lightA = nodeA.children[0] as SpotLight;
-	const lightB = nodeB.children[0] as SpotLight;
+		const documentView = new DocumentView(document, { imageProvider });
+		const nodeA = documentView.view(nodeDefA);
+		const nodeB = documentView.view(nodeDefB);
+		const lightA = nodeA.children[0] as SpotLight;
+		const lightB = nodeB.children[0] as SpotLight;
 
-	const toUUID = (object: Object3D): string => object.uuid;
+		const toUUID = (object: Object3D): string => object.uuid;
 
-	t.deepEqual(nodeA.rotation.toArray(), [-Math.PI, 0, -0, 'XYZ'], 'nodeA.rotation');
-	t.deepEqual(nodeB.rotation.toArray(), [-Math.PI, 0, -Math.PI, 'XYZ'], 'nodeB.rotation');
+		deepEqual(nodeA.rotation.toArray(), [-Math.PI, 0, -0, 'XYZ'], 'nodeA.rotation');
+		deepEqual(nodeB.rotation.toArray(), [-Math.PI, 0, -Math.PI, 'XYZ'], 'nodeB.rotation');
 
-	t.is(lightA.type, 'SpotLight', 'lightA.type');
-	t.is(lightB.type, 'SpotLight', 'lightB.type');
-	t.true(lightA !== lightB, 'lightA !== lightB');
+		strictEqual(lightA.type, 'SpotLight', 'lightA.type');
+		strictEqual(lightB.type, 'SpotLight', 'lightB.type');
+		ok(lightA !== lightB, 'lightA !== lightB');
 
-	t.is(lightA.target.type, 'Object3D', 'lightA.target.type');
-	t.is(lightB.target.type, 'Object3D', 'lightB.target.type');
-	t.deepEqual([lightA.target.uuid], lightA.children.map(toUUID), 'lightA.children');
-	t.deepEqual([lightB.target.uuid], lightB.children.map(toUUID), 'lightB.children');
-	t.true(lightA.target !== lightB.target, 'lightA.target !== lightB.target');
+		strictEqual(lightA.target.type, 'Object3D', 'lightA.target.type');
+		strictEqual(lightB.target.type, 'Object3D', 'lightB.target.type');
+		deepEqual([lightA.target.uuid], lightA.children.map(toUUID), 'lightA.children');
+		deepEqual([lightB.target.uuid], lightB.children.map(toUUID), 'lightB.children');
+		ok(lightA.target !== lightB.target, 'lightA.target !== lightB.target');
+	});
 });

--- a/packages/view/test/LightSubject.test.ts
+++ b/packages/view/test/LightSubject.test.ts
@@ -9,7 +9,7 @@ import type { DirectionalLight, Object3D, PointLight, SpotLight } from 'three';
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-describe('LightSubject', () => {
+describe('view::LightSubject', () => {
 	test('point', async () => {
 		const document = new Document();
 		const lightExt = document.createExtension(KHRLightsPunctual);

--- a/packages/view/test/MaterialSubject.test.ts
+++ b/packages/view/test/MaterialSubject.test.ts
@@ -1,7 +1,8 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document, Primitive as PrimitiveDef } from '@gltf-transform/core';
 import { KHRMaterialsClearcoat, KHRMaterialsUnlit } from '@gltf-transform/extensions';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 import type {
 	BufferGeometry,
@@ -17,137 +18,148 @@ import type {
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('MaterialSubject', async (t) => {
-	const document = new Document();
-	const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
-	const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
-	const materialDef = document.createMaterial('Material').setBaseColorTexture(texDef1).setEmissiveTexture(texDef2);
-	const primDef = document.createPrimitive().setMaterial(materialDef);
-	const meshDef = document.createMesh('Mesh').addPrimitive(primDef);
-	const nodeDef = document.createNode('Node').setMesh(meshDef);
-	const sceneDef = document.createScene('Scene').addChild(nodeDef);
+describe('MaterialSubject', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
+		const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
+		const materialDef = document
+			.createMaterial('Material')
+			.setBaseColorTexture(texDef1)
+			.setEmissiveTexture(texDef2);
+		const primDef = document.createPrimitive().setMaterial(materialDef);
+		const meshDef = document.createMesh('Mesh').addPrimitive(primDef);
+		const nodeDef = document.createNode('Node').setMesh(meshDef);
+		const sceneDef = document.createScene('Scene').addChild(nodeDef);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const scene = documentView.view(sceneDef);
-	let mesh = scene.children[0].children[0].children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
-	let material = mesh.material;
+		const documentView = new DocumentView(document, { imageProvider });
+		const scene = documentView.view(sceneDef);
+		let mesh = scene.children[0].children[0].children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
+		let material = mesh.material;
 
-	t.is(material.name, 'Material', 'material.name → Material');
-	t.is(material.type, 'MeshStandardMaterial', 'material.type → MeshStandardMaterial');
-	t.truthy(material.map, 'material.map → ok');
-	t.truthy(material.emissiveMap, 'material.emissiveMap → ok');
+		strictEqual(material.name, 'Material', 'material.name → Material');
+		strictEqual(material.type, 'MeshStandardMaterial', 'material.type → MeshStandardMaterial');
+		ok(material.map, 'material.map → ok');
+		ok(material.emissiveMap, 'material.emissiveMap → ok');
 
-	texDef1.dispose();
-	mesh = scene.children[0].children[0].children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
-	material = mesh.material;
+		texDef1.dispose();
+		mesh = scene.children[0].children[0].children[0] as Mesh<BufferGeometry, MeshStandardMaterial>;
+		material = mesh.material;
 
-	t.falsy(material.map, 'material.map → null');
-	t.truthy(material.emissiveMap, 'material.emissiveMap → ok');
-});
+		strictEqual(material.map, null, 'material.map → null');
+		ok(material.emissiveMap, 'material.emissiveMap → ok');
+	});
 
-test('MaterialSubject | extensions', async (t) => {
-	const document = new Document();
-	const unlitExtension = document.createExtension(KHRMaterialsUnlit);
-	const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
+	test('extensions', async () => {
+		const document = new Document();
+		const unlitExtension = document.createExtension(KHRMaterialsUnlit);
+		const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
 
-	const materialDef = document.createMaterial('Material');
-	const documentView = new DocumentView(document, { imageProvider });
+		const materialDef = document.createMaterial('Material');
+		const documentView = new DocumentView(document, { imageProvider });
 
-	let material = documentView.view(materialDef);
+		let material = documentView.view(materialDef);
 
-	t.is(material.type, 'MeshStandardMaterial', 'MeshStandardMaterial');
+		strictEqual(material.type, 'MeshStandardMaterial', 'MeshStandardMaterial');
 
-	materialDef.setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
-	material = documentView.view(materialDef);
+		materialDef.setExtension('KHR_materials_unlit', unlitExtension.createUnlit());
+		material = documentView.view(materialDef);
 
-	t.is(material.type, 'MeshBasicMaterial', 'MeshBasicMaterial');
+		strictEqual(material.type, 'MeshBasicMaterial', 'MeshBasicMaterial');
 
-	materialDef.setExtension('KHR_materials_unlit', null);
-	material = documentView.view(materialDef);
+		materialDef.setExtension('KHR_materials_unlit', null);
+		material = documentView.view(materialDef);
 
-	t.is(material.type, 'MeshStandardMaterial', 'MeshStandardMaterial');
+		strictEqual(material.type, 'MeshStandardMaterial', 'MeshStandardMaterial');
 
-	materialDef.setExtension('KHR_materials_clearcoat', clearcoatExtension.createClearcoat());
-	material = documentView.view(materialDef);
+		materialDef.setExtension('KHR_materials_clearcoat', clearcoatExtension.createClearcoat());
+		material = documentView.view(materialDef);
 
-	t.is(material.type, 'MeshPhysicalMaterial', 'MeshPhysicalMaterial');
-});
+		strictEqual(material.type, 'MeshPhysicalMaterial', 'MeshPhysicalMaterial');
+	});
 
-test('MaterialSubject | dispose', async (t) => {
-	const document = new Document();
-	const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
-	const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
-	const materialDef = document.createMaterial('Material').setBaseColorTexture(texDef1).setEmissiveTexture(texDef2);
-	const meshPrimDef = document.createPrimitive().setMode(PrimitiveDef.Mode.TRIANGLES).setMaterial(materialDef);
-	const pointsPrimDef = document.createPrimitive().setMode(PrimitiveDef.Mode.POINTS).setMaterial(materialDef);
-	const meshDef = document.createMesh('Mesh').addPrimitive(meshPrimDef).addPrimitive(pointsPrimDef);
-	const sceneDef = document.createScene('Scene').addChild(document.createNode('Node').setMesh(meshDef));
+	test('dispose', async () => {
+		const document = new Document();
+		const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
+		const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
+		const materialDef = document
+			.createMaterial('Material')
+			.setBaseColorTexture(texDef1)
+			.setEmissiveTexture(texDef2);
+		const meshPrimDef = document.createPrimitive().setMode(PrimitiveDef.Mode.TRIANGLES).setMaterial(materialDef);
+		const pointsPrimDef = document.createPrimitive().setMode(PrimitiveDef.Mode.POINTS).setMaterial(materialDef);
+		const meshDef = document.createMesh('Mesh').addPrimitive(meshPrimDef).addPrimitive(pointsPrimDef);
+		const sceneDef = document.createScene('Scene').addChild(document.createNode('Node').setMesh(meshDef));
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const scene = documentView.view(sceneDef);
-	const [mesh, points] = scene.getObjectByName('Mesh')!.children as [Mesh, Points];
-	const meshMaterial = mesh.material as MeshStandardMaterial;
-	const pointsMaterial = points.material as PointsMaterial;
+		const documentView = new DocumentView(document, { imageProvider });
+		const scene = documentView.view(sceneDef);
+		const [mesh, points] = scene.getObjectByName('Mesh')!.children as [Mesh, Points];
+		const meshMaterial = mesh.material as MeshStandardMaterial;
+		const pointsMaterial = points.material as PointsMaterial;
 
-	const disposed = new Set();
-	meshMaterial.addEventListener('dispose', () => disposed.add(meshMaterial));
-	pointsMaterial.addEventListener('dispose', () => disposed.add(pointsMaterial));
+		const disposed = new Set();
+		meshMaterial.addEventListener('dispose', () => disposed.add(meshMaterial));
+		pointsMaterial.addEventListener('dispose', () => disposed.add(pointsMaterial));
 
-	t.is(disposed.size, 0, 'initial values');
-	t.is(meshMaterial.type, 'MeshStandardMaterial', 'creates MeshStandardMaterial');
-	t.is(pointsMaterial.type, 'PointsMaterial', 'creates PointsMaterial');
+		strictEqual(disposed.size, 0, 'initial values');
+		strictEqual(meshMaterial.type, 'MeshStandardMaterial', 'creates MeshStandardMaterial');
+		strictEqual(pointsMaterial.type, 'PointsMaterial', 'creates PointsMaterial');
 
-	meshPrimDef.setMaterial(null);
-	documentView.gc();
+		meshPrimDef.setMaterial(null);
+		documentView.gc();
 
-	t.is(disposed.size, 1, 'dispose count (1/3)');
-	t.truthy(disposed.has(meshMaterial), 'dispose MeshStandardMaterial');
+		strictEqual(disposed.size, 1, 'dispose count (1/3)');
+		ok(disposed.has(meshMaterial), 'dispose MeshStandardMaterial');
 
-	pointsPrimDef.setMode(PrimitiveDef.Mode.LINES);
-	documentView.gc();
+		pointsPrimDef.setMode(PrimitiveDef.Mode.LINES);
+		documentView.gc();
 
-	t.is(disposed.size, 2, 'dispose count (2/3)');
-	t.truthy(disposed.has(pointsMaterial), 'dispose PointsMaterial');
+		strictEqual(disposed.size, 2, 'dispose count (2/3)');
+		ok(disposed.has(pointsMaterial), 'dispose PointsMaterial');
 
-	const [_, lines] = scene.getObjectByName('Mesh')!.children as [unknown, LineSegments];
-	const lineMaterial = lines.material as LineBasicMaterial;
-	lineMaterial.addEventListener('dispose', () => disposed.add(lineMaterial));
+		const [_, lines] = scene.getObjectByName('Mesh')!.children as [unknown, LineSegments];
+		const lineMaterial = lines.material as LineBasicMaterial;
+		lineMaterial.addEventListener('dispose', () => disposed.add(lineMaterial));
 
-	t.is(lineMaterial.type, 'LineBasicMaterial', 'creates LineBasicMaterial');
+		strictEqual(lineMaterial.type, 'LineBasicMaterial', 'creates LineBasicMaterial');
 
-	materialDef.dispose();
-	documentView.gc();
+		materialDef.dispose();
+		documentView.gc();
 
-	t.is(disposed.size, 3, 'dispose count (3/3)');
-	t.truthy(disposed.has(pointsMaterial), 'dispose LineBasicMaterial');
-});
+		strictEqual(disposed.size, 3, 'dispose count (3/3)');
+		ok(disposed.has(pointsMaterial), 'dispose LineBasicMaterial');
+	});
 
-test('MaterialSubject | texture memory', async (t) => {
-	const document = new Document();
-	const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
-	const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
-	const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
-	const materialDef = document.createMaterial('Material').setBaseColorTexture(texDef1).setEmissiveTexture(texDef2);
+	test('texture memory', async () => {
+		const document = new Document();
+		const clearcoatExtension = document.createExtension(KHRMaterialsClearcoat);
+		const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));
+		const texDef2 = document.createTexture('Tex2').setMimeType('image/png').setImage(new Uint8Array(0));
+		const materialDef = document
+			.createMaterial('Material')
+			.setBaseColorTexture(texDef1)
+			.setEmissiveTexture(texDef2);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	let material = documentView.view(materialDef);
-	const { map, emissiveMap } = material as unknown as {
-		map: Texture;
-		emissiveMap: Texture;
-	};
+		const documentView = new DocumentView(document, { imageProvider });
+		let material = documentView.view(materialDef);
+		const { map, emissiveMap } = material as unknown as {
+			map: Texture;
+			emissiveMap: Texture;
+		};
 
-	t.is(material.type, 'MeshStandardMaterial', 'original material');
-	t.truthy(map.source === emissiveMap.source, 'map.source === emissiveMap.source');
+		strictEqual(material.type, 'MeshStandardMaterial', 'original material');
+		ok(map.source === emissiveMap.source, 'map.source === emissiveMap.source');
 
-	const baseVersion = map.version;
-	t.is(map.version, baseVersion, 'map.version');
-	t.is(emissiveMap.version, baseVersion, 'emissiveMap.version');
+		const baseVersion = map.version;
+		strictEqual(map.version, baseVersion, 'map.version');
+		strictEqual(emissiveMap.version, baseVersion, 'emissiveMap.version');
 
-	materialDef.setExtension('KHR_materials_clearcoat', clearcoatExtension.createClearcoat());
-	material = documentView.view(materialDef);
+		materialDef.setExtension('KHR_materials_clearcoat', clearcoatExtension.createClearcoat());
+		material = documentView.view(materialDef);
 
-	t.is(material.type, 'MeshPhysicalMaterial', 'new material');
-	t.truthy(map.source === emissiveMap.source, 'map.source === emissiveMap.source');
-	t.is(map.version, baseVersion, 'map.version');
-	t.is(emissiveMap.version, baseVersion, 'emissiveMap.version');
+		strictEqual(material.type, 'MeshPhysicalMaterial', 'new material');
+		ok(map.source === emissiveMap.source, 'map.source === emissiveMap.source');
+		strictEqual(map.version, baseVersion, 'map.version');
+		strictEqual(emissiveMap.version, baseVersion, 'emissiveMap.version');
+	});
 });

--- a/packages/view/test/MaterialSubject.test.ts
+++ b/packages/view/test/MaterialSubject.test.ts
@@ -18,7 +18,7 @@ import type {
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-describe('MaterialSubject', () => {
+describe('view::MaterialSubject', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const texDef1 = document.createTexture('Tex1').setMimeType('image/png').setImage(new Uint8Array(0));

--- a/packages/view/test/MeshSubject.test.ts
+++ b/packages/view/test/MeshSubject.test.ts
@@ -1,12 +1,13 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('MeshSubject', async (t) => {
+test('MeshSubject', async () => {
 	const document = new Document();
 	const position = document
 		.createAccessor()
@@ -18,16 +19,16 @@ test('MeshSubject', async (t) => {
 	const documentView = new DocumentView(document, { imageProvider });
 	const mesh = documentView.view(meshDef);
 
-	t.is(mesh.name, 'MyMesh', 'mesh → name');
+	strictEqual(mesh.name, 'MyMesh', 'mesh → name');
 
 	meshDef.setName('MyMeshRenamed');
-	t.is(mesh.name, 'MyMeshRenamed', 'mesh → name (2)');
+	strictEqual(mesh.name, 'MyMeshRenamed', 'mesh → name (2)');
 
-	t.is(mesh.children[0].type, 'Mesh', 'mesh → prim (initial)');
+	strictEqual(mesh.children[0].type, 'Mesh', 'mesh → prim (initial)');
 
 	meshDef.removePrimitive(primDef);
-	t.is(mesh.children.length, 0, 'mesh → prim (remove)');
+	strictEqual(mesh.children.length, 0, 'mesh → prim (remove)');
 
 	meshDef.addPrimitive(primDef);
-	t.is(mesh.children.length, 1, 'mesh → prim (add)');
+	strictEqual(mesh.children.length, 1, 'mesh → prim (add)');
 });

--- a/packages/view/test/NodeSubject.test.ts
+++ b/packages/view/test/NodeSubject.test.ts
@@ -7,7 +7,7 @@ import { JSDOM } from 'jsdom';
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-describe('NodeSubject', () => {
+describe('view::NodeSubject', () => {
 	test('basic', async () => {
 		const document = new Document();
 		const nodeDef1 = document

--- a/packages/view/test/NodeSubject.test.ts
+++ b/packages/view/test/NodeSubject.test.ts
@@ -1,89 +1,92 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { describe, test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('NodeSubject', async (t) => {
-	const document = new Document();
-	const nodeDef1 = document
-		.createNode('Node1')
-		.setTranslation([0, 2, 0])
-		.setRotation([0, 0, 0.707, 0.707])
-		.setScale([0.5, 0.5, 0.5])
-		.addChild(document.createNode('Node2').setTranslation([5, 0, 0]));
+describe('NodeSubject', () => {
+	test('basic', async () => {
+		const document = new Document();
+		const nodeDef1 = document
+			.createNode('Node1')
+			.setTranslation([0, 2, 0])
+			.setRotation([0, 0, 0.707, 0.707])
+			.setScale([0.5, 0.5, 0.5])
+			.addChild(document.createNode('Node2').setTranslation([5, 0, 0]));
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const node1 = documentView.view(nodeDef1);
+		const documentView = new DocumentView(document, { imageProvider });
+		const node1 = documentView.view(nodeDef1);
 
-	t.is(node1.name, 'Node1', 'node1 → name');
-	t.is(node1.children.length, 1, 'node1 → children');
-	t.deepEqual(node1.position.toArray(), [0, 2, 0], 'node1 → position');
-	t.deepEqual(node1.quaternion.toArray(), [0, 0, 0.707, 0.707], 'node1 → quaternion');
-	t.deepEqual(node1.scale.toArray(), [0.5, 0.5, 0.5], 'node1 → scale');
+		strictEqual(node1.name, 'Node1', 'node1 → name');
+		strictEqual(node1.children.length, 1, 'node1 → children');
+		deepEqual(node1.position.toArray(), [0, 2, 0], 'node1 → position');
+		deepEqual(node1.quaternion.toArray(), [0, 0, 0.707, 0.707], 'node1 → quaternion');
+		deepEqual(node1.scale.toArray(), [0.5, 0.5, 0.5], 'node1 → scale');
 
-	const node2 = node1.children[0];
-	t.is(node2.name, 'Node2', 'node2 → name');
-	t.is(node2.children.length, 0, 'node2 → children');
-	t.deepEqual(node2.position.toArray(), [5, 0, 0], 'node2 → position');
-	t.deepEqual(node2.quaternion.toArray(), [0, 0, 0, 1], 'node2 → quaternion');
-	t.deepEqual(node2.scale.toArray(), [1, 1, 1], 'node2 → scale');
+		const node2 = node1.children[0];
+		strictEqual(node2.name, 'Node2', 'node2 → name');
+		strictEqual(node2.children.length, 0, 'node2 → children');
+		deepEqual(node2.position.toArray(), [5, 0, 0], 'node2 → position');
+		deepEqual(node2.quaternion.toArray(), [0, 0, 0, 1], 'node2 → quaternion');
+		deepEqual(node2.scale.toArray(), [1, 1, 1], 'node2 → scale');
 
-	nodeDef1.setName('RenamedNode').setTranslation([0, 0, 0]);
+		nodeDef1.setName('RenamedNode').setTranslation([0, 0, 0]);
 
-	t.is(node1.name, 'RenamedNode', 'node1 → name');
-	t.deepEqual(node1.position.toArray(), [0, 0, 0], 'node1 → position');
-});
+		strictEqual(node1.name, 'RenamedNode', 'node1 → name');
+		deepEqual(node1.position.toArray(), [0, 0, 0], 'node1 → position');
+	});
 
-test('NodeSubject | update in place', async (t) => {
-	const document = new Document();
-	const meshDef = document.createMesh().setName('Mesh.v1');
-	const nodeDef1 = document.createNode('Node1').setMesh(meshDef);
-	const nodeDef2 = document.createNode('Node2').setMesh(meshDef).addChild(nodeDef1);
-	const sceneDef = document.createScene().addChild(nodeDef2);
+	test('update in place', async () => {
+		const document = new Document();
+		const meshDef = document.createMesh().setName('Mesh.v1');
+		const nodeDef1 = document.createNode('Node1').setMesh(meshDef);
+		const nodeDef2 = document.createNode('Node2').setMesh(meshDef).addChild(nodeDef1);
+		const sceneDef = document.createScene().addChild(nodeDef2);
 
-	const documentView = new DocumentView(document, { imageProvider });
-	const scene = documentView.view(sceneDef);
-	const node1 = documentView.view(nodeDef1);
-	const node2 = documentView.view(nodeDef2);
-	const mesh = node1.children[0];
+		const documentView = new DocumentView(document, { imageProvider });
+		const scene = documentView.view(sceneDef);
+		const node1 = documentView.view(nodeDef1);
+		const node2 = documentView.view(nodeDef2);
+		const mesh = node1.children[0];
 
-	t.truthy(scene, 'scene ok');
-	t.truthy(node1, 'node1 ok');
-	t.truthy(node2, 'node2 ok');
-	t.truthy(mesh, 'mesh ok');
+		ok(scene, 'scene ok');
+		ok(node1, 'node1 ok');
+		ok(node2, 'node2 ok');
+		ok(mesh, 'mesh ok');
 
-	t.is(scene.children[0], node2, 'node2 view');
-	t.is(scene.children[0].children[0], node1, 'node1 view');
-	t.is(scene.children[0].children[0].children[0], mesh, 'mesh view');
+		strictEqual(scene.children[0], node2, 'node2 view');
+		strictEqual(scene.children[0].children[0], node1, 'node1 view');
+		strictEqual(scene.children[0].children[0].children[0], mesh, 'mesh view');
 
-	nodeDef1.setScale([2, 2, 2]);
-	nodeDef2.setScale([3, 3, 3]);
+		nodeDef1.setScale([2, 2, 2]);
+		nodeDef2.setScale([3, 3, 3]);
 
-	t.is(scene.children[0], node2, 'node2 view after update');
-	t.is(scene.children[0].children[0], node1, 'node1 view after update');
-	t.is(scene.children[0].children[0].children[0], mesh, 'mesh view');
+		strictEqual(scene.children[0], node2, 'node2 view after update');
+		strictEqual(scene.children[0].children[0], node1, 'node1 view after update');
+		strictEqual(scene.children[0].children[0].children[0], mesh, 'mesh view');
 
-	t.deepEqual(node1.scale.toArray([]), [2, 2, 2], 'node1 scale');
-	t.deepEqual(node2.scale.toArray([]), [3, 3, 3], 'node2 scale');
+		deepEqual(node1.scale.toArray([]), [2, 2, 2], 'node1 scale');
+		deepEqual(node2.scale.toArray([]), [3, 3, 3], 'node2 scale');
 
-	t.truthy(
-		node1.children.some((o) => o.name === 'Mesh.v1'),
-		'node1.mesh.name',
-	);
-	t.truthy(
-		node2.children.some((o) => o.name === 'Mesh.v1'),
-		'node2.mesh.name',
-	);
-	meshDef.setName('Mesh.v2');
-	t.truthy(
-		node1.children.some((o) => o.name === 'Mesh.v2'),
-		'node1.mesh.name',
-	);
-	t.truthy(
-		node2.children.some((o) => o.name === 'Mesh.v2'),
-		'node2.mesh.name',
-	);
+		ok(
+			node1.children.some((o) => o.name === 'Mesh.v1'),
+			'node1.mesh.name',
+		);
+		ok(
+			node2.children.some((o) => o.name === 'Mesh.v1'),
+			'node2.mesh.name',
+		);
+		meshDef.setName('Mesh.v2');
+		ok(
+			node1.children.some((o) => o.name === 'Mesh.v2'),
+			'node1.mesh.name',
+		);
+		ok(
+			node2.children.some((o) => o.name === 'Mesh.v2'),
+			'node2.mesh.name',
+		);
+	});
 });

--- a/packages/view/test/PrimitiveSubject.test.ts
+++ b/packages/view/test/PrimitiveSubject.test.ts
@@ -1,12 +1,13 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document, Primitive as PrimitiveDef } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('PrimitiveSubject', async (t) => {
+test('PrimitiveSubject', async () => {
 	const document = new Document();
 	const position = document
 		.createAccessor()
@@ -22,37 +23,37 @@ test('PrimitiveSubject', async (t) => {
 	const disposed = new Set();
 	geometry.addEventListener('dispose', () => disposed.add(geometry));
 
-	t.is(prim.type, 'Mesh', 'Mesh');
+	strictEqual(prim.type, 'Mesh', 'Mesh');
 
 	primDef.setMode(PrimitiveDef.Mode.POINTS);
 	prim = documentView.view(primDef);
 
-	t.is(prim.type, 'Points', 'Points');
+	strictEqual(prim.type, 'Points', 'Points');
 
 	primDef.setMode(PrimitiveDef.Mode.LINES);
 	prim = documentView.view(primDef);
 
-	t.is(prim.type, 'LineSegments', 'LineSegments');
+	strictEqual(prim.type, 'LineSegments', 'LineSegments');
 
 	primDef.setMode(PrimitiveDef.Mode.LINE_LOOP);
 	prim = documentView.view(primDef);
 
-	t.is(prim.type, 'LineLoop', 'LineLoop');
+	strictEqual(prim.type, 'LineLoop', 'LineLoop');
 
 	primDef.setMode(PrimitiveDef.Mode.LINE_STRIP);
 	prim = documentView.view(primDef);
 
-	t.is(prim.type, 'Line', 'Line');
+	strictEqual(prim.type, 'Line', 'Line');
 
-	t.is(prim.material.name, 'MyMaterial', 'prim.material → material');
+	strictEqual(prim.material.name, 'MyMaterial', 'prim.material → material');
 
 	primDef.setMaterial(null);
 
-	t.is(prim.material.name, '__DefaultMaterial', 'prim.material → null');
+	strictEqual(prim.material.name, '__DefaultMaterial', 'prim.material → null');
 
-	t.is(disposed.size, 0, 'preserve geometry');
+	strictEqual(disposed.size, 0, 'preserve geometry');
 
 	primDef.dispose();
 
-	t.is(disposed.size, 1, 'dispose geometry');
+	strictEqual(disposed.size, 1, 'dispose geometry');
 });

--- a/packages/view/test/SceneSubject.test.ts
+++ b/packages/view/test/SceneSubject.test.ts
@@ -1,12 +1,13 @@
+import { strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document, type Node } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('SceneBinding', async (t) => {
+test('SceneBinding', async () => {
 	const document = new Document();
 	let nodeDef: Node;
 	const sceneDef = document
@@ -19,17 +20,17 @@ test('SceneBinding', async (t) => {
 	const documentView = new DocumentView(document, { imageProvider });
 	const scene = documentView.view(sceneDef);
 
-	t.is(scene.name, 'MyScene', 'scene → name');
+	strictEqual(scene.name, 'MyScene', 'scene → name');
 	sceneDef.setName('MySceneRenamed');
-	t.is(scene.name, 'MySceneRenamed', 'scene → name (renamed)');
-	t.is(scene.children.length, 3, 'scene → children → 3');
+	strictEqual(scene.name, 'MySceneRenamed', 'scene → name (renamed)');
+	strictEqual(scene.children.length, 3, 'scene → children → 3');
 
-	t.is(scene.children[1].children[0].name, 'Node4', 'scene → ... → grandchild');
+	strictEqual(scene.children[1].children[0].name, 'Node4', 'scene → ... → grandchild');
 	nodeDef.listChildren()[0].dispose();
-	t.is(scene.children[1].children.length, 0, 'scene → ... → grandchild (dispose)');
+	strictEqual(scene.children[1].children.length, 0, 'scene → ... → grandchild (dispose)');
 
 	nodeDef.dispose();
-	t.is(scene.children.length, 2, 'scene → children → 2');
+	strictEqual(scene.children.length, 2, 'scene → children → 2');
 	sceneDef.removeChild(sceneDef.listChildren()[0]);
-	t.is(scene.children.length, 1, 'scene → children → 1');
+	strictEqual(scene.children.length, 1, 'scene → children → 1');
 });

--- a/packages/view/test/SceneSubject.test.ts
+++ b/packages/view/test/SceneSubject.test.ts
@@ -7,7 +7,7 @@ import { JSDOM } from 'jsdom';
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('SceneBinding', async () => {
+test('SceneSubject', async () => {
 	const document = new Document();
 	let nodeDef: Node;
 	const sceneDef = document

--- a/packages/view/test/SkinSubject.test.ts
+++ b/packages/view/test/SkinSubject.test.ts
@@ -1,13 +1,14 @@
+import { deepEqual, ok, strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 import type { Bone, Mesh, SkinnedMesh } from 'three';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('SkinSubject', async (t) => {
+test('SkinSubject', async () => {
 	const document = new Document();
 	const positionDef = document
 		.createAccessor('POSITION')
@@ -39,12 +40,12 @@ test('SkinSubject', async (t) => {
 	const mesh = armature.children.find((child) => child.name === 'Mesh') as Mesh;
 	const prim = mesh.children.find((child) => child.type === 'SkinnedMesh') as SkinnedMesh;
 
-	t.is(armature.name, 'Armature', 'armature → name');
-	t.is(mesh.type, 'Group', 'armature → mesh');
-	t.is(prim.type, 'SkinnedMesh', 'armature → mesh → prim');
-	t.is(boneA.type, 'Bone', 'armature → jointA');
-	t.is(boneB.type, 'Bone', 'armature → jointA → jointB');
-	t.truthy(prim.skeleton, 'skeleton');
-	t.deepEqual(prim.skeleton.bones, [boneA, boneB], 'skeleton.bones');
-	t.is(prim.skeleton.boneInverses.length, 2, 'skeleton.boneInverses');
+	strictEqual(armature.name, 'Armature', 'armature → name');
+	strictEqual(mesh.type, 'Group', 'armature → mesh');
+	strictEqual(prim.type, 'SkinnedMesh', 'armature → mesh → prim');
+	strictEqual(boneA.type, 'Bone', 'armature → jointA');
+	strictEqual(boneB.type, 'Bone', 'armature → jointA → jointB');
+	ok(prim.skeleton, 'skeleton');
+	deepEqual(prim.skeleton.bones, [boneA, boneB], 'skeleton.bones');
+	strictEqual(prim.skeleton.boneInverses.length, 2, 'skeleton.boneInverses');
 });

--- a/packages/view/test/TextureSubject.test.ts
+++ b/packages/view/test/TextureSubject.test.ts
@@ -1,13 +1,14 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { test } from 'node:test';
 import { Document } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
-import test from 'ava';
 import { JSDOM } from 'jsdom';
 import { type MeshStandardMaterial, NoColorSpace, SRGBColorSpace, type Texture } from 'three';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('TextureBinding', async (t) => {
+test('TextureBinding', async () => {
 	const document = new Document();
 	const textureDef = document
 		.createTexture('MyTexture')
@@ -27,16 +28,16 @@ test('TextureBinding', async (t) => {
 	const metalnessMap = material.metalnessMap as Texture;
 	const roughnessMap = material.roughnessMap as Texture;
 
-	t.truthy(texture, 'texture');
-	t.is(map.colorSpace, SRGBColorSpace, 'map.colorSpace = "srgb"');
-	t.is(map.channel, 0, 'map.channel = 0');
-	t.is(roughnessMap.colorSpace, NoColorSpace, 'no color space');
-	t.is(metalnessMap.colorSpace, NoColorSpace, 'no color space');
-	t.is(roughnessMap.channel, 1, 'roughnessMap.channel = 1');
-	t.is(metalnessMap.channel, 1, 'metalnessMap.channel = 1');
-	t.true(map.source === metalnessMap.source, 'map.source === metalnessMap.source');
-	t.true(metalnessMap === roughnessMap, 'metalnessMap === roughnessMap');
-	t.falsy(texture.flipY || map.flipY || roughnessMap.flipY || metalnessMap.flipY, 'flipY=false');
+	ok(texture, 'texture');
+	strictEqual(map.colorSpace, SRGBColorSpace, 'map.colorSpace = "srgb"');
+	strictEqual(map.channel, 0, 'map.channel = 0');
+	strictEqual(roughnessMap.colorSpace, NoColorSpace, 'no color space');
+	strictEqual(metalnessMap.colorSpace, NoColorSpace, 'no color space');
+	strictEqual(roughnessMap.channel, 1, 'roughnessMap.channel = 1');
+	strictEqual(metalnessMap.channel, 1, 'metalnessMap.channel = 1');
+	ok(map.source === metalnessMap.source, 'map.source === metalnessMap.source');
+	ok(metalnessMap === roughnessMap, 'metalnessMap === roughnessMap');
+	strictEqual(texture.flipY || map.flipY || roughnessMap.flipY || metalnessMap.flipY, false, 'flipY=false');
 
 	const disposed = new Set();
 	texture.addEventListener('dispose', () => disposed.add(texture));
@@ -47,18 +48,18 @@ test('TextureBinding', async (t) => {
 	materialDef.setBaseColorTexture(null);
 	documentView.gc();
 
-	t.is(disposed.size, 1, 'dispose count (1/3)');
-	t.true(disposed.has(map), 'dispose map');
+	strictEqual(disposed.size, 1, 'dispose count (1/3)');
+	ok(disposed.has(map), 'dispose map');
 
 	materialDef.dispose();
 	documentView.gc();
 
-	t.is(disposed.size, 2, 'dispose count (2/3)');
-	t.true(disposed.has(map), 'dispose roughnessMap, metalnessMap');
+	strictEqual(disposed.size, 2, 'dispose count (2/3)');
+	ok(disposed.has(map), 'dispose roughnessMap, metalnessMap');
 
 	textureDef.dispose();
 	documentView.gc();
 
-	t.is(disposed.size, 3, 'dispose count (3/3)');
-	t.true(disposed.has(texture), 'dispose roughnessMap, metalnessMap');
+	strictEqual(disposed.size, 3, 'dispose count (3/3)');
+	ok(disposed.has(texture), 'dispose roughnessMap, metalnessMap');
 });

--- a/packages/view/test/TextureSubject.test.ts
+++ b/packages/view/test/TextureSubject.test.ts
@@ -8,7 +8,7 @@ import { type MeshStandardMaterial, NoColorSpace, SRGBColorSpace, type Texture }
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
 
-test('TextureBinding', async () => {
+test('TextureSubject', async () => {
 	const document = new Document();
 	const textureDef = document
 		.createTexture('MyTexture')

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,23 +928,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/node-pre-gyp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@mapbox/node-pre-gyp@npm:2.0.0"
-  dependencies:
-    consola: "npm:^3.2.3"
-    detect-libc: "npm:^2.0.0"
-    https-proxy-agent: "npm:^7.0.5"
-    node-fetch: "npm:^2.6.7"
-    nopt: "npm:^8.0.0"
-    semver: "npm:^7.5.3"
-    tar: "npm:^7.4.0"
-  bin:
-    node-pre-gyp: bin/node-pre-gyp
-  checksum: 10c0/7d874c7f6f5560a87be7207f28d9a4e53b750085a82167608fd573aab8073645e95b3608f69e244df0e1d24e90a66525aeae708aba82ca73ff668ed0ab6abda6
-  languageName: node
-  linkType: hard
-
 "@napi-rs/wasm-runtime@npm:0.2.4":
   version: 0.2.4
   resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
@@ -1699,22 +1682,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^5.1.3":
-  version: 5.3.0
-  resolution: "@rollup/pluginutils@npm:5.3.0"
-  dependencies:
-    "@types/estree": "npm:^1.0.0"
-    estree-walker: "npm:^2.0.2"
-    picomatch: "npm:^4.0.2"
-  peerDependencies:
-    rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-  peerDependenciesMeta:
-    rollup:
-      optional: true
-  checksum: 10c0/001834bf62d7cf5bac424d2617c113f7f7d3b2bf3c1778cbcccb72cdc957b68989f8e7747c782c2b911f1dde8257f56f8ac1e779e29e74e638e3f1e2cac2bcd0
-  languageName: node
-  linkType: hard
-
 "@sigstore/bundle@npm:^2.3.2":
   version: 2.3.2
   resolution: "@sigstore/bundle@npm:2.3.2"
@@ -1777,13 +1744,6 @@ __metadata:
   version: 0.27.8
   resolution: "@sinclair/typebox@npm:0.27.8"
   checksum: 10c0/ef6351ae073c45c2ac89494dbb3e1f87cc60a93ce4cde797b782812b6f97da0d620ae81973f104b43c9b7eaa789ad20ba4f6a1359f1cc62f63729a55a7d22d4e
-  languageName: node
-  linkType: hard
-
-"@sindresorhus/merge-streams@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
-  checksum: 10c0/482ee543629aa1933b332f811a1ae805a213681ecdd98c042b1c1b89387df63e7812248bb4df3910b02b3cc5589d3d73e4393f30e197c9dde18046ccd471fc6b
   languageName: node
   linkType: hard
 
@@ -1975,7 +1935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.0, @types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6":
+"@types/estree@npm:^1.0.5, @types/estree@npm:^1.0.6":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
@@ -2205,28 +2165,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/nft@npm:^1.3.2":
-  version: 1.5.0
-  resolution: "@vercel/nft@npm:1.5.0"
-  dependencies:
-    "@mapbox/node-pre-gyp": "npm:^2.0.0"
-    "@rollup/pluginutils": "npm:^5.1.3"
-    acorn: "npm:^8.6.0"
-    acorn-import-attributes: "npm:^1.9.5"
-    async-sema: "npm:^3.1.1"
-    bindings: "npm:^1.4.0"
-    estree-walker: "npm:2.0.2"
-    glob: "npm:^13.0.0"
-    graceful-fs: "npm:^4.2.9"
-    node-gyp-build: "npm:^4.2.2"
-    picomatch: "npm:^4.0.2"
-    resolve-from: "npm:^5.0.0"
-  bin:
-    nft: out/cli.js
-  checksum: 10c0/e44f2bb41908f11ece98aa5c4f33b7ff6575a5102ab2db2675f4ee74bcc62439dce4d363a393f80a677898f63f7cac5741685653ee97a924e61e75c9d5b504d6
-  languageName: node
-  linkType: hard
-
 "@webgpu/types@npm:*":
   version: 0.1.66
   resolution: "@webgpu/types@npm:0.1.66"
@@ -2449,25 +2387,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-import-attributes@npm:^1.9.5":
-  version: 1.9.5
-  resolution: "acorn-import-attributes@npm:1.9.5"
-  peerDependencies:
-    acorn: ^8
-  checksum: 10c0/5926eaaead2326d5a86f322ff1b617b0f698aa61dc719a5baa0e9d955c9885cc71febac3fb5bacff71bbf2c4f9c12db2056883c68c53eb962c048b952e1e013d
-  languageName: node
-  linkType: hard
-
-"acorn-walk@npm:^8.3.5":
-  version: 8.3.5
-  resolution: "acorn-walk@npm:8.3.5"
-  dependencies:
-    acorn: "npm:^8.11.0"
-  checksum: 10c0/e31bf5b5423ed1349437029d66d708b9fbd1b77a644b031501e2c753b028d13b56348210ed901d5b1d0d86eb3381c0a0fc0d0998511a9d546d1194936266a332
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.11.0, acorn@npm:^8.12.1, acorn@npm:^8.6.0":
+"acorn@npm:^8.12.1":
   version: 8.15.0
   resolution: "acorn@npm:8.15.0"
   bin:
@@ -2560,7 +2480,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^6.0.1, ansi-regex@npm:^6.2.2":
+"ansi-regex@npm:^6.0.1":
   version: 6.2.2
   resolution: "ansi-regex@npm:6.2.2"
   checksum: 10c0/05d4acb1d2f59ab2cf4b794339c7b168890d44dda4bf0ce01152a8da0213aca207802f930442ce8cd22d7a92f44907664aac6508904e75e038fa944d2601b30f
@@ -2592,7 +2512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.0.0, ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
+"ansi-styles@npm:^6.0.0, ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
@@ -2643,13 +2563,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-find-index@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "array-find-index@npm:1.0.2"
-  checksum: 10c0/86b9485c74ddd324feab807e10a6de3f9c1683856267236fac4bb4d4667ada6463e106db3f6c540ae6b720e0442b590ec701d13676df4c6af30ebf4da09b4f57
-  languageName: node
-  linkType: hard
-
 "array-ify@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-ify@npm:1.0.0"
@@ -2664,13 +2577,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arrgv@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "arrgv@npm:1.0.2"
-  checksum: 10c0/7e6e782e6b749923ac7cbc4048ef6fe0844c4a59bfc8932fcd4c44566ba25eed46501f94dd7cf3c7297da88f3f599ca056bfb77d0c2484aebc92f04239f69124
-  languageName: node
-  linkType: hard
-
 "arrify@npm:^1.0.1":
   version: 1.0.1
   resolution: "arrify@npm:1.0.1"
@@ -2682,13 +2588,6 @@ __metadata:
   version: 2.0.1
   resolution: "arrify@npm:2.0.1"
   checksum: 10c0/3fb30b5e7c37abea1907a60b28a554d2f0fc088757ca9bf5b684786e583fdf14360721eb12575c1ce6f995282eab936712d3c4389122682eafab0e0b57f78dbb
-  languageName: node
-  linkType: hard
-
-"arrify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "arrify@npm:3.0.0"
-  checksum: 10c0/2e26601b8486f29780f1f70f7ac05a226755814c2a3ab42e196748f650af1dc310cd575a11dd4b9841c70fd7460b2dd2b8fe6fb7a3375878e2660706efafa58e
   languageName: node
   linkType: hard
 
@@ -2713,13 +2612,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-sema@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "async-sema@npm:3.1.1"
-  checksum: 10c0/a16da9f7f2dbdd00a969bf264b7ad331b59df3eac2b38f529b881c5cc8662594e68ed096d927ec2aabdc13454379cdc6d677bcdb0a3d2db338fb4be17957832b
-  languageName: node
-  linkType: hard
-
 "async@npm:^3.2.3, async@npm:^3.2.6":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
@@ -2731,60 +2623,6 @@ __metadata:
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
   checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
-  languageName: node
-  linkType: hard
-
-"ava@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "ava@npm:7.0.0"
-  dependencies:
-    "@vercel/nft": "npm:^1.3.2"
-    acorn: "npm:^8.16.0"
-    acorn-walk: "npm:^8.3.5"
-    ansi-styles: "npm:^6.2.3"
-    arrgv: "npm:^1.0.2"
-    arrify: "npm:^3.0.0"
-    callsites: "npm:^4.2.0"
-    cbor: "npm:^10.0.11"
-    chalk: "npm:^5.6.2"
-    chunkd: "npm:^2.0.1"
-    ci-info: "npm:^4.4.0"
-    ci-parallel-vars: "npm:^1.0.1"
-    cli-truncate: "npm:^5.1.1"
-    code-excerpt: "npm:^4.0.0"
-    common-path-prefix: "npm:^3.0.0"
-    concordance: "npm:^5.0.4"
-    currently-unhandled: "npm:^0.4.1"
-    debug: "npm:^4.4.3"
-    emittery: "npm:^1.2.0"
-    figures: "npm:^6.1.0"
-    globby: "npm:^16.1.1"
-    ignore-by-default: "npm:^2.1.0"
-    indent-string: "npm:^5.0.0"
-    is-plain-object: "npm:^5.0.0"
-    is-promise: "npm:^4.0.0"
-    matcher: "npm:^6.0.0"
-    memoize: "npm:^10.2.0"
-    ms: "npm:^2.1.3"
-    p-map: "npm:^7.0.4"
-    package-config: "npm:^5.0.0"
-    picomatch: "npm:^4.0.3"
-    plur: "npm:^6.0.0"
-    pretty-ms: "npm:^9.3.0"
-    resolve-cwd: "npm:^3.0.0"
-    stack-utils: "npm:^2.0.6"
-    supertap: "npm:^3.0.1"
-    temp-dir: "npm:^3.0.0"
-    write-file-atomic: "npm:^7.0.0"
-    yargs: "npm:^18.0.0"
-  peerDependencies:
-    "@ava/typescript": "*"
-  peerDependenciesMeta:
-    "@ava/typescript":
-      optional: true
-  bin:
-    ava: entrypoints/cli.mjs
-  checksum: 10c0/19c5e494bac1cc8140e78cb1440f299f9ae07baea50740c4d66daec3e2af048e71b8b5313e4834e100aeead7182d9bfe1b7acaad3dab7317ef2a00f23d39bc92
   languageName: node
   linkType: hard
 
@@ -2855,15 +2693,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bindings@npm:^1.4.0":
-  version: 1.5.0
-  resolution: "bindings@npm:1.5.0"
-  dependencies:
-    file-uri-to-path: "npm:1.0.0"
-  checksum: 10c0/3dab2491b4bb24124252a91e656803eac24292473e56554e35bbfe3cc1875332cfa77600c3bac7564049dc95075bf6fcc63a4609920ff2d64d0fe405fcf0d4ba
-  languageName: node
-  linkType: hard
-
 "bl@npm:^4.0.3, bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -2872,13 +2701,6 @@ __metadata:
     inherits: "npm:^2.0.4"
     readable-stream: "npm:^3.4.0"
   checksum: 10c0/02847e1d2cb089c9dc6958add42e3cdeaf07d13f575973963335ac0fdece563a50ac770ac4c8fa06492d2dd276f6cc3b7f08c7cd9c7a7ad0f8d388b2a28def5f
-  languageName: node
-  linkType: hard
-
-"blueimp-md5@npm:^2.10.0":
-  version: 2.19.0
-  resolution: "blueimp-md5@npm:2.19.0"
-  checksum: 10c0/85d04343537dd99a288c62450341dcce7380d3454c81f8e5a971ddd80307d6f9ef51b5b92ad7d48aaaa92fd6d3a1f6b2f4fada068faae646887f7bfabc17a346
   languageName: node
   linkType: hard
 
@@ -3033,13 +2855,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "callsites@npm:4.2.0"
-  checksum: 10c0/8f7e269ec09fc0946bb22d838a8bc7932e1909ab4a833b964749f4d0e8bdeaa1f253287c4f911f61781f09620b6925ccd19a5ea4897489c4e59442c660c312a3
-  languageName: node
-  linkType: hard
-
 "camelcase-keys@npm:^6.2.2":
   version: 6.2.2
   resolution: "camelcase-keys@npm:6.2.2"
@@ -3055,15 +2870,6 @@ __metadata:
   version: 5.3.1
   resolution: "camelcase@npm:5.3.1"
   checksum: 10c0/92ff9b443bfe8abb15f2b1513ca182d16126359ad4f955ebc83dc4ddcc4ef3fdd2c078bc223f2673dc223488e75c99b16cc4d056624374b799e6a1555cf61b23
-  languageName: node
-  linkType: hard
-
-"cbor@npm:^10.0.11":
-  version: 10.0.12
-  resolution: "cbor@npm:10.0.12"
-  dependencies:
-    nofilter: "npm:^3.0.2"
-  checksum: 10c0/4c197d783415cade31565725a5e6b2b967d856285eacdb0b5f5ec0687d93c12f2ee9c6cc05aa7be02e8bbf0fe3ba40d22be69b56bd2ab1be2cc0a59370f14246
   languageName: node
   linkType: hard
 
@@ -3097,13 +2903,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.6.2":
-  version: 5.6.2
-  resolution: "chalk@npm:5.6.2"
-  checksum: 10c0/99a4b0f0e7991796b1e7e3f52dceb9137cae2a9dfc8fc0784a550dc4c558e15ab32ed70b14b21b52beb2679b4892b41a0aa44249bcb996f01e125d58477c6976
-  languageName: node
-  linkType: hard
-
 "chardet@npm:^2.1.0":
   version: 2.1.0
   resolution: "chardet@npm:2.1.0"
@@ -3134,13 +2933,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chunkd@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "chunkd@npm:2.0.1"
-  checksum: 10c0/4e0c5aac6048ecedfa4cd0a5f6c4f010c70a7b7645aeca7bfeb47cb0733c3463054f0ced3f2667b2e0e67edd75d68a8e05481b01115ba3f8a952a93026254504
-  languageName: node
-  linkType: hard
-
 "ci-info@npm:^3.2.0":
   version: 3.9.0
   resolution: "ci-info@npm:3.9.0"
@@ -3152,20 +2944,6 @@ __metadata:
   version: 4.3.1
   resolution: "ci-info@npm:4.3.1"
   checksum: 10c0/7dd82000f514d76ddfe7775e4cb0d66e5c638f5fa0e2a3be29557e898da0d32ac04f231217d414d07fb968b1fbc6d980ee17ddde0d2c516f23da9cfff608f6c1
-  languageName: node
-  linkType: hard
-
-"ci-info@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "ci-info@npm:4.4.0"
-  checksum: 10c0/44156201545b8dde01aa8a09ee2fe9fc7a73b1bef9adbd4606c9f61c8caeeb73fb7a575c88b0443f7b4edb5ee45debaa59ed54ba5f99698339393ca01349eb3a
-  languageName: node
-  linkType: hard
-
-"ci-parallel-vars@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "ci-parallel-vars@npm:1.0.1"
-  checksum: 10c0/80952f699cbbc146092b077b4f3e28d085620eb4e6be37f069b4dbb3db0ee70e8eec3beef4ebe70ff60631e9fc743b9d0869678489f167442cac08b260e5ac08
   languageName: node
   linkType: hard
 
@@ -3231,16 +3009,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^5.1.1":
-  version: 5.2.0
-  resolution: "cli-truncate@npm:5.2.0"
-  dependencies:
-    slice-ansi: "npm:^8.0.0"
-    string-width: "npm:^8.2.0"
-  checksum: 10c0/0d4ec94702ca85b64522ac93633837fb5ea7db17b79b1322a60f6045e6ae2b8cd7bd4c1d19ac7d1f9e10e3bbda1112e172e439b68c02b785ee00da8d6a5c5471
-  languageName: node
-  linkType: hard
-
 "cli-width@npm:^3.0.0":
   version: 3.0.0
   resolution: "cli-width@npm:3.0.0"
@@ -3267,17 +3035,6 @@ __metadata:
     strip-ansi: "npm:^6.0.1"
     wrap-ansi: "npm:^7.0.0"
   checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "cliui@npm:9.0.1"
-  dependencies:
-    string-width: "npm:^7.2.0"
-    strip-ansi: "npm:^7.1.0"
-    wrap-ansi: "npm:^9.0.0"
-  checksum: 10c0/13441832e9efe7c7a76bd2b8e683555c478d461a9f249dc5db9b17fe8d4b47fa9277b503914b90bd00e4a151abb6b9b02b2288972ffe2e5e3ca40bcb1c2330d3
   languageName: node
   linkType: hard
 
@@ -3317,15 +3074,6 @@ __metadata:
   version: 13.0.3
   resolution: "code-block-writer@npm:13.0.3"
   checksum: 10c0/87db97b37583f71cfd7eced8bf3f0a0a0ca53af912751a734372b36c08cd27f3e8a4878ec05591c0cd9ae11bea8add1423e132d660edd86aab952656dd41fd66
-  languageName: node
-  linkType: hard
-
-"code-excerpt@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "code-excerpt@npm:4.0.0"
-  dependencies:
-    convert-to-spaces: "npm:^2.0.1"
-  checksum: 10c0/b6c5a06e039cecd2ab6a0e10ee0831de8362107d1f298ca3558b5f9004cb8e0260b02dd6c07f57b9a0e346c76864d2873311ee1989809fdeb05bd5fbbadde773
   languageName: node
   linkType: hard
 
@@ -3445,13 +3193,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"common-path-prefix@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "common-path-prefix@npm:3.0.0"
-  checksum: 10c0/c4a74294e1b1570f4a8ab435285d185a03976c323caa16359053e749db4fde44e3e6586c29cd051100335e11895767cbbd27ea389108e327d62f38daf4548fdb
-  languageName: node
-  linkType: hard
-
 "compare-func@npm:^2.0.0":
   version: 2.0.0
   resolution: "compare-func@npm:2.0.0"
@@ -3478,29 +3219,6 @@ __metadata:
     readable-stream: "npm:^3.0.2"
     typedarray: "npm:^0.0.6"
   checksum: 10c0/29565dd9198fe1d8cf57f6cc71527dbc6ad67e12e4ac9401feb389c53042b2dceedf47034cbe702dfc4fd8df3ae7e6bfeeebe732cc4fa2674e484c13f04c219a
-  languageName: node
-  linkType: hard
-
-"concordance@npm:^5.0.4":
-  version: 5.0.4
-  resolution: "concordance@npm:5.0.4"
-  dependencies:
-    date-time: "npm:^3.1.0"
-    esutils: "npm:^2.0.3"
-    fast-diff: "npm:^1.2.0"
-    js-string-escape: "npm:^1.0.1"
-    lodash: "npm:^4.17.15"
-    md5-hex: "npm:^3.0.1"
-    semver: "npm:^7.3.2"
-    well-known-symbols: "npm:^2.0.0"
-  checksum: 10c0/59b440f330df3a7c9aa148ba588b3e99aed86acab225b4f01ffcea34ace4cf11f817e31153254e8f38ed48508998dad40b9106951a743c334d751f7ab21afb8a
-  languageName: node
-  linkType: hard
-
-"consola@npm:^3.2.3":
-  version: 3.4.2
-  resolution: "consola@npm:3.4.2"
-  checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
   languageName: node
   linkType: hard
 
@@ -3611,13 +3329,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-to-spaces@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "convert-to-spaces@npm:2.0.1"
-  checksum: 10c0/d90aa0e3b6a27f9d5265a8d32def3c5c855b3e823a9db1f26d772f8146d6b91020a2fdfd905ce8048a73fad3aaf836fef8188c67602c374405e2ae8396c4ac46
-  languageName: node
-  linkType: hard
-
 "cookie@npm:^0.6.0":
   version: 0.6.0
   resolution: "cookie@npm:0.6.0"
@@ -3686,15 +3397,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"currently-unhandled@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "currently-unhandled@npm:0.4.1"
-  dependencies:
-    array-find-index: "npm:^1.0.1"
-  checksum: 10c0/32d197689ec32f035910202c1abb0dc6424dce01d7b51779c685119b380d98535c110ffff67a262fc7e367612a7dfd30d3d3055f9a6634b5a9dd1302de7ef11c
-  languageName: node
-  linkType: hard
-
 "cwise-compiler@npm:^1.0.0":
   version: 1.1.3
   resolution: "cwise-compiler@npm:1.1.3"
@@ -3742,15 +3444,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-time@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "date-time@npm:3.1.0"
-  dependencies:
-    time-zone: "npm:^1.0.0"
-  checksum: 10c0/aa3e2e930d74b0b9e90f69de7a16d3376e30f21f1f4ce9a2311d8fec32d760e776efea752dafad0ce188187265235229013036202be053fc2d7979813bfb6ded
-  languageName: node
-  linkType: hard
-
 "dateformat@npm:^3.0.3":
   version: 3.0.3
   resolution: "dateformat@npm:3.0.3"
@@ -3758,7 +3451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.4, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.3.4":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -3857,7 +3550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.0, detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
+"detect-libc@npm:^2.0.3, detect-libc@npm:^2.1.2":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
@@ -3955,13 +3648,6 @@ __metadata:
   bin:
     ejs: bin/cli.js
   checksum: 10c0/52eade9e68416ed04f7f92c492183340582a36482836b11eab97b159fcdcfdedc62233a1bf0bf5e5e1851c501f2dca0e2e9afd111db2599e4e7f53ee29429ae1
-  languageName: node
-  linkType: hard
-
-"emittery@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "emittery@npm:1.2.0"
-  checksum: 10c0/3b16d67b2cbbc19d44fa124684039956dc94c376cefa8c7b29f4c934d9d370e6819f642cddaa343b83b1fc03fda554a1498e12f5861caf9d6f6394ff4b6e808a
   languageName: node
   linkType: hard
 
@@ -4129,20 +3815,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-string-regexp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "escape-string-regexp@npm:2.0.0"
-  checksum: 10c0/2530479fe8db57eace5e8646c9c2a9c80fa279614986d16dcc6bcaceb63ae77f05a851ba6c43756d816c61d7f4534baf56e3c705e3e0d884818a46808811c507
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "escape-string-regexp@npm:5.0.0"
-  checksum: 10c0/6366f474c6f37a802800a435232395e04e9885919873e382b157ab7e8f0feb8fed71497f84a6f6a81a49aab41815522f5839112bd38026d203aea0c91622df95
-  languageName: node
-  linkType: hard
-
 "esm-env@npm:^1.2.1, esm-env@npm:^1.2.2":
   version: 1.2.2
   resolution: "esm-env@npm:1.2.2"
@@ -4171,20 +3843,6 @@ __metadata:
     "@typescript-eslint/types":
       optional: true
   checksum: 10c0/32df8e8637e5c696d78d985ade4a56ec2147e62ecef6a6df7c85fed6a5a796c2f9847e0950b2858412a844f6d15bc18bff68631b87a018dab669ca99b0079bf9
-  languageName: node
-  linkType: hard
-
-"estree-walker@npm:2.0.2, estree-walker@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "estree-walker@npm:2.0.2"
-  checksum: 10c0/53a6c54e2019b8c914dc395890153ffdc2322781acf4bd7d1a32d7aedc1710807bdcd866ac133903d5629ec601fbb50abe8c2e5553c7f5a0afdd9b6af6c945af
-  languageName: node
-  linkType: hard
-
-"esutils@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "esutils@npm:2.0.3"
-  checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
   languageName: node
   linkType: hard
 
@@ -4233,14 +3891,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-diff@npm:^1.2.0":
-  version: 1.3.0
-  resolution: "fast-diff@npm:1.3.0"
-  checksum: 10c0/5c19af237edb5d5effda008c891a18a585f74bf12953be57923f17a3a4d0979565fc64dbc73b9e20926b9d895f5b690c618cbb969af0cf022e3222471220ad29
-  languageName: node
-  linkType: hard
-
-"fast-glob@npm:^3.3.2, fast-glob@npm:^3.3.3":
+"fast-glob@npm:^3.3.2":
   version: 3.3.3
   resolution: "fast-glob@npm:3.3.3"
   dependencies:
@@ -4304,22 +3955,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "figures@npm:6.1.0"
-  dependencies:
-    is-unicode-supported: "npm:^2.0.0"
-  checksum: 10c0/9159df4264d62ef447a3931537de92f5012210cf5135c35c010df50a2169377581378149abfe1eb238bd6acbba1c0d547b1f18e0af6eee49e30363cedaffcfe4
-  languageName: node
-  linkType: hard
-
-"file-uri-to-path@npm:1.0.0":
-  version: 1.0.0
-  resolution: "file-uri-to-path@npm:1.0.0"
-  checksum: 10c0/3b545e3a341d322d368e880e1c204ef55f1d45cdea65f7efc6c6ce9e0c4d22d802d5629320eb779d006fe59624ac17b0e848d83cc5af7cd101f206cb704f5519
-  languageName: node
-  linkType: hard
-
 "filelist@npm:^1.0.4":
   version: 1.0.4
   resolution: "filelist@npm:1.0.4"
@@ -4335,13 +3970,6 @@ __metadata:
   dependencies:
     to-regex-range: "npm:^5.0.1"
   checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
-  languageName: node
-  linkType: hard
-
-"find-up-simple@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "find-up-simple@npm:1.0.1"
-  checksum: 10c0/ad34de157b7db925d50ff78302fefb28e309f3bc947c93ffca0f9b0bccf9cf1a2dc57d805d5c94ec9fc60f4838f5dbdfd2a48ecd77c23015fa44c6dd5f60bc40
   languageName: node
   linkType: hard
 
@@ -4519,13 +4147,6 @@ __metadata:
   version: 1.4.0
   resolution: "get-east-asian-width@npm:1.4.0"
   checksum: 10c0/4e481d418e5a32061c36fbb90d1b225a254cc5b2df5f0b25da215dcd335a3c111f0c2023ffda43140727a9cafb62dac41d022da82c08f31083ee89f714ee3b83
-  languageName: node
-  linkType: hard
-
-"get-east-asian-width@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "get-east-asian-width@npm:1.5.0"
-  checksum: 10c0/bff8bbc8d81790b9477f7aa55b1806b9f082a8dc1359fff7bd8b96939622c86b729685afc2bfeb22def1fc6ef1e5228e4d87dd4e6da60bc43a5edfb03c4ee167
   languageName: node
   linkType: hard
 
@@ -4708,7 +4329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^13.0.0, glob@npm:^13.0.6":
+"glob@npm:^13.0.6":
   version: 13.0.6
   resolution: "glob@npm:13.0.6"
   dependencies:
@@ -4731,20 +4352,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^16.1.1":
-  version: 16.1.1
-  resolution: "globby@npm:16.1.1"
-  dependencies:
-    "@sindresorhus/merge-streams": "npm:^4.0.0"
-    fast-glob: "npm:^3.3.3"
-    ignore: "npm:^7.0.5"
-    is-path-inside: "npm:^4.0.0"
-    slash: "npm:^5.1.0"
-    unicorn-magic: "npm:^0.4.0"
-  checksum: 10c0/2fbed8e5c59639a98b9b9c700afe5bcedf14742b43c25950cfd34a032db0cce4b440d8436beb4a936d211744e0b7330646f086b95cd8054251162c5d83001600
-  languageName: node
-  linkType: hard
-
 "gltf-transform@workspace:.":
   version: 0.0.0-use.local
   resolution: "gltf-transform@workspace:."
@@ -4758,7 +4365,6 @@ __metadata:
     "@types/node": "npm:26.2.0"
     "@types/semver": "npm:^7.8.0"
     "@types/three": "npm:^0.177.0"
-    ava: "npm:^7.0.0"
     c8: "npm:^11.0.0"
     d3-dsv: "npm:^3.0.1"
     draco3dgltf: "npm:1.5.7"
@@ -4796,7 +4402,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
@@ -4955,7 +4561,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5":
+"https-proxy-agent@npm:^7.0.1":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -4997,13 +4603,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore-by-default@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "ignore-by-default@npm:2.1.0"
-  checksum: 10c0/3a6040dac25ed9da39dee73bf1634fdd1e15b0eb7cf52a6bdec81c310565782d8811c104ce40acb3d690d61c5fc38a91c78e6baee830a8a2232424dbc6b66981
-  languageName: node
-  linkType: hard
-
 "ignore-walk@npm:^6.0.4":
   version: 6.0.5
   resolution: "ignore-walk@npm:6.0.5"
@@ -5017,13 +4616,6 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^7.0.5":
-  version: 7.0.5
-  resolution: "ignore@npm:7.0.5"
-  checksum: 10c0/ae00db89fe873064a093b8999fe4cc284b13ef2a178636211842cceb650b9c3e390d3339191acb145d81ed5379d2074840cf0c33a20bdbd6f32821f79eb4ad5d
   languageName: node
   linkType: hard
 
@@ -5067,13 +4659,6 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: 10c0/1e1904ddb0cb3d6cce7cd09e27a90184908b7a5d5c21b92e232c93579d314f0b83c246ffb035493d0504b1e9147ba2c9b21df0030f48673fba0496ecd698161f
-  languageName: node
-  linkType: hard
-
-"indent-string@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "indent-string@npm:5.0.0"
-  checksum: 10c0/8ee77b57d92e71745e133f6f444d6fa3ed503ad0e1bcd7e80c8da08b42375c07117128d670589725ed07b1978065803fa86318c309ba45415b7fe13e7f170220
   languageName: node
   linkType: hard
 
@@ -5150,13 +4735,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"irregular-plurals@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "irregular-plurals@npm:4.2.0"
-  checksum: 10c0/f3b86491a2e2879c8bb4f818dede9d1305d02893076e73e6b620fcf570330bcaa0520dc1342d088b35dfea07e79919ff780e21f61c4e1fb6cc50858c1045be81
-  languageName: node
-  linkType: hard
-
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
@@ -5228,7 +4806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-fullwidth-code-point@npm:^5.0.0, is-fullwidth-code-point@npm:^5.1.0":
+"is-fullwidth-code-point@npm:^5.0.0":
   version: 5.1.0
   resolution: "is-fullwidth-code-point@npm:5.1.0"
   dependencies:
@@ -5274,13 +4852,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-path-inside@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "is-path-inside@npm:4.0.0"
-  checksum: 10c0/51188d7e2b1d907a9a5f7c18d99a90b60870b951ed87cf97595d9aaa429d4c010652c3350bcbf31182e7f4b0eab9a1860b43e16729b13cb1a44baaa6cdb64c46
-  languageName: node
-  linkType: hard
-
 "is-plain-obj@npm:^1.0.0, is-plain-obj@npm:^1.1.0":
   version: 1.1.0
   resolution: "is-plain-obj@npm:1.1.0"
@@ -5297,24 +4868,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: 10c0/893e42bad832aae3511c71fd61c0bf61aa3a6d853061c62a307261842727d0d25f761ce9379f7ba7226d6179db2a3157efa918e7fe26360f3bf0842d9f28942c
-  languageName: node
-  linkType: hard
-
 "is-potential-custom-element-name@npm:^1.0.1":
   version: 1.0.1
   resolution: "is-potential-custom-element-name@npm:1.0.1"
   checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
-  languageName: node
-  linkType: hard
-
-"is-promise@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "is-promise@npm:4.0.0"
-  checksum: 10c0/ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
   languageName: node
   linkType: hard
 
@@ -5363,13 +4920,6 @@ __metadata:
   version: 0.1.0
   resolution: "is-unicode-supported@npm:0.1.0"
   checksum: 10c0/00cbe3455c3756be68d2542c416cab888aebd5012781d6819749fefb15162ff23e38501fe681b3d751c73e8ff561ac09a5293eba6f58fdf0178462ce6dcb3453
-  languageName: node
-  linkType: hard
-
-"is-unicode-supported@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-unicode-supported@npm:2.1.0"
-  checksum: 10c0/a0f53e9a7c1fdbcf2d2ef6e40d4736fdffff1c9f8944c75e15425118ff3610172c87bf7bc6c34d3903b04be59790bb2212ddbe21ee65b5a97030fc50370545a5
   languageName: node
   linkType: hard
 
@@ -5483,13 +5033,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-string-escape@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "js-string-escape@npm:1.0.1"
-  checksum: 10c0/2c33b9ff1ba6b84681c51ca0997e7d5a1639813c95d5b61cb7ad47e55cc28fa4a0b1935c3d218710d8e6bcee5d0cd8c44755231e3a4e45fc604534d9595a3628
-  languageName: node
-  linkType: hard
-
 "js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -5508,7 +5051,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1, js-yaml@npm:^3.14.1":
+"js-yaml@npm:^3.10.0, js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -5975,13 +5518,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"load-json-file@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "load-json-file@npm:7.0.1"
-  checksum: 10c0/7117459608a0b6329c7f78e6e1f541b3162dd901c29dd5af721fec8b270177d2e3d7999c971f344fff04daac368d052732e2c7146014bc84d15e0b636975e19a
-  languageName: node
-  linkType: hard
-
 "locate-character@npm:^3.0.0":
   version: 3.0.0
   resolution: "locate-character@npm:3.0.0"
@@ -6024,7 +5560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.14, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -6197,28 +5733,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matcher@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "matcher@npm:6.0.0"
-  dependencies:
-    escape-string-regexp: "npm:^5.0.0"
-  checksum: 10c0/b2eb6a23de82be3cbcf8e79034638a44e22ce6fcc6968ea2a7b342b1e059eb15bc18bf32d8fce7390c9b0710b21a8eabdc133190c0d86a91de2491b0afae3ca7
-  languageName: node
-  linkType: hard
-
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
-  languageName: node
-  linkType: hard
-
-"md5-hex@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "md5-hex@npm:3.0.1"
-  dependencies:
-    blueimp-md5: "npm:^2.10.0"
-  checksum: 10c0/ee2b4d8da16b527b3a3fe4d7a96720f43afd07b46a82d49421208b5a126235fb75cfb30b80d4029514772c8844273f940bddfbf4155c787f968f3be4060d01e4
   languageName: node
   linkType: hard
 
@@ -6242,15 +5760,6 @@ __metadata:
   peerDependencies:
     svelte: ^3.56.0 || ^4.0.0 || ^5.0.0-next.120
   checksum: 10c0/fd26af50390aecb0699a41d88e5a91206e06e80b78ac46b4082e1f42b684b3882286037d717b53b3f46aff1be63f8ae66b242ee98d7727b2a4c60b279c1cc7df
-  languageName: node
-  linkType: hard
-
-"memoize@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "memoize@npm:10.2.0"
-  dependencies:
-    mimic-function: "npm:^5.0.1"
-  checksum: 10c0/8a5891f313e8db82bab4bb9694752aab40c11ce3bf9b8cc32228ebaf87e14e8109a23b37ceef32baadbedc09af2c4dd0d361a93e9e591bb0ed9e23f728e1ce9f
   languageName: node
   linkType: hard
 
@@ -6341,7 +5850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mimic-function@npm:^5.0.0, mimic-function@npm:^5.0.1":
+"mimic-function@npm:^5.0.0":
   version: 5.0.1
   resolution: "mimic-function@npm:5.0.1"
   checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
@@ -6716,31 +6225,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.7":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:^4.2.2":
-  version: 4.8.4
-  resolution: "node-gyp-build@npm:4.8.4"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10c0/444e189907ece2081fe60e75368784f7782cfddb554b60123743dfb89509df89f1f29c03bbfa16b3a3e0be3f48799a4783f487da6203245fa5bed239ba7407e1
-  languageName: node
-  linkType: hard
-
 "node-gyp@npm:^10.0.0":
   version: 10.3.1
   resolution: "node-gyp@npm:10.3.1"
@@ -6785,13 +6269,6 @@ __metadata:
   version: 1.1.12
   resolution: "node-machine-id@npm:1.1.12"
   checksum: 10c0/ab2fea5f75a6f1ce3c76c5e0ae3903b631230e0a99b003d176568fff8ddbdf7b2943be96cd8d220c497ca0f6149411831f8a450601929f326781cb1b59bab7f8
-  languageName: node
-  linkType: hard
-
-"nofilter@npm:^3.0.2":
-  version: 3.1.0
-  resolution: "nofilter@npm:3.1.0"
-  checksum: 10c0/92459f3864a067b347032263f0b536223cbfc98153913b5dce350cb39c8470bc1813366e41993f22c33cc6400c0f392aa324a4b51e24c22040635c1cdb046499
   languageName: node
   linkType: hard
 
@@ -7202,13 +6679,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^7.0.4":
-  version: 7.0.4
-  resolution: "p-map@npm:7.0.4"
-  checksum: 10c0/a5030935d3cb2919d7e89454d1ce82141e6f9955413658b8c9403cfe379283770ed3048146b44cde168aa9e8c716505f196d5689db0ae3ce9a71521a2fef3abd
-  languageName: node
-  linkType: hard
-
 "p-pipe@npm:3.1.0":
   version: 3.1.0
   resolution: "p-pipe@npm:3.1.0"
@@ -7262,16 +6732,6 @@ __metadata:
   dependencies:
     p-reduce: "npm:^2.0.0"
   checksum: 10c0/ccae582b75a3597018a375f8eac32b93e8bfb9fc22a8e5037787ef4ebf5958d7465c2d3cbe26443971fbbfda2bcb7b645f694b91f928fc9a71fa5031e6e33f85
-  languageName: node
-  linkType: hard
-
-"package-config@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "package-config@npm:5.0.0"
-  dependencies:
-    find-up-simple: "npm:^1.0.0"
-    load-json-file: "npm:^7.0.1"
-  checksum: 10c0/f6c48930700b73a41d839bf2898b628d23665827488a4f34aed2d05e4a99d7a70a70ada115c3546765947fbc8accff94c0779da21ea084b25df47cb774531eeb
   languageName: node
   linkType: hard
 
@@ -7348,13 +6808,6 @@ __metadata:
     json-parse-even-better-errors: "npm:^2.3.0"
     lines-and-columns: "npm:^1.1.6"
   checksum: 10c0/77947f2253005be7a12d858aedbafa09c9ae39eb4863adf330f7b416ca4f4a08132e453e08de2db46459256fb66afaac5ee758b44fe6541b7cdaf9d252e59585
-  languageName: node
-  linkType: hard
-
-"parse-ms@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "parse-ms@npm:4.0.0"
-  checksum: 10c0/a7900f4f1ebac24cbf5e9708c16fb2fd482517fad353aecd7aefb8c2ba2f85ce017913ccb8925d231770404780df46244ea6fec598b3bde6490882358b4d2d16
   languageName: node
   linkType: hard
 
@@ -7521,15 +6974,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plur@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "plur@npm:6.0.0"
-  dependencies:
-    irregular-plurals: "npm:^4.2.0"
-  checksum: 10c0/5c54badee70debea38e7153b197c1235847edc10952c3dd959c9610005f75013c2053be1cba87acde4531498d7a9e8b16c6b358f3940f05aa6e1aeedbc991b7a
-  languageName: node
-  linkType: hard
-
 "postcss-selector-parser@npm:^6.0.10":
   version: 6.1.2
   resolution: "postcss-selector-parser@npm:6.1.2"
@@ -7559,15 +7003,6 @@ __metadata:
     ansi-styles: "npm:^5.0.0"
     react-is: "npm:^18.0.0"
   checksum: 10c0/edc5ff89f51916f036c62ed433506b55446ff739358de77207e63e88a28ca2894caac6e73dcb68166a606e51c8087d32d400473e6a9fdd2dbe743f46c9c0276f
-  languageName: node
-  linkType: hard
-
-"pretty-ms@npm:^9.3.0":
-  version: 9.3.0
-  resolution: "pretty-ms@npm:9.3.0"
-  dependencies:
-    parse-ms: "npm:^4.0.0"
-  checksum: 10c0/555ea39a1de48a30601938aedb76d682871d33b6dee015281c37108921514b11e1792928b1648c2e5589acc73c8ef0fb5e585fb4c718e340a28b86799e90fb34
   languageName: node
   linkType: hard
 
@@ -8193,7 +7628,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -8208,15 +7643,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
-  languageName: node
-  linkType: hard
-
-"serialize-error@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "serialize-error@npm:7.0.1"
-  dependencies:
-    type-fest: "npm:^0.13.1"
-  checksum: 10c0/7982937d578cd901276c8ab3e2c6ed8a4c174137730f1fb0402d005af209a0e84d04acc874e317c936724c7b5b26c7a96ff7e4b8d11a469f4924a4b0ea814c05
   languageName: node
   linkType: hard
 
@@ -8411,13 +7837,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slash@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "slash@npm:5.1.0"
-  checksum: 10c0/eb48b815caf0bdc390d0519d41b9e0556a14380f6799c72ba35caf03544d501d18befdeeef074bc9c052acf69654bc9e0d79d7f1de0866284137a40805299eb3
-  languageName: node
-  linkType: hard
-
 "slice-ansi@npm:^2.1.0":
   version: 2.1.0
   resolution: "slice-ansi@npm:2.1.0"
@@ -8446,16 +7865,6 @@ __metadata:
     ansi-styles: "npm:^6.2.1"
     is-fullwidth-code-point: "npm:^5.0.0"
   checksum: 10c0/36742f2eb0c03e2e81a38ed14d13a64f7b732fe38c3faf96cce0599788a345011e840db35f1430ca606ea3f8db2abeb92a8d25c2753a819e3babaa10c2e289a2
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "slice-ansi@npm:8.0.0"
-  dependencies:
-    ansi-styles: "npm:^6.2.3"
-    is-fullwidth-code-point: "npm:^5.1.0"
-  checksum: 10c0/0ce4aa91febb7cea4a00c2c27bb820fa53b6d2862ce0f80f7120134719f7914fc416b0ed966cf35250a3169e152916392f35917a2d7cad0fcc5d8b841010fa9a
   languageName: node
   linkType: hard
 
@@ -8594,15 +8003,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.6":
-  version: 2.0.6
-  resolution: "stack-utils@npm:2.0.6"
-  dependencies:
-    escape-string-regexp: "npm:^2.0.0"
-  checksum: 10c0/651c9f87667e077584bbe848acaecc6049bc71979f1e9a46c7b920cad4431c388df0f51b8ad7cfd6eed3db97a2878d0fc8b3122979439ea8bac29c61c95eec8a
-  languageName: node
-  linkType: hard
-
 "string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
@@ -8636,7 +8036,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
+"string-width@npm:^7.0.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -8644,16 +8044,6 @@ __metadata:
     get-east-asian-width: "npm:^1.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10c0/eb0430dd43f3199c7a46dcbf7a0b34539c76fe3aa62763d0b0655acdcbdf360b3f66f3d58ca25ba0205f42ea3491fa00f09426d3b7d3040e506878fc7664c9b9
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "string-width@npm:8.2.0"
-  dependencies:
-    get-east-asian-width: "npm:^1.5.0"
-    strip-ansi: "npm:^7.1.2"
-  checksum: 10c0/d8915428b43519b0f494da6590dbe4491857d8a12e40250e50fc01fbb616ffd8400a436bbe25712255ee129511fe0414c49d3b6b9627e2bc3a33dcec1d2eda02
   languageName: node
   linkType: hard
 
@@ -8702,15 +8092,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^7.1.2":
-  version: 7.2.0
-  resolution: "strip-ansi@npm:7.2.0"
-  dependencies:
-    ansi-regex: "npm:^6.2.2"
-  checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
-  languageName: node
-  linkType: hard
-
 "strip-bom@npm:^3.0.0":
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
@@ -8738,18 +8119,6 @@ __metadata:
   dependencies:
     min-indent: "npm:^1.0.0"
   checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
-  languageName: node
-  linkType: hard
-
-"supertap@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "supertap@npm:3.0.1"
-  dependencies:
-    indent-string: "npm:^5.0.0"
-    js-yaml: "npm:^3.14.1"
-    serialize-error: "npm:^7.0.1"
-    strip-ansi: "npm:^7.0.1"
-  checksum: 10c0/8164674f2e280cab875f0fef5bb36c15553c13e29697ff92f4e0d6bc62149f0303a89eee47535413ed145ea72e14a24d065bab233059d48a499ec5ebb4566b0f
   languageName: node
   linkType: hard
 
@@ -8858,7 +8227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.0, tar@npm:^7.4.3":
+"tar@npm:^7.4.3":
   version: 7.5.1
   resolution: "tar@npm:7.5.1"
   dependencies:
@@ -8875,13 +8244,6 @@ __metadata:
   version: 1.0.0
   resolution: "temp-dir@npm:1.0.0"
   checksum: 10c0/648669d5e154d1961217784c786acadccf0156519c19e0aceda7edc76f5bdfa32a40dd7f88ebea9238ed6e3dedf08b846161916c8947058c384761351be90a8e
-  languageName: node
-  linkType: hard
-
-"temp-dir@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "temp-dir@npm:3.0.0"
-  checksum: 10c0/a86978a400984cd5f315b77ebf3fe53bb58c61f192278cafcb1f3fb32d584a21dc8e08b93171d7874b7cc972234d3455c467306cc1bfc4524b622e5ad3bfd671
   languageName: node
   linkType: hard
 
@@ -8931,13 +8293,6 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
-  languageName: node
-  linkType: hard
-
-"time-zone@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "time-zone@npm:1.0.0"
-  checksum: 10c0/d00ebd885039109011b6e2423ebbf225160927333c2ade6d833e9cc4676db20759f1f3855fafde00d1bd668c243a6aa68938ce71fe58aab0d514e820d59c1d81
   languageName: node
   linkType: hard
 
@@ -9195,13 +8550,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "type-fest@npm:0.13.1"
-  checksum: 10c0/0c0fa07ae53d4e776cf4dac30d25ad799443e9eef9226f9fddbb69242db86b08584084a99885cfa5a9dfe4c063ebdc9aa7b69da348e735baede8d43f1aeae93b
-  languageName: node
-  linkType: hard
-
 "type-fest@npm:^0.18.0":
   version: 0.18.1
   resolution: "type-fest@npm:0.18.1"
@@ -9308,13 +8656,6 @@ __metadata:
   version: 8.10.0
   resolution: "undici@npm:8.10.0"
   checksum: 10c0/37ae2b1db8f65c3a003504e2040e96887b99f9db16ba07dcf49c37ed8b7f8c72f4452f2d46f52f7c9e49518fe8325e3b5e7e02ac3a2424886bd67d4b62a0ecab
-  languageName: node
-  linkType: hard
-
-"unicorn-magic@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "unicorn-magic@npm:0.4.0"
-  checksum: 10c0/cd6eff90967a5528dfa2016bdb5b38b0cd64c8558f9ba04fb5c2c23f3a232a67dfe2bfa4c45af3685d5f1a40dbac6a36d48e053f80f97ae4da1e0f6a55431685
   languageName: node
   linkType: hard
 
@@ -9604,13 +8945,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"well-known-symbols@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "well-known-symbols@npm:2.0.0"
-  checksum: 10c0/cb6c12e98877e8952ec28d13ae6f4fdb54ae1cb49b16a728720276dadd76c930e6cb0e174af3a4620054dd2752546f842540122920c6e31410208abd4958ee6b
-  languageName: node
-  linkType: hard
-
 "whatwg-mimetype@npm:^5.0.0":
   version: 5.0.0
   resolution: "whatwg-mimetype@npm:5.0.0"
@@ -9801,15 +9135,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "write-file-atomic@npm:7.0.1"
-  dependencies:
-    signal-exit: "npm:^4.0.1"
-  checksum: 10c0/69cebb64945e22928a24ae7e2a55bf54438c92d6f657c1fa5e96b7c7a50f6c022e7454ab5c259079bb35f60296242f3a21234c79320d64a8ad57675b56a2098d
-  languageName: node
-  linkType: hard
-
 "write-json-file@npm:^3.2.0":
   version: 3.2.0
   resolution: "write-json-file@npm:3.2.0"
@@ -9900,13 +9225,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "yargs-parser@npm:22.0.0"
-  checksum: 10c0/cb7ef81759c4271cb1d96b9351dbbc9a9ce35d3e1122d2b739bf6c432603824fa02c67cc12dcef6ea80283379d63495686e8f41cc7b06c6576e792aba4d33e1c
-  languageName: node
-  linkType: hard
-
 "yargs@npm:17.7.2, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
@@ -9934,20 +9252,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "yargs@npm:18.0.0"
-  dependencies:
-    cliui: "npm:^9.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    string-width: "npm:^7.2.0"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^22.0.0"
-  checksum: 10c0/bf290e4723876ea9c638c786a5c42ac28e03c9ca2325e1424bf43b94e5876456292d3ed905b853ebbba6daf43ed29e772ac2a6b3c5fb1b16533245d6211778f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Moving testing framework to `node:test`, reducing dependencies and opening up the possibility of running the test suite in Deno.

Related:
- #457 
- https://github.com/donmccurdy/glTF-Transform/issues/789
- https://github.com/donmccurdy/glTF-Transform/pull/799

References:
- https://nodejs.org/api/test.html
- https://docs.deno.com/runtime/test/#running-tests


#### PR Dependency Tree


* **PR #1851** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)