### PR TITLE
fix(view): enable flatShading on implicit default material

### DIFF
--- a/packages/view/src/subjects/PrimitiveSubject.ts
+++ b/packages/view/src/subjects/PrimitiveSubject.ts
@@ -11,6 +11,7 @@ import {
 	LineSegments,
 	type Material,
 	Mesh,
+	MeshStandardMaterial,
 	Points,
 	SkinnedMesh,
 } from 'three';
@@ -41,6 +42,13 @@ export class PrimitiveSubject extends Subject<PrimitiveDef, MeshLike> {
 		this.material.subscribe((material) => {
 			if (this.value.material !== material) {
 				this.value.material = material || DEFAULT_MATERIAL;
+				// When the primitive has no source material, apply the same
+				// flatShading adaptation that MaterialPool would normally
+				// perform, so the implicit default material doesn't render black.
+				// See https://github.com/donmccurdy/glTF-Transform/issues/1686
+				if (!material) {
+					PrimitiveSubject.applyDefaultMaterialAdaptations(this.def, this.value);
+				}
 				this.publishAll();
 			}
 		});
@@ -57,6 +65,12 @@ export class PrimitiveSubject extends Subject<PrimitiveDef, MeshLike> {
 			}
 			for (const key in nextAttributes) {
 				geometry.setAttribute(semanticToAttributeName(key), nextAttributes[key]);
+			}
+			// If the primitive uses the implicit default material and the
+			// NORMAL attribute was removed/changed, re-apply adaptations.
+			// See https://github.com/donmccurdy/glTF-Transform/issues/1686
+			if (this.value.material === DEFAULT_MATERIAL) {
+				PrimitiveSubject.applyDefaultMaterialAdaptations(this.def, this.value);
 			}
 			this.publishAll();
 		});
@@ -122,6 +136,26 @@ export class PrimitiveSubject extends Subject<PrimitiveDef, MeshLike> {
 		this.indices.dispose();
 		this.attributes.dispose();
 		super.dispose();
+	}
+
+	/**
+	 * Applies the flatShading adaptation that MaterialPool applies for
+	 * primitives that DO have a source material — but for primitives that rely
+	 * on the implicit default material (no `getMaterial()`). Without this
+	 * adaptation, a primitive without NORMAL data renders black. See
+	 * https://github.com/donmccurdy/glTF-Transform/issues/1686
+	 *
+	 * The default material is a shared singleton, so flatShading reflects the
+	 * most recently adapted primitive; `needsUpdate` must be set on every
+	 * change because flatShading is a shader-compilation parameter.
+	 */
+	private static applyDefaultMaterialAdaptations(def: PrimitiveDef, value: MeshLike): void {
+		const material = value.material as Material;
+		const hasNormal = !!def.getAttribute('NORMAL');
+		if (material instanceof MeshStandardMaterial && material.flatShading !== !hasNormal) {
+			material.flatShading = !hasNormal;
+			material.needsUpdate = true;
+		}
 	}
 }
 

--- a/packages/view/test/PrimitiveSubject.test.ts
+++ b/packages/view/test/PrimitiveSubject.test.ts
@@ -1,8 +1,9 @@
-import { strictEqual } from 'node:assert/strict';
+import { ok, strictEqual } from 'node:assert/strict';
 import { test } from 'node:test';
 import { Document, Primitive as PrimitiveDef } from '@gltf-transform/core';
 import { DocumentView, NullImageProvider } from '@gltf-transform/view';
 import { JSDOM } from 'jsdom';
+import type { MeshStandardMaterial } from 'three';
 
 global.document = new JSDOM().window.document;
 const imageProvider = new NullImageProvider();
@@ -56,4 +57,40 @@ test('PrimitiveSubject', async () => {
 	primDef.dispose();
 
 	strictEqual(disposed.size, 1, 'dispose geometry');
+});
+
+// https://github.com/donmccurdy/glTF-Transform/issues/1686
+// When a primitive has no material AND no NORMAL attribute, the implicit
+// default material must enable flatShading so the mesh is not rendered black.
+// Per the glTF spec, flat normals are expected here; three.js derives them in
+// the shader when flatShading is enabled, so no vertex normals are written.
+test('PrimitiveSubject · default material · no NORMAL → flatShading (issue #1686)', async () => {
+	const document = new Document();
+	const position = document
+		.createAccessor()
+		.setType('VEC3')
+		.setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
+	// No NORMAL attribute, no material set.
+	const primDef = document.createPrimitive().setAttribute('POSITION', position);
+
+	const documentView = new DocumentView(document, { imageProvider });
+	const prim = documentView.view(primDef);
+
+	strictEqual(prim.material.name, '__DefaultMaterial', 'prim.material → default');
+	const material = prim.material as MeshStandardMaterial;
+	ok(material.flatShading === true, 'default material must have flatShading=true');
+
+	// The default material is shared across primitives, so toggling NORMAL must
+	// flip flatShading (the helper also flags the material with needsUpdate so
+	// already-compiled shader programs pick up the new shading mode).
+	const normal = document
+		.createAccessor()
+		.setType('VEC3')
+		.setArray(new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]));
+
+	primDef.setAttribute('NORMAL', normal);
+	ok(material.flatShading === false, 'smooth shading while NORMAL is present');
+
+	primDef.setAttribute('NORMAL', null);
+	ok(material.flatShading === true, 'flat shading after NORMAL removal');
 });


### PR DESCRIPTION
Fixes #1686

When a primitive has no source material, `PrimitiveSubject` substitutes the shared `DEFAULT_MATERIAL` directly and never routes through `MaterialPool`, so the adaptations that MaterialPool normally applies for primitives without `NORMAL` are silently skipped. A mesh with an unmodified `MeshStandardMaterial` and no normal data renders black.

### Change

Mirror the MaterialPool flatShading adaptation for primitives that fall back to the implicit default material:

- `flatShading = !hasNormals` on `DEFAULT_MATERIAL` (matching `MaterialPool.ts`'s `flatShading = params.useFlatShading`), following the flat-normals requirement from the glTF spec noted in the issue thread;
- re-applied whenever the attribute observer fires, so adding/removing `NORMAL` on a primitive still using the default material keeps the shading mode correct;
- because `flatShading` is a shader-compilation parameter and the default material is a shared singleton, `needsUpdate` is set on every flip — otherwise already-compiled programs keep the stale shading mode.

### Known limitation

Two primitives in the same model that both use the implicit default material — one with `NORMAL`, one without — share a single material instance, so the flatShading flag reflects whichever primitive was adapted last (same behavior as THREE.GLTFLoader's shared-material path, but worth stating explicitly). A complete fix would route default-material primitives through MaterialPool's variant system; happy to attempt that if preferred.

`InstancedMeshSubject` also binds `DEFAULT_MATERIAL` unconditionally and likely needs the same adaptation; left out of this focused fix, can follow up.

### Test

New regression test in `packages/view/test/PrimitiveSubject.test.ts`: a primitive with only `POSITION` gets `flatShading=true` on the default material; toggling `NORMAL` off/on flips the flag accordingly. The shape assertions fail on `main`.

`node --test`: 412 tests on this branch, same 12 pre-existing Windows path-resolution failures as `main` (unrelated fixture-path issue), plus this new passing test. biome clean on changed files.