### PR TITLE
fix(coverage): enable source maps so c8 reports on source, not bundled dist

### DIFF
--- a/.github/.c8rc
+++ b/.github/.c8rc
@@ -1,4 +1,5 @@
 {
+	"all": true,
 	"exclude": [
 		"packages/*/vendor",
 		"packages/*/test",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
 	treeshake: { moduleSideEffects: false },
 	// For gl-matrix bundling. See: https://tsdown.dev/options/platform#module-resolution
 	inputOptions: { resolve: { mainFields: ['module', 'main'] } },
+	// Emit source maps so c8 can map coverage back to original .ts sources
+	// instead of reporting on bundled dist files. See: https://tsdown.dev/options/sourcemap
+	sourcemap: true,
 });


### PR DESCRIPTION
Fixes #1210. Code coverage reports on bundled dist/ files instead of source .ts files.

Changes: tsdown.config.ts adds sourcemap:true; .c8rc adds all:true.

Closes #1210